### PR TITLE
Fix(ci): Replace npm ci with npm install in workflow

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -60,9 +60,9 @@ jobs:
         shell: pwsh
         run: |
           cd web_platform/frontend
-          npm ci --verbose 2>&1 | Tee-Object -FilePath ../../npm-frontend-install.log
+          npm install --verbose 2>&1 | Tee-Object -FilePath ../../npm-frontend-install.log
           if ($LASTEXITCODE -ne 0) {
-            Write-Error "npm ci failed for frontend!"
+            Write-Error "npm install failed for frontend!"
             exit 1
           }
 
@@ -212,9 +212,9 @@ jobs:
         shell: pwsh
         run: |
           cd electron
-          npm ci --verbose 2>&1 | Tee-Object -FilePath ../npm-electron-install.log
+          npm install --verbose 2>&1 | Tee-Object -FilePath ../npm-electron-install.log
           if ($LASTEXITCODE -ne 0) {
-            Write-Error "npm ci failed for electron!"
+            Write-Error "npm install failed for electron!"
             exit 1
           }
 


### PR DESCRIPTION
This commit provides a targeted fix for the `EUSAGE` error that occurred during the `npm ci` step in the last workflow run.

The "Absolute Nuclear Cache Annihilation" step correctly removes all `package-lock.json` files to ensure a completely sterile build environment. However, the `npm ci` command is specifically designed to work only when a `package-lock.json` is present.

This has been corrected by replacing `npm ci` with `npm install` for both the frontend and electron dependency installation steps. The `npm install` command will correctly generate a `package-lock.json` if one is missing, which is the required behavior in this context.