### PR TITLE
fix(installer): Resolve silent MSI installation failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aiosqlite==0.21.0
 keyring==25.6.0
 tenacity==9.1.2
 fastapi==0.104.1
-uvicorn[standard]==0.24.0
+uvicorn==0.24.0
 pydantic==2.5.2
 pydantic-settings==2.1.0
 httpx[http2]==0.27.0


### PR DESCRIPTION
This commit addresses two critical issues causing the MSI installer to fail silently with a "setup was interrupted" message on Windows.

1.  **Dependency Fix:** The `uvicorn[standard]` dependency was replaced with `uvicorn`. The `[standard]` extra installs the `uvloop` package, which is known to be incompatible with the Windows build environment and causes the PyInstaller-packaged executable to crash on startup. Removing it prevents this silent failure.

2.  **Asset Restoration:** The installer's UI assets (`banner.bmp` and `dialog.bmp`) were replaced with known-good versions from the repository. The previous assets were likely corrupt, a condition known to cause the installer to crash before displaying its UI.