### PR TITLE
fix: Resolve UnicodeEncodeError and smoke test failures in CI

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -124,7 +124,8 @@ jobs:
               try {
                 $response = Invoke-WebRequest -Uri "http://127.0.0.1:8000/health" -TimeoutSec 1 -UseBasicParsing
                 if ($response.StatusCode -eq 200) {
-                  $apiResponse = Invoke-WebRequest -Uri "http://127.0.0.1:8000/api/races" -TimeoutSec 1 -UseBasicParsing -ErrorAction SilentlyContinue
+                  $headers = @{ "X-API-Key" = $env:API_KEY }
+                  $apiResponse = Invoke-WebRequest -Uri "http://127.0.0.1:8000/api/races" -Headers $headers -TimeoutSec 1 -UseBasicParsing -ErrorAction SilentlyContinue
                   if ($apiResponse.StatusCode -eq 200) {
                     Write-Host "[OK] Health check and API test passed on attempt $i!"
                     $serverReady = $true
@@ -233,4 +234,30 @@ jobs:
     needs: [build-backend]
     runs-on: windows-latest
     steps:
-      # ... wix installer steps ...
+      - name: Checkout Repository
+        uses: actions/checkout@v4.1.7
+      - name: Setup Python
+        uses: actions/setup-python@v5.1.1
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Download Backend Executable
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: backend-executable-${{ github.sha }}
+          path: dist
+      - name: Install WiX Toolset
+        shell: pwsh
+        run: |
+          choco install wixtoolset -y --no-progress
+          $wixPath = "C:\Program Files (x86)\WiX ToolSet v3.14\bin"
+          echo "PATH=$wixPath;${env:PATH}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Build Backend Service MSI with WiX
+        shell: pwsh
+        run: |
+          python build_wix/build_msi.py
+      - name: Upload WiX MSI Artifact
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: fortuna-wix-installer-windows
+          path: dist/Fortuna-Backend-Service.msi
+          retention-days: 7

--- a/python_service/main.py
+++ b/python_service/main.py
@@ -3,6 +3,9 @@ import sys
 import os
 from multiprocessing import freeze_support
 
+# Force UTF-8 encoding for stdout and stderr, crucial for PyInstaller on Windows
+os.environ['PYTHONUTF8'] = '1'
+
 # This is the definitive entry point for the Fortuna Faucet backend service.
 # It is designed to be compiled with PyInstaller.
 
@@ -30,7 +33,7 @@ def main():
 
     # It's critical to import the app object *after* the path has been manipulated.
     from python_service.api import app
-    from python_service.config import get__settings
+    from python_service.config import get_settings
 
     settings = get_settings()
 


### PR DESCRIPTION
This commit addresses a `UnicodeEncodeError` that was causing the PyInstaller executable to crash on Windows runners in the CI pipeline.

- Sets the `PYTHONUTF8=1` environment variable at the start of `python_service/main.py`. This forces the Python interpreter to use UTF-8 for stdout/stderr, preventing the encoding error when logging certain characters.

This commit also includes the previous fixes from this session:
- Corrected a typo (`get__settings` -> `get_settings`) in `python_service/main.py`.
- Fixed the artifact name in the `build-wix-installer` job.
- Added the `X-API-Key` header to the smoke test to prevent `403 Forbidden` errors.