### PR TITLE
Fix(electron): Include backend executable in MSI build

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -22,6 +22,12 @@
       "web-ui-build/out/**/*",
       "resources/**/*"
     ],
+    "extraResources": [
+      {
+        "from": "resources/fortuna-backend.exe",
+        "to": "resources/fortuna-backend.exe"
+      }
+    ],
     "asarUnpack": [
       "**/resources/fortuna-backend.exe"
     ],


### PR DESCRIPTION
Updates `electron/package.json` to correctly package the `fortuna-backend.exe` into the MSI installer.

The `extraResources` configuration was added to the `build` section. This explicitly tells electron-builder to copy the backend executable from the `resources/` directory into the final application package, making it available at runtime.

This resolves the GitHub Actions build failure where the post-build verification script could not find the executable within the extracted MSI.