### PR TITLE
Fix(ci): Correct path for pip install in workflow

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -124,11 +124,13 @@ jobs:
         shell: pwsh
         run: |
           Write-Host "Installing Python dependencies..." -ForegroundColor Cyan
-          pip install -r python_service/requirements.txt --verbose 2>&1 | Tee-Object -FilePath pip-install.log
+          cd python_service
+          pip install -r requirements.txt --verbose 2>&1 | Tee-Object -FilePath ../pip-install.log
           if ($LASTEXITCODE -ne 0) {
             Write-Error "Pip install failed!"
             exit 1
           }
+          cd ..
           Write-Host "✅ Dependencies installed" -ForegroundColor Green
 
       - name: Build Backend Executable with PyInstaller


### PR DESCRIPTION
This commit corrects a pathing error in the `Install Python Dependencies` step of the `.github/workflows/build-msi.yml` file.

The previous version was attempting to run `pip install -r python_service/requirements.txt` from the root directory, which is incorrect.

This has been corrected to `cd python_service` first, and then run `pip install -r requirements.txt`. This ensures the command executes in the correct directory and can find the requirements file. The logging path has also been adjusted accordingly.