### PR TITLE
Fix(build): Correct electron-builder config for MSI packaging

### DIFF
--- a/electron/electron-builder-config.yml
+++ b/electron/electron-builder-config.yml
@@ -4,9 +4,11 @@ directories:
   buildResources: "assets"
   output: "dist"
 files:
-  - "**/*"
-  - "!node_modules/**/*"
-  - "!dist/**/*"
+  - "main.js"
+  - "preload.js"
+  - "package.json"
+  - "web-ui-build/out/**/*"
+  - "assets/**/*"
 extraResources:
   - from: "resources/fortuna-backend.exe"
     to: "fortuna-backend.exe"


### PR DESCRIPTION
Resolves an issue where the installed application would hang on the 'Loading Dashboard' screen. The previous broad glob pattern in electron-builder-config.yml was unreliable.

Replaced the catch-all pattern with an explicit whitelist of required files and directories to ensure all frontend assets and the backend executable are correctly packaged.