### PR TITLE
feat(setup): Implement self-installing GUI and fix build

### DIFF
--- a/.github/workflows/build_msi.yml
+++ b/.github/workflows/build_msi.yml
@@ -10,6 +10,9 @@ jobs:
   build_msi:
     runs-on: windows-latest
 
+    env:
+      CERT_BASE64_ENV: ${{ secrets.WINDOWS_SIGNING_CERT }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -30,7 +33,7 @@ jobs:
           npm run build
 
       - name: Install Code Signing Certificate
-        if: runner.os == 'Windows' && secrets.WINDOWS_SIGNING_CERT != ''
+        if: runner.os == 'Windows' && env.CERT_BASE64_ENV != ''
         env:
           CERT_BASE64: ${{ secrets.WINDOWS_SIGNING_CERT }}
           CERT_PASSWORD: ${{ secrets.WINDOWS_SIGNING_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -1,44 +1,40 @@
-# 🐴 Fortuna Faucet - Racing Analysis Engine (Developer Guide)
+# 🐴 Fortuna Faucet - Racing Analysis Engine
 
-This document serves as the central guide for developers contributing to the Fortuna Faucet project. For user-facing installation instructions, see `README_WINDOWS.md`.
+Welcome to Fortuna Faucet! This guide will help you get the application running.
 
-## Core Architecture
+## Getting Started (for Users)
 
-- **Backend (`python_service/`):** An asynchronous FastAPI application.
-- **Frontend (`web_platform/frontend/`):** A Next.js and TypeScript dashboard.
-- **Unified Launcher (`launcher_gui.py`):** The primary entry point for local development, managing all services and providing real-time health monitoring.
+If you have downloaded this project as a ZIP file, you can get started right away.
 
-## Local Development Setup
+1.  **Run the Application:** Double-click the `fortuna_app.py` file.
+2.  **One-Click Setup:** A setup window will appear to automatically install all required dependencies. Click **'Start Installation'** and wait for the process to complete.
+3.  **Launch:** Once finished, click **'Launch'** to start the main application dashboard.
+
+That's it! The application is now ready to use.
+
+---
+
+## For Developers
+
+This section contains instructions for developers who wish to contribute to the project or manage the environment manually.
+
+### Core Architecture
+
+*   **Backend (`python_service/`):** An asynchronous FastAPI application.
+*   **Frontend (`web_platform/frontend/`):** A Next.js and TypeScript dashboard.
+*   **Unified Launcher (`fortuna_app.py`):** The primary entry point for local development, managing all services and providing real-time health monitoring.
+
+### Manual Development Setup
 
 1.  **Prerequisites:** Python 3.11+, Node.js (LTS), Git.
 2.  **Clone:** `git clone https://github.com/masonj0/fortuna.git`
-3.  **Backend:** Create a venv and `pip install -r requirements.txt`.
+3.  **Backend:** Create a venv (`python -m venv .venv`) and `pip install -r requirements.txt`.
 4.  **Frontend:** `cd web_platform/frontend` and run `npm install`.
 
-### Running for Development
+### Creating a Release Build (MSI Installer)
 
-The entire system can be run for local development using the central GUI launcher. With your Python virtual environment activated, run:
+The project uses the WiX Toolset to create a distributable MSI installer.
 
-```bash
-python launcher_gui.py
-```
-
-## Creating a Release Build (MSI Installer)
-
-The project has a professional, automated build pipeline for creating a distributable MSI installer using the WiX Toolset.
-
-- **Configuration:** All WiX source files are located in the `wix/` directory.
-- **Build Orchestration:** The entire build process is managed by the PowerShell script located at `scripts/build_msi.ps1`.
-
-To create a release build locally, ensure the WiX Toolset v4 is installed and run the orchestrator:
-
-```powershell
-# Navigate to the project root
-./scripts/build_msi.ps1
-```
-
-The final `.msi` package will be generated in the `dist/` directory.
-
-### Automated CI/CD
-
-This build process is fully automated via GitHub Actions, as defined in `.github/workflows/build_msi.yml`. Every push to `main` or `develop` will automatically build, test, and archive the MSI installer as a workflow artifact.
+*   **Configuration:** All WiX source files are in the `wix/` directory.
+*   **Build Script:** The build process is managed by `scripts/build_msi.ps1`.
+*   **CI/CD:** The build is automated via GitHub Actions, defined in `.github/workflows/build_msi.yml`. To create a release build locally, ensure the WiX Toolset is installed and run the PowerShell script.

--- a/web_platform/frontend/next.config.mjs
+++ b/web_platform/frontend/next.config.mjs
@@ -9,6 +9,8 @@ const withPWA = nextPWA({
   disable: process.env.NODE_ENV === 'development'
 });
 
-const nextConfig = {};
+const nextConfig = {
+  output: 'export',
+};
 
 export default withPWA(nextConfig);

--- a/web_platform/frontend/package.json
+++ b/web_platform/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
-  "scripts": { "dev": "next dev", "build": "next build && next export", "start": "next start" },
+  "scripts": { "dev": "next dev", "build": "next build", "start": "next start" },
   "dependencies": {
     "next": "14.1.0",
     "react": "^18",


### PR DESCRIPTION
This commit introduces a self-installing setup wizard and fixes a critical Next.js build error.

- Implemented a self-installing GUI in `fortuna_app.py`. The application now checks for a virtual environment on launch and, if not found, displays a setup wizard to automate the installation of all Python and Node.js dependencies.
- Updated `README.md` to be user-centric, providing simple instructions for the new one-click setup process.
- Fixed the deprecated `next export` command by adding `output: 'export'` to `next.config.mjs` and removing the command from the `package.json` build script.