### PR TITLE
fix(electron): Use app.isPackaged to detect production mode

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -37,6 +37,13 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Diagnostic - Initial Workspace Structure
+        shell: pwsh
+        run: |
+          Write-Host "--- [DIAG] Initial Workspace Structure ---"
+          Get-ChildItem -Recurse -Depth 3 | Out-String -Width 120
+          Write-Host "------------------------------------------"
+
       # ===== FRONTEND BUILD =====
       - name: Clear Caches for Fresh Build
         shell: pwsh
@@ -65,6 +72,10 @@ jobs:
 
           $fileCount = (Get-ChildItem -Path "out" -Recurse -File | Measure-Object).Count
           Write-Host "✅ Frontend built successfully: $fileCount files in out/" -ForegroundColor Green
+
+          Write-Host "--- [DIAG] Frontend Output Files (web_platform/frontend/out) ---"
+          Get-ChildItem -Recurse "out" | Out-String -Width 120
+          Write-Host "--------------------------------------------------------------"
 
       - name: Stage Frontend Assets for Electron
         shell: pwsh
@@ -98,6 +109,10 @@ jobs:
           }
 
           Write-Host "✅ Successfully staged $destFiles frontend files" -ForegroundColor Green
+
+          Write-Host "--- [DIAG] Staged Frontend Assets (electron/web-ui-build) ---"
+          Get-ChildItem -Recurse $dest | Out-String -Width 120
+          Write-Host "---------------------------------------------------------------"
 
       # ===== BACKEND BUILD =====
       - name: Install Python Dependencies
@@ -150,6 +165,10 @@ jobs:
 
           Write-Host "✅ Backend executable built" -ForegroundColor Green
 
+          Write-Host "--- [DIAG] PyInstaller Output (dist/) ---"
+          Get-ChildItem -Recurse ".\dist\" | Out-String -Width 120
+          Write-Host "-----------------------------------------"
+
       - name: Stage Backend Executable
         shell: pwsh
         run: |
@@ -184,6 +203,10 @@ jobs:
           }
 
           Write-Host "✅ Backend executable staged successfully" -ForegroundColor Green
+
+          Write-Host "--- [DIAG] Staged Backend Assets (electron/resources) ---"
+          Get-ChildItem -Recurse $destDir | Out-String -Width 120
+          Write-Host "---------------------------------------------------------"
 
       # ===== ELECTRON BUILD =====
       - name: Install Electron Dependencies
@@ -290,6 +313,13 @@ jobs:
           Set-Content -Path "electron/package.json" -Value $correctConfig -Force
           Write-Host "✅ Forcefully overwrote electron/package.json with correct configuration." -ForegroundColor Green
 
+      - name: Diagnostic - Final Pre-Build Structure
+        shell: pwsh
+        run: |
+          Write-Host "--- [DIAG] Final Structure of 'electron' directory before build ---"
+          Get-ChildItem -Recurse ".\electron\" -Depth 4 | Out-String -Width 120
+          Write-Host "--------------------------------------------------------------------"
+
       - name: Build MSI Installer
         shell: pwsh
         run: |
@@ -343,6 +373,10 @@ jobs:
             $fullPath = (Resolve-Path $extractPath).Path
             & msiexec /a "$($msiFile.FullName)" /qn TARGETDIR="$fullPath"
           }
+
+          Write-Host "--- [DIAG] Full Extracted MSI Contents ---"
+          Get-ChildItem -Recurse $extractPath | Out-String -Width 120
+          Write-Host "------------------------------------------"
 
           # Search for critical components
           Write-Host "`nSearching for backend executable..." -ForegroundColor Yellow

--- a/electron/main.js
+++ b/electron/main.js
@@ -13,7 +13,7 @@ class FortunaDesktopApp {
 
   async startBackend() {
     return new Promise((resolve, reject) => {
-      const isDev = process.env.NODE_ENV !== 'production';
+      const isDev = !app.isPackaged;
 
       if (isDev) {
         // Development: use Python venv
@@ -119,7 +119,7 @@ class FortunaDesktopApp {
       backgroundColor: '#1a1a2e'
     });
 
-    const isDev = process.env.NODE_ENV !== 'production';
+    const isDev = !app.isPackaged;
 
     if (isDev) {
       // Development: load from Next.js dev server
@@ -214,7 +214,7 @@ class FortunaDesktopApp {
   async initialize() {
     try {
       console.log('=== Fortuna Faucet Starting ===');
-      console.log('Mode:', process.env.NODE_ENV || 'production');
+      console.log('Mode:', !app.isPackaged ? 'Development' : 'Production');
       console.log('Platform:', process.platform);
       console.log('Electron version:', process.versions.electron);
 


### PR DESCRIPTION
Resolves a critical startup error where the packaged MSI-installed application would fail with a "Python venv not found" message.

The root cause was the use of `process.env.NODE_ENV !== 'production'` to differentiate between development and production environments. This check is unreliable in a packaged Electron application, causing the app to incorrectly execute its development-mode startup logic.

This commit replaces the faulty environment variable check with the canonical `!app.isPackaged` property. This is the robust, framework-standard method for determining if the app is running in a development environment or from a packaged distribution.

This change ensures the production application correctly identifies its environment and proceeds to launch the bundled `fortuna-backend.exe`, fixing the startup error.