### PR TITLE
feat: Add parallel WiX build system and fix CI vulnerabilities

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -154,3 +154,32 @@ jobs:
           name: fortuna-installer-windows
           path: electron/dist/*.msi
           retention-days: 7
+
+  build-wix-installer:
+    name: '🔥 Build WiX Installer (Alternative)'
+    needs: [build-backend]
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.1.7
+      - name: Download Backend Executable
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: backend-executable
+          path: dist
+      - name: Install WiX Toolset
+        shell: pwsh
+        run: |
+          choco install wixtoolset --version 3.14.1 -y --no-progress
+          $wixPath = "C:\\Program Files (x86)\\WiX ToolSet v3.14\\bin"
+          echo "WIX=$wixPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Build Backend Service MSI with WiX
+        shell: pwsh
+        run: |
+          python build_wix/build_msi.py
+      - name: Upload WiX MSI Artifact
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: fortuna-wix-installer-windows
+          path: dist/Fortuna-Backend-Service.msi
+          retention-days: 7

--- a/build_wix/Product.wxs
+++ b/build_wix/Product.wxs
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Product Id="*" Name="Fortuna Backend Service" Language="1033" Version="1.0.0.0"
+             Manufacturer="Fortuna Project" UpgradeCode="{da2c1b11-23f3-4787-a655-8094e97aa905}">
+
+        <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
+        <MajorUpgrade DowngradeErrorMessage="A newer version is already installed." />
+        <MediaTemplate EmbedCab="yes" />
+
+        <Feature Id="ProductFeature" Title="Fortuna Backend Service" Level="1">
+            <ComponentGroupRef Id="MainFiles" />
+            <ComponentRef Id="ServiceControl" />
+        </Feature>
+
+        <Directory Id="TARGETDIR" Name="SourceDir">
+            <Directory Id="ProgramFilesFolder">
+                <Directory Id="INSTALLFOLDER" Name="Fortuna Backend Service" />
+            </Directory>
+        </Directory>
+
+        <ComponentGroup Id="MainFiles">
+            <!-- This will be auto-populated by the 'heat' tool -->
+        </ComponentGroup>
+
+        <DirectoryRef Id="INSTALLFOLDER">
+            <Component Id="ServiceControl" Guid="*">
+                <ServiceInstall Id="ServiceInstaller"
+                                Type="ownProcess"
+                                Name="FortunaBackendService"
+                                DisplayName="Fortuna Backend Service"
+                                Description="Provides access to the Fortuna racing data engine."
+                                Start="auto"
+                                Account="LocalSystem"
+                                ErrorControl="normal" />
+                <ServiceControl Id="StartService" Name="FortunaBackendService" Start="install" Wait="no" />
+                <ServiceControl Id="StopService" Name="FortunaBackendService" Stop="both" Remove="uninstall" Wait="yes" />
+            </Component>
+        </DirectoryRef>
+
+    </Product>
+</Wix>

--- a/build_wix/build_msi.py
+++ b/build_wix/build_msi.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+DIST_DIR = PROJECT_ROOT / 'dist'
+BUILD_DIR = PROJECT_ROOT / 'build'
+MSI_SOURCE_DIR = PROJECT_ROOT / 'build_wix' / 'msi_source'
+EXECUTABLE_NAME = 'fortuna-backend.exe'
+
+def run_command(cmd, cwd=None):
+    print(f'▶ Running: {" ".join(cmd)}')
+    subprocess.run(cmd, cwd=cwd, check=True, text=True)
+
+def main():
+    print('=== Starting Fortuna WiX MSI Build ===')
+
+    exe_path = DIST_DIR / EXECUTABLE_NAME
+
+    # 1. Build Executable with PyInstaller (if it doesn't exist)
+    if not exe_path.exists():
+        print('--- Step 1: Building executable with PyInstaller ---')
+        run_command(['pyinstaller', str(PROJECT_ROOT / 'fortuna-backend.spec')])
+        if not exe_path.exists():
+            sys.exit('✗ PyInstaller build failed: Executable not found.')
+        print(f'✓ Executable created at {exe_path}')
+    else:
+        print(f'--- Step 1: Found existing executable at {exe_path}, skipping build. ---')
+
+    # 2. Generate WiX file list from the dist directory
+    print("--- Step 2: Generating WiX file list with 'heat' ---")
+    MSI_SOURCE_DIR.mkdir(exist_ok=True)
+    files_wxs = MSI_SOURCE_DIR / 'files.wxs'
+    run_command(['heat', 'dir', str(DIST_DIR), '-o', str(files_wxs), '-gg', '-sfrag', '-srd', '-cg', 'MainFiles', '-dr', 'INSTALLFOLDER'])
+    print(f'✓ WiX file fragment created at {files_wxs}')
+
+    # 3. Compile WiX project
+    print("--- Step 3: Compiling WiX project with 'candle' ---")
+    obj_dir = MSI_SOURCE_DIR / 'obj'
+    obj_dir.mkdir(exist_ok=True)
+    run_command(['candle', str(PROJECT_ROOT / 'build_wix' / 'Product.wxs'), str(files_wxs), '-o', f'{obj_dir}/'])
+    print('✓ WiX compilation successful.')
+
+    # 4. Link WiX project into MSI
+    print("--- Step 4: Linking MSI with 'light' ---")
+    output_msi = PROJECT_ROOT / 'dist' / 'Fortuna-Backend-Service.msi'
+    run_command(['light', '-o', str(output_msi), f'{obj_dir}/*.wixobj'])
+    print(f'✓ MSI created successfully at {output_msi}')
+
+    print('\n=== BUILD COMPLETE ===')
+
+if __name__ == '__main__':
+    main()

--- a/python_service/requirements.txt
+++ b/python_service/requirements.txt
@@ -95,13 +95,13 @@ pywin32==306
     # via -r python_service/requirements.in, keyring, pynput
 redis==5.0.7
     # via -r python_service/requirements.in, slowapi
-requests==2.32.3
+requests==2.32.4
     # via -r python_service/requirements.in (implicit)
 scipy==1.14.0
     # via -r python_service/requirements.in
 selectolax==0.4.0
     # via -r python_service/requirements.in
-setuptools==69.5.1
+setuptools==70.0.0
     # via -r python_service/requirements.in
 six==1.16.0
     # via python-dateutil, pynput
@@ -121,7 +121,7 @@ tomli==2.0.1
     # via black
 tzdata==2024.1
     # via pandas
-urllib3==2.2.2
+urllib3==2.5.0
     # via httpx, requests
 uvicorn==0.30.1
     # via -r python_service/requirements.in


### PR DESCRIPTION
- Implements a new, parallel build system using the WiX Toolset in the `build_wix` directory. This provides a high-control alternative to the existing electron-builder workflow for creating the MSI installer.
- Adds a new `build-wix-installer` job to the `.github/workflows/build-msi.yml` workflow to automate this new build process.
- Fixes security vulnerabilities reported by `pip-audit` by upgrading `requests` to `2.32.4`, `urllib3` to `2.5.0`, and pinning `setuptools` to `70.0.0` in `python_service/requirements.txt`.
- Reverts a series of extensive but unsuccessful refactoring attempts aimed at fixing the backend test suite. The test suite remains in a failing state and requires further investigation.