### PR TITLE
Fix WiX linker errors and architecture mismatch

### DIFF
--- a/wix/product.wxs
+++ b/wix/product.wxs
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
-     xmlns:WixUI="http://schemas.microsoft.com/wix/WixUIExtension">
+     xmlns:WixUI="http://schemas.microsoft.com/wix/WixUIExtension"
+     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
 
   <Product
     Id="*"
@@ -14,6 +15,7 @@
       InstallerVersion="200"
       Compressed="yes"
       InstallScope="perMachine"
+      Platform="x64"
       Description="Horse racing analysis platform with Python backend and React frontend"
       Comments="Professional-grade installer"/>
 
@@ -23,7 +25,7 @@
 
     <!-- Directory Structure -->
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
+      <Directory Id="ProgramFiles64Folder">
         <Directory Id="INSTALLFOLDER" Name="Fortuna Faucet"/>
       </Directory>
       <Directory Id="ProgramMenuFolder">
@@ -52,7 +54,7 @@
 
     <ComponentGroup Id="ShortcutsComponentGroup" Directory="ApplicationProgramsFolder">
       <Component Id="DesktopShortcutsComponent" Guid="*">
-          <Shortcut Id="DashboardShortcut" Name="Fortuna Faucet Dashboard" Description="Open racing analysis dashboard" Target="http://localhost:3000" Advertise="no"/>
+          <util:InternetShortcut Id="DashboardShortcut" Name="Fortuna Faucet Dashboard" Target="http://localhost:3000"/>
           <Shortcut Id="UninstallShortcut" Name="Uninstall Fortuna Faucet" Description="Remove this application" Target="[SystemFolder]msiexec.exe" Arguments="/x [ProductCode]" Advertise="no"/>
           <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
           <RegistryValue Root="HKCU" Key="Software\Fortuna Faucet" Name="Installed" Type="integer" Value="1" KeyPath="yes"/>


### PR DESCRIPTION
Corrected multiple WiX ICE errors to ensure a successful MSI build:
- Set package Platform to 'x64' and targeted ProgramFiles64Folder to resolve the ICE80 32/64-bit mismatch.
- Replaced the standard Shortcut with a util:InternetShortcut for the dashboard URL to fix the ICE03 bad shortcut target error.
- Added the WixUtilExtension namespace to support the InternetShortcut element.