### PR TITLE
Fix: Correct pip-audit command in CI workflow

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -345,13 +345,17 @@ jobs:
 
       - name: Backend - Security Audit
         id: security_audit
+        shell: pwsh
         run: |
           Write-Host "`n=== BACKEND: Security Audit ===" -ForegroundColor Cyan
           pip install pip-audit
 
+          # Run the audit from within the python_service directory to avoid project path conflicts
+          cd python_service
+
           # Run the audit, ignoring known vulnerabilities.
           # The build will now FAIL if any NEW vulnerabilities are found.
-          pip-audit -r python_service/requirements.txt --ignore-vuln-id-file audit-ignore.txt
+          pip-audit -r requirements.txt --ignore-vuln-id-file ../audit-ignore.txt
 
       - name: Backend - Verify Source Files
         shell: pwsh


### PR DESCRIPTION
Resolves an error in the 'Backend - Security Audit' step where `pip-audit` would fail with a conflicting arguments error.

The `pip-audit` command was being executed from the repository root, causing it to implicitly find the `pyproject.toml` file as a project path. This conflicted with the explicit `-r python_service/requirements.txt` argument.

The fix is to change the working directory to `python_service` before running the `pip-audit` command. This isolates the command from the root `pyproject.toml`, resolving the conflict and allowing the audit to proceed as intended.