### PR TITLE
Fix: Update python dependencies to resolve security vulnerabilities

### DIFF
--- a/python_service/requirements.in
+++ b/python_service/requirements.in
@@ -4,9 +4,9 @@
 #
 
 # --- Core Application Framework (Hard Pins) ---
-fastapi==0.115.0
+fastapi
 uvicorn==0.30.1
-cryptography==42.0.5  # Pinned to satisfy pyopenssl < 43
+cryptography
 
 # --- Core Application Dependencies (Flexible) ---
 pydantic-settings
@@ -22,7 +22,7 @@ aiosqlite
 SQLAlchemy
 psycopg2-binary
 structlog
-certifi==2023.7.22
+certifi
 
 # --- Desktop & OS Integration (Flexible) ---
 psutil

--- a/python_service/requirements.txt
+++ b/python_service/requirements.txt
@@ -4,67 +4,69 @@
 #
 #    pip-compile --output-file=python_service/requirements.txt python_service/requirements.in
 #
-aiosqlite==0.20.0
+aiosqlite==0.21.0
     # via -r python_service/requirements.in
 altgraph==0.17.4
     # via pyinstaller
+annotated-doc==0.0.4
+    # via fastapi
 annotated-types==0.7.0
     # via pydantic
-anyio==4.4.0
+anyio==4.11.0
     # via
     #   httpx
     #   starlette
-beautifulsoup4==4.12.3
+beautifulsoup4==4.14.2
     # via -r python_service/requirements.in
-black==24.4.2
+black==25.11.0
     # via -r python_service/requirements.in
 build==1.3.0
     # via pip-tools
-certifi==2023.7.22
+certifi==2025.10.5
     # via
     #   -r python_service/requirements.in
     #   httpcore
     #   httpx
     #   requests
-cffi==1.16.0
+cffi==2.0.0
     # via cryptography
-charset-normalizer==3.3.2
+charset-normalizer==3.4.4
     # via requests
-click==8.1.7
+click==8.3.0
     # via
     #   black
     #   pip-tools
     #   uvicorn
-cryptography==42.0.5
+cryptography==46.0.3
     # via
     #   -r python_service/requirements.in
     #   secretstorage
 deprecated==1.3.1
     # via limits
-fastapi==0.115.0
+fastapi==0.121.1
     # via -r python_service/requirements.in
-greenlet==3.0.3
+greenlet==3.2.4
     # via sqlalchemy
-h11==0.14.0
+h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
-h2==4.1.0
+h2==4.3.0
     # via httpx
-hpack==4.0.0
+hpack==4.1.0
     # via h2
-httpcore==1.0.5
+httpcore==1.0.9
     # via httpx
 httpx[http2]==0.28.1
     # via -r python_service/requirements.in
-hyperframe==6.0.1
+hyperframe==6.1.0
     # via h2
-idna==3.7
+idna==3.11
     # via
     #   anyio
     #   httpx
     #   requests
-iniconfig==2.0.0
+iniconfig==2.3.0
     # via pytest
 jaraco-classes==3.4.0
     # via keyring
@@ -76,7 +78,7 @@ jeepney==0.9.0
     # via
     #   keyring
     #   secretstorage
-keyring==25.2.1
+keyring==25.6.0
     # via -r python_service/requirements.in
 limits==5.6.0
     # via slowapi
@@ -84,14 +86,14 @@ more-itertools==10.8.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via black
-numpy==2.0.0
+numpy==2.3.4
     # via
     #   -r python_service/requirements.in
     #   pandas
     #   scipy
-packaging==24.1
+packaging==25.0
     # via
     #   black
     #   build
@@ -99,83 +101,96 @@ packaging==24.1
     #   pyinstaller
     #   pyinstaller-hooks-contrib
     #   pytest
-pandas==2.2.2
+pandas==2.3.3
     # via -r python_service/requirements.in
 pathspec==0.12.1
     # via black
-pip-tools==7.4.1
+pip-tools==7.5.1
     # via -r python_service/requirements.in
-platformdirs==4.2.2
+platformdirs==4.5.0
     # via black
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
-psutil==5.9.8
+psutil==7.1.3
     # via -r python_service/requirements.in
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.11
     # via -r python_service/requirements.in
-pycparser==2.22
+pycparser==2.23
     # via cffi
-pydantic==2.8.2
+pydantic==2.12.4
     # via
     #   fastapi
     #   pydantic-settings
-pydantic-core==2.20.1
+pydantic-core==2.41.5
     # via pydantic
-pydantic-settings==2.3.4
+pydantic-settings==2.12.0
     # via -r python_service/requirements.in
+pygments==2.19.2
+    # via pytest
 pyinstaller==6.6.0
     # via -r python_service/requirements.in
-pyinstaller-hooks-contrib==2024.8
+pyinstaller-hooks-contrib==2025.9
     # via pyinstaller
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==8.1.2
+pytest==9.0.0
     # via
     #   -r python_service/requirements.in
     #   pytest-asyncio
-pytest-asyncio==0.23.7
+pytest-asyncio==1.3.0
     # via -r python_service/requirements.in
 python-dateutil==2.9.0.post0
     # via pandas
-python-dotenv==1.0.1
+python-dotenv==1.2.1
     # via pydantic-settings
-pytz==2024.1
+pytokens==0.3.0
+    # via black
+pytz==2025.2
     # via pandas
-redis==5.0.7
+redis==7.0.1
     # via -r python_service/requirements.in
-requests==2.32.4
+requests==2.32.5
     # via -r python_service/requirements.in
-scipy==1.14.0
+scipy==1.16.3
     # via -r python_service/requirements.in
-secretstorage==3.4.0
+secretstorage==3.4.1
     # via keyring
 selectolax==0.4.0
     # via -r python_service/requirements.in
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 slowapi==0.1.9
     # via -r python_service/requirements.in
 sniffio==1.3.1
     # via anyio
-soupsieve==2.5
+soupsieve==2.8
     # via beautifulsoup4
-sqlalchemy==2.0.31
+sqlalchemy==2.0.44
     # via -r python_service/requirements.in
-starlette==0.38.2
+starlette==0.49.3
     # via fastapi
-structlog==24.1.0
+structlog==25.5.0
     # via -r python_service/requirements.in
 typing-extensions==4.15.0
     # via
     #   aiosqlite
+    #   anyio
+    #   beautifulsoup4
     #   fastapi
     #   limits
     #   pydantic
     #   pydantic-core
+    #   pytest-asyncio
     #   sqlalchemy
-tzdata==2024.1
+    #   starlette
+    #   typing-inspection
+typing-inspection==0.4.2
+    # via
+    #   pydantic
+    #   pydantic-settings
+tzdata==2025.2
     # via pandas
 urllib3==2.5.0
     # via
@@ -183,7 +198,7 @@ urllib3==2.5.0
     #   requests
 uvicorn==0.30.1
     # via -r python_service/requirements.in
-wheel==0.43.0
+wheel==0.45.1
     # via
     #   -r python_service/requirements.in
     #   pip-tools


### PR DESCRIPTION
Updated `python_service/requirements.in` and recompiled `python_service/requirements.txt` to upgrade vulnerable packages.

- Unpinned `certifi`, `cryptography`, and `fastapi` to allow `pip-compile` to select the latest secure versions.
- Regenerated `requirements.txt` using `pip-compile --upgrade`.
- Verified the fix with `pip-audit`, which now reports no known vulnerabilities.