### PR TITLE
The `fortuna-backend.exe` was not being included in the MSI installer…

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -22,7 +22,8 @@
       "main.js",
       "preload.js",
       "package.json",
-      "web-ui-build/out/**/*"
+      "web-ui-build/out/**/*",
+      "resources/**/*"
     ],
 
     "extraResources": [


### PR DESCRIPTION
… because the `electron-builder` `files` array, which acts as a whitelist, did not include the `resources/` directory.

This change adds `resources/**/*` to the `files` array in `electron/package.json`. This ensures the directory is visible to the build process, allowing the `extraResources` configuration to correctly find and package the backend executable alongside the application's `asar` archive.