### PR TITLE
Fix electron-builder configuration in electron/package.json

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -31,15 +31,13 @@
     ],
     "win": {
       "target": "msi",
-      "icon": "assets/icon.ico",
-      "shortcutName": "Fortuna Faucet"
+      "icon": "assets/icon.ico"
     },
     "msi": {
       "oneClick": false,
-      "allowToChangeInstallationDirectory": true,
       "perMachine": true,
       "createDesktopShortcut": true,
-      "installerIcon": "assets/icon.ico"
+      "shortcutName": "Fortuna Faucet"
     },
     "nsis": {
       "oneClick": false,


### PR DESCRIPTION
- Removed `allowToChangeInstallationDirectory` from the `msi` configuration as it is no longer a valid property. The desired behavior is the default when `oneClick` is false.
- Moved `shortcutName` from the `win` configuration to the `msi` configuration, where it is a valid property.

This resolves the schema validation errors that were causing the MSI build to fail.