### PR TITLE
feat: Use hardcoded API key for deep test

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -445,7 +445,7 @@ jobs:
 
           # Create .env file for the backend process
           $envLines = @(
-            "API_KEY=${{ env.API_KEY }}",
+            "API_KEY=fortuna-test-key-1234567890abcdefghijklmnopqrstuvwxyz",
             "PORT=$testPort",
             "HOST=0.0.0.0"
           )


### PR DESCRIPTION
This commit modifies the CI/CD workflow to use a hardcoded, fake API key for the 'Backend - Deep Integration Test' step.

This is a temporary debugging measure, as requested, to bypass potential issues with GitHub secrets and validate that the rest of the build and test pipeline is functioning correctly. The goal is to achieve a successful MSI build.