### PR TITLE
fix(ci): Correct all backend executable paths for --onedir build

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -570,7 +570,7 @@ jobs:
         timeout-minutes: 10
         run: |
           Write-Host "`n=== E2E UI TEST: FORTRESS MODE ===" -ForegroundColor Magenta
-          $backendExe = "electron/resources/fortuna-backend.exe"
+          $backendExe = "electron/resources/fortuna-backend/fortuna-backend.exe"
           $frontendDir = "electron/web-ui-build/out"
           $backendPort = "8999"
           $frontendPort = "8998"
@@ -698,7 +698,7 @@ jobs:
             "package.json" = "electron/package.json"
             "electron-builder-config.yml" = "electron/electron-builder-config.yml"
             "icon.ico" = "electron/assets/icon.ico"
-            "backend.exe" = "electron/resources/fortuna-backend.exe"
+            "backend.exe" = "electron/resources/fortuna-backend/fortuna-backend.exe"
             "frontend/index.html" = "electron/web-ui-build/out/index.html"
             "frontend/_next" = "electron/web-ui-build/out/_next"
           }


### PR DESCRIPTION
This commit resolves the final pathing errors in the `.github/workflows/build-msi.yml` file that arose after switching the PyInstaller build from `--onefile` to `--onedir` mode.

The following paths were corrected to point to the new executable location (`electron/resources/fortuna-backend/fortuna-backend.exe`):
- The `$backendExe` variable in the 'End-to-End UI Test' step.
- The `backend.exe` check in the 'Electron - Pre-Build Verification' step.

With these changes, all steps in the CI workflow now reference the correct executable path, completing the architectural fix and resolving the build failure.