### PR TITLE
Fix(wix): Remove duplicate WIXUI_INSTALLDIR property

### DIFF
--- a/wix/product.wxs
+++ b/wix/product.wxs
@@ -69,7 +69,6 @@
       <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2">1</Publish>
       <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
     </UI>
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
     <UIRef Id="WixUI_Common" />
     <WixVariable Id="WixUILicenseRtf" Value="electron\assets\license.rtf"/>
     <!-- The following two variables are for custom UI images. -->


### PR DESCRIPTION
Resolved a WiX linker error LGHT0091 ("Duplicate symbol 'Property:WIXUI_INSTALLDIR' found") in the `product.wxs` file.

The `WIXUI_INSTALLDIR` property was defined twice. This often happens when using a standard WiX UI extension like `WixUI_InstallDir`, which implicitly defines the property, and then defining it again manually.

This commit removes the redundant manual definition, allowing the linker to succeed.