### PR TITLE
fix(installer): Resolve multiple critical installation failures

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -23,8 +23,7 @@
       "assets/**/*",
       "../web_platform/frontend/out/**/*",
       "../scripts/validate_installation.ps1",
-      "!../.venv/",
-      "!node_modules/**/*"
+      "!../.venv/"
     ],
     "extraResources": [
       {

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aiosqlite==0.21.0
 keyring==25.6.0
 tenacity==9.1.2
 fastapi==0.104.1
-uvicorn[standard]==0.24.0
+uvicorn==0.24.0
 pydantic==2.5.2
 pydantic-settings==2.1.0
 httpx[http2]==0.27.0


### PR DESCRIPTION
This commit resolves a series of critical issues that caused the Windows MSI installer to fail.

1.  **Fix Missing Node.js Dependencies:** The `electron/package.json` file contained a `"!node_modules/**/*"` rule that incorrectly excluded all Node.js dependencies from the packaged application. This caused runtime errors for missing modules like `node-notifier`. The rule has been removed to ensure production dependencies are correctly bundled.

2.  **Fix Incompatible Backend Dependency:** The `uvicorn[standard]` dependency was replaced with `uvicorn` in `requirements.txt`. The `[standard]` extra installs `uvloop`, which is incompatible with the Windows build environment and caused the packaged `api.exe` to crash silently during installation.

3.  **Restore Corrupted UI Assets:** The installer's UI assets (`banner.bmp`, `dialog.bmp`) were replaced with known-good versions. The previous files were likely corrupt, which is another known cause of silent installer crashes.