### PR TITLE
refactor: Encapsulate Windows notifications for portability

### DIFF
--- a/python_service/engine.py
+++ b/python_service/engine.py
@@ -33,6 +33,7 @@ from .adapters.tvg_adapter import TVGAdapter
 from .cache_manager import cache_async_result
 from .health import health_monitor
 from .models import AggregatedResponse
+from .notifications import send_toast
 from .models import OddsData
 from .models import Race
 from .models import Runner
@@ -313,14 +314,10 @@ class FortunaEngine:
         )
 
         # --- Add Success Notification ---
-        try:
-            from windows_toasts import Toast, WindowsToaster
-            toaster = WindowsToaster("Fortuna Faucet Data Refresh")
-            new_toast = Toast()
-            new_toast.text_fields = [f"Successfully fetched {len(deduped_races)} races from {len(source_infos)} sources."]
-            toaster.show_toast(new_toast)
-        except (ImportError, RuntimeError):
-            pass
+        send_toast(
+            "Fortuna Faucet Data Refresh",
+            f"Successfully fetched {len(deduped_races)} races from {len(source_infos)} sources."
+        )
 
         return response_obj.model_dump()
 

--- a/python_service/notifications.py
+++ b/python_service/notifications.py
@@ -1,0 +1,29 @@
+# python_service/notifications.py
+
+import sys
+import structlog
+
+log = structlog.get_logger(__name__)
+
+def send_toast(title: str, message: str):
+    """
+    Sends a desktop notification. This function is platform-aware and will only
+    attempt to send a toast on Windows. On other operating systems, it will
+    log the notification content.
+    """
+    if sys.platform == "win32":
+        try:
+            from windows_toasts import Toast, WindowsToaster
+            toaster = WindowsToaster(title)
+            new_toast = Toast()
+            new_toast.text_fields = [message]
+            toaster.show_toast(new_toast)
+            log.info("Sent Windows toast notification.", title=title, message=message)
+        except ImportError:
+            log.warning("windows_toasts library not found, skipping notification.",
+                        recommendation="Install with: pip install windows-toasts")
+        except Exception as e:
+            log.error("Failed to send Windows toast notification.", exc_info=True)
+    else:
+        log.info("Skipping toast notification on non-Windows platform.",
+                   platform=sys.platform, title=title, message=message)


### PR DESCRIPTION
- Created a new `notifications.py` module to handle platform-specific desktop notifications.
- The `send_toast` function in this module checks the operating system and only attempts to import and use the `windows_toasts` library on Windows.
- Refactored `FortunaEngine` to use this new module, removing the direct dependency on `windows_toasts` and making the core engine platform-agnostic.