### PR TITLE
Refactor: Use single-quoted PowerShell here-strings in CI

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -347,7 +347,7 @@ jobs:
           $adaptersPath = (Resolve-Path -Path "python_service/adapters").Path
 
           # Create a .spec file for better control and reproducibility
-          $specContent = @"
+          $specContent = @'
 # -*- mode: python ; coding: utf-8 -*-
 import sys
 import os
@@ -356,7 +356,7 @@ from PyInstaller.utils.hooks import collect_all, collect_submodules, copy_metada
 block_cipher = None
 
 # Collect all data and submodules for critical packages
-datas = [('$($adaptersPath.Replace('\', '/'))', 'adapters')]
+datas = [('__ADAPTERS_PATH__', 'adapters')]
 hiddenimports = []
 binaries = []
 
@@ -399,7 +399,8 @@ exe = EXE(
     codesign_identity=None, entitlements_file=None,
     icon='../electron/assets/icon.ico' if os.path.exists('../electron/assets/icon.ico') else None,
 )
-"@
+'@
+          $specContent = $specContent -replace '__ADAPTERS_PATH__', $($adaptersPath.Replace('\', '/'))
 
           Set-Content -Path "fortuna-backend.spec" -Value $specContent
 
@@ -633,33 +634,34 @@ exe = EXE(
               Write-Host "✅ Playwright ready" -ForegroundColor Green
 
               Write-Host "`n✍️  Running E2E screenshot test..." -ForegroundColor Cyan
-              $pyScript = @(
-                  "from playwright.sync_api import sync_playwright",
-                  "import sys",
-                  "import json",
-                  "",
-                  "def run(playwright):",
-                  "    browser = playwright.chromium.launch()",
-                  "    page = browser.new_page()",
-                  "    try:",
-                  "        url = f'http://127.0.0.1:$frontendPort'",
-                  "        print(f'[E2E] Navigating to {url}')",
-                  "        page.goto(url, timeout=20000)",
-                  "        print('[E2E] Waiting for body element')",
-                  "        page.wait_for_selector('body', timeout=10000)",
-                  "        print('[E2E] Page loaded successfully')",
-                  "        page.screenshot(path='e2e-screenshot.png', full_page=True)",
-                  "        print('[E2E] ✅ E2E TEST PASSED')",
-                  "    except Exception as e:",
-                  "        print(f'[E2E] ❌ E2E TEST FAILED: {e}', file=sys.stderr)",
-                  "        page.screenshot(path='e2e-screenshot-failed.png', full_page=True)",
-                  "        raise",
-                  "    finally:",
-                  "        browser.close()",
-                  "",
-                  "with sync_playwright() as playwright:",
-                  "    run(playwright)"
-              ) -join "`n"
+              $pyScript = @'
+from playwright.sync_api import sync_playwright
+import sys
+import json
+
+def run(playwright):
+    browser = playwright.chromium.launch()
+    page = browser.new_page()
+    try:
+        url = 'http://127.0.0.1:__FRONTEND_PORT__'
+        print(f'[E2E] Navigating to {url}')
+        page.goto(url, timeout=20000)
+        print('[E2E] Waiting for body element')
+        page.wait_for_selector('body', timeout=10000)
+        print('[E2E] Page loaded successfully')
+        page.screenshot(path='e2e-screenshot.png', full_page=True)
+        print('[E2E] ✅ E2E TEST PASSED')
+    except Exception as e:
+        print(f'[E2E] ❌ E2E TEST FAILED: {e}', file=sys.stderr)
+        page.screenshot(path='e2e-screenshot-failed.png', full_page=True)
+        raise
+    finally:
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)
+'@
+              $pyScript = $pyScript -replace '__FRONTEND_PORT__', $frontendPort
               Set-Content -Path "run_e2e_test.py" -Value $pyScript
 
               py run_e2e_test.py 2>&1 | Tee-Object -FilePath "$testDir/playwright.log"


### PR DESCRIPTION
Replaced double-quoted PowerShell here-strings (`@"..."@`) with single-quoted here-strings (`@'...'@`) in the `.github/workflows/build-msi.yml` workflow.

This change prevents unintentional PowerShell variable expansion within the string and avoids special character issues with YAML parsing, leading to a more robust and predictable CI pipeline.

Dynamic variables are now handled safely using placeholders and the `-replace` operator.