### PR TITLE
fix(ci): Correct syntax for secret in workflow conditional

### DIFF
--- a/.github/workflows/build_msi.yml
+++ b/.github/workflows/build_msi.yml
@@ -10,6 +10,9 @@ jobs:
   build_msi:
     runs-on: windows-latest
 
+    env:
+      CERT_BASE64_ENV: ${{ secrets.WINDOWS_SIGNING_CERT }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -30,7 +33,7 @@ jobs:
           npm run build
 
       - name: Install Code Signing Certificate
-        if: runner.os == 'Windows' && secrets.WINDOWS_SIGNING_CERT != ''
+        if: runner.os == 'Windows' && env.CERT_BASE64_ENV != ''
         env:
           CERT_BASE64: ${{ secrets.WINDOWS_SIGNING_CERT }}
           CERT_PASSWORD: ${{ secrets.WINDOWS_SIGNING_PASSWORD }}


### PR DESCRIPTION
Fixes a syntax error in the `build_msi.yml` workflow that caused the build to fail.

The `secrets` context cannot be directly accessed in a step's `if` conditional. The correct procedure is to first map the secret to a job-level environment variable and then check the value of that environment variable in the conditional.

This change implements the correct pattern, resolving the "Unrecognized named-value: 'secrets'" error.