### PR TITLE
fix(build): Create robust PyInstaller build for aiosqlite

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -207,8 +207,11 @@ jobs:
             --hidden-import=redis.asyncio `
             --hidden-import=redis.asyncio.client `
             --hidden-import=redis.asyncio.connection `
+            --hidden-import=aiosqlite `
+            --hidden-import=_sqlite3 `
             --collect-all=uvicorn `
             --collect-all=fastapi `
+            --collect-all=aiosqlite `
             --add-data $addDataArg `
             api.py `
             2>&1 | Tee-Object -FilePath ../logs/pyinstaller.log


### PR DESCRIPTION
The compiled fortuna-backend.exe was failing on startup with a `ModuleNotFoundError: No module named 'aiosqlite'`.

This change implements a comprehensive fix by adding three flags to the PyInstaller command in the `build-msi.yml` workflow:

1.  `--hidden-import=aiosqlite`: Explicitly includes the main package.
2.  `--hidden-import=_sqlite3`: Explicitly includes the underlying C-extension for the standard library's sqlite3 module, which aiosqlite wraps.
3.  `--collect-all=aiosqlite`: Ensures all sub-modules and data files associated with the aiosqlite package are found and bundled.

This multi-layered approach ensures all necessary modules for SQLite are correctly bundled into the final executable, resolving the runtime error and making the build significantly more robust.