### PR TITLE
fix(build): Add aiosqlite to PyInstaller hidden imports

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -207,6 +207,7 @@ jobs:
             --hidden-import=redis.asyncio `
             --hidden-import=redis.asyncio.client `
             --hidden-import=redis.asyncio.connection `
+            --hidden-import=aiosqlite `
             --collect-all=uvicorn `
             --collect-all=fastapi `
             --add-data $addDataArg `


### PR DESCRIPTION
The compiled fortuna-backend.exe was failing on startup with a `ModuleNotFoundError: No module named 'aiosqlite'`.

This change fixes the issue by explicitly adding `aiosqlite` as a hidden import to the PyInstaller command in the `build-msi.yml` GitHub Actions workflow. This ensures the module is correctly bundled into the final executable, resolving the runtime error.