### PR TITLE
fix(build): Add tenacity to hiddenimports in PyInstaller spec

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           # The --local flag is critical to prevent pip-audit from scanning system-wide packages
           pip-audit -r python_service/requirements.txt --local
-      - name: Backend - Prepare and Build
+      - name: Backend - Prepare Spec File
         shell: pwsh
         run: |
           Move-Item -Path "fortuna-backend.spec.template" -Destination "fortuna-backend.spec"

--- a/fortuna-backend.spec.template
+++ b/fortuna-backend.spec.template
@@ -59,6 +59,7 @@ for pkg in ['pydantic', 'fastapi', 'uvicorn', 'starlette', 'httpx', 'anyio']:
     except:
         pass
 hiddenimports += [
+    'tenacity',
     'uvicorn.lifespan', 'anyio._backends._asyncio', 'redis.asyncio',
     'keyring.backends.fail', 'keyring.backends.windows',
     '_ssl', '_hashlib', '_sqlite3'


### PR DESCRIPTION
The backend executable was failing to start in the smoke test due to a `ModuleNotFoundError: No module named 'tenacity'`.

This occurred because PyInstaller's static analysis did not automatically detect this dependency.

This commit resolves the issue by explicitly adding 'tenacity' to the `hiddenimports` list in the `fortuna-backend.spec.template`. This ensures the module is always bundled into the final executable, fixing the crash and allowing the CI pipeline to proceed.