### PR TITLE
Fix(wix): Relocate misplaced Publish element to fix build

### DIFF
--- a/wix/WixUI_CustomProgress.wxs
+++ b/wix/WixUI_CustomProgress.wxs
@@ -23,8 +23,9 @@
         <Control Id="ProgressBar" Type="ProgressBar" X="35" Y="120" Width="300" Height="10" ProgressBlocks="yes" Text="Progress">
           <Subscribe Event="SetProgress" Attribute="Progress" />
         </Control>
-        <Publish Dialog="InstallProgressDlg" Control="Cancel" Event="SpawnDialog" Value="CancelDlg">1</Publish>
       </Dialog>
+
+      <!-- The Publish element must be a child of UI, not Dialog -->
       <Publish Dialog="InstallProgressDlg" Control="Cancel" Event="SpawnDialog" Value="CancelDlg">1</Publish>
     </UI>
   </Fragment>


### PR DESCRIPTION
Resolved a WiX compiler error CNDL0005 ("The Dialog element contains an unexpected child element 'Publish'") in the `WixUI_CustomProgress.wxs` file.

The <Publish> element was incorrectly nested inside the <Dialog> element. According to the WiX schema, it must be a direct child of the <UI> element.

This commit moves the <Publish> element to its correct location and also removes a duplicate entry that was present. This allows the MSI installer to compile successfully.