### PR TITLE
feat: Implement Twinspires adapter and fix WiX build

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -124,7 +124,8 @@ jobs:
               try {
                 $response = Invoke-WebRequest -Uri "http://127.0.0.1:8000/health" -TimeoutSec 1 -UseBasicParsing
                 if ($response.StatusCode -eq 200) {
-                  $apiResponse = Invoke-WebRequest -Uri "http://127.0.0.1:8000/api/races" -TimeoutSec 1 -UseBasicParsing -ErrorAction SilentlyContinue
+                  $headers = @{ "X-API-Key" = $env:API_KEY }
+                  $apiResponse = Invoke-WebRequest -Uri "http://127.0.0.1:8000/api/races" -Headers $headers -TimeoutSec 1 -UseBasicParsing -ErrorAction SilentlyContinue
                   if ($apiResponse.StatusCode -eq 200) {
                     Write-Host "[OK] Health check and API test passed on attempt $i!"
                     $serverReady = $true
@@ -232,5 +233,33 @@ jobs:
     timeout-minutes: 15
     needs: [build-backend]
     runs-on: windows-latest
+    env:
+      PYTHONIOENCODING: 'utf-8' # FIX: Forces Python to use UTF-8 for all I/O to prevent Unicode errors
     steps:
-      # ... wix installer steps ...
+      - name: Checkout Repository
+        uses: actions/checkout@v4.1.7
+      - name: Setup Python
+        uses: actions/setup-python@v5.1.1
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Download Backend Executable
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: backend-executable-${{ github.sha }}
+          path: dist
+      - name: Install WiX Toolset
+        shell: pwsh
+        run: |
+          choco install wixtoolset -y --no-progress
+          $wixPath = "C:\Program Files (x86)\WiX ToolSet v3.14\bin"
+          echo "PATH=$wixPath;${env:PATH}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Build Backend Service MSI with WiX
+        shell: pwsh
+        run: |
+          python build_wix/build_msi.py
+      - name: Upload WiX MSI Artifact
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: fortuna-wix-installer-windows
+          path: dist/Fortuna-Backend-Service.msi
+          retention-days: 7

--- a/ROADMAP_APPENDICES.md
+++ b/ROADMAP_APPENDICES.md
@@ -54,4 +54,5 @@ This document tracks the strategic evolution of the Fortuna Faucet project.
       - **Primary Track List API:** `https://www.twinspires.com/adw/todays-tracks?affid=0`
       - **Example Race Card URL (Thoroughbred):** `https://www.twinspires.com/adw/todays-tracks/fl/Thoroughbred/races?affid=0`
       - **Example Race Card URL (Greyhound):** `https://www.twinspires.com/adw/todays-tracks/cp1/Greyhound/races?affid=0`
+    - **Status:** In Progress. Initial implementation is complete, including fetching all tracks and their corresponding race cards for all three disciplines (Thoroughbred, Harness, Greyhound). The final piece of work is to discover and implement the API endpoint for fetching the runner data for each race.
     - **Notes:** The race card endpoint provides race details but does not include runner information, which will require discovering and integrating a second API endpoint.

--- a/build_wix/Product.wxs
+++ b/build_wix/Product.wxs
@@ -18,10 +18,6 @@
             </Directory>
         </Directory>
 
-        <ComponentGroup Id="MainFiles">
-            <!-- This will be auto-populated by the 'heat' tool -->
-        </ComponentGroup>
-
         <DirectoryRef Id="INSTALLFOLDER">
             <Component Id="ServiceControl" Guid="*">
                 <ServiceInstall Id="ServiceInstaller"

--- a/build_wix/build_msi.py
+++ b/build_wix/build_msi.py
@@ -12,7 +12,9 @@ EXECUTABLE_NAME = 'fortuna-backend.exe'
 
 def run_command(cmd, cwd=None):
     print(f'▶ Running: {" ".join(cmd)}')
-    subprocess.run(cmd, cwd=cwd, check=True, text=True)
+    # FIX: Explicitly use UTF-8 for decoding the output, and ignore errors for robustness.
+    # This resolves the UnicodeDecodeError when reading the external WiX process's output.
+    subprocess.run(cmd, cwd=cwd, check=True, text=True, encoding='utf-8', errors='ignore')
 
 def main():
     print('=== Starting Fortuna WiX MSI Build ===')

--- a/python_service/adapters/twinspires_adapter.py
+++ b/python_service/adapters/twinspires_adapter.py
@@ -20,67 +20,99 @@ class TwinSpiresAdapter(BaseAdapterV3):
 
     async def _fetch_data(self, date: str) -> Any:
         """
-        TODO: Implement the logic to fetch data from the Twinspires JSON API.
-
-        *** JB's Discoveries for the next agent to implement ***
-
-        The goal is to reverse-engineer the site's API to get a list of all tracks
-        for a given day, then get the race card for each track, and finally the
-        runner data for each race.
-
-        1.  **Main Page (potential source for a list of all tracks):**
-            - https://www.twinspires.com/bet/todays-races/
-
-        2.  **API Endpoint for All Tracks (CRITICAL DISCOVERY):**
-            - This URL appears to provide the core data for all tracks for the day.
-            - https://www.twinspires.com/adw/todays-tracks?affid=0
-
-        3.  **Example Track URLs (these seem to load the race card data):**
-            - Greyhound: https://www.twinspires.com/adw/todays-tracks/cp1/Greyhound/races?affid=0
-            - Thoroughbred: https://www.twinspires.com/adw/todays-tracks/fl/Thoroughbred/races?affid=0
-            - Harness: https://www.twinspires.com/adw/todays-tracks/mr/Harness/races?affid=0
-
-        3.  **Example Race Card JSON (for Central Park):**
-            This data is likely fetched by one of the track URLs above. Note that this
-            JSON does NOT contain the runner (horse/greyhound) data, so another API
-            call will be needed to get the entries for each race.
-
-            ```json
-            [
-                {"raceType":"","purse":"0","maxClaimPrice":"0","grade":"","raceNumber":1,"raceDate":"2025-10-27","postTime":"2025-10-27T10:36:17-04:00","postTimeStamp":1761575777000,"mtp":0,"status":"Closed","distance":"303 Y","distanceLong":"303 YARDS","ageRestrictions":"","sexRestrictions":"","wagers":"Win Place Exacta Quinella Trifecta Central Park","country":"ENG","carryover":[],"formattedPurse":"$0","hasSilks":false,"displayRaceName":"","displayRaceDescription":"","surfaceConditionMap":{},"hasBrisPick":false,"currentRace":false,"hasExpertPick":false},
-                {"raceType":"","purse":"0","maxClaimPrice":"0","grade":"","raceNumber":2,"raceDate":"2025-10-27","postTime":"2025-10-27T10:54:15-04:00","postTimeStamp":1761576855000,"mtp":0,"status":"Closed","distance":"537 Y","distanceLong":"537 YARDS","ageRestrictions":"","sexRestrictions":"","wagers":"Win Place Exacta Quinella Trifecta Central Park","country":"ENG","carryover":[],"formattedPurse":"$0","hasSilks":false,"displayRaceName":"","displayRaceDescription":"","surfaceConditionMap":{},"hasBrisPick":false,"currentRace":false,"hasExpertPick":false},
-                {"raceType":"","purse":"0","maxClaimPrice":"0","grade":"","raceNumber":3,"raceDate":"2025-10-27","postTime":"2025-10-27T11:13:16-04:00","postTimeStamp":1761577996000,"mtp":0,"status":"Closed","distance":"303 Y","distanceLong":"303 YARDS","ageRestrictions":"","sexRestrictions":"","wagers":"Win Place Exacta Quinella Trifecta Central Park","country":"ENG","carryover":[],"formattedPurse":"$0","hasSilks":false,"displayRaceName":"","displayRaceDescription":"","surfaceConditionMap":{},"hasBrisPick":false,"currentRace":false,"hasExpertPick":false},
-                {"raceType":"","purse":"0","maxClaimPrice":"0","grade":"","raceNumber":4,"raceDate":"2025-10-27","postTime":"2025-10-27T11:32:24-04:00","postTimeStamp":1761579144000,"mtp":0,"status":"Closed","distance":"303 Y","distanceLong":"303 YARDS","ageRestrictions":"","sexRestrictions":"","wagers":"Win Place Exacta Quinella Trifecta Central Park","country":"ENG","carryover":[],"formattedPurse":"$0","hasSilks":false,"displayRaceName":"","displayRaceDescription":"","surfaceConditionMap":{},"hasBrisPick":false,"currentRace":false,"hasExpertPick":false},
-                {"raceType":"","purse":"0","maxClaimPrice":"0","grade":"","raceNumber":5,"raceDate":"2025-10-27","postTime":"2025-10-27T11:51:15-04:00","postTimeStamp":1761580275000,"mtp":0,"status":"Closed","distance":"537 Y","distanceLong":"537 YARDS","ageRestrictions":"","sexRestrictions":"","wagers":"Win Place Exacta Quinella Trifecta Central Park","country":"ENG","carryover":[],"formattedPurse":"$0","hasSilks":false,"displayRaceName":"","displayRaceDescription":"","surfaceConditionMap":{},"hasBrisPick":false,"currentRace":false,"hasExpertPick":false},
-                {"raceType":"","purse":"0","maxClaimPrice":"0","grade":"","raceNumber":6,"raceDate":"2025-10-27","postTime":"2025-10-27T12:09:15-04:00","postTimeStamp":1761581355000,"mtp":0,"status":"Closed","distance":"303 Y","distanceLong":"303 YARDS","ageRestrictions":"","sexRestrictions":"","wagers":"Win Place Exacta Quinella Trifecta Central Park","country":"ENG","carryover":[],"formattedPurse":"$0","hasSilks":false,"displayRaceName":"","displayRaceDescription":"","surfaceConditionMap":{},"hasBrisPick":false,"currentRace":false,"hasExpertPick":false},
-                {"raceType":"","purse":"0","maxClaimPrice":"0","grade":"","raceNumber":7,"raceDate":"2025-10-27","postTime":"2025-10-27T12:28:16-04:00","postTimeStamp":1761582496000,"mtp":0,"status":"Closed","distance":"537 Y","distanceLong":"537 YARDS","ageRestrictions":"","sexRestrictions":"","wagers":"Win Place Exacta Quinella Trifecta Central Park","country":"ENG","carryover":[],"formattedPurse":"$0","hasSilks":false,"displayRaceName":"","displayRaceDescription":"","surfaceConditionMap":{},"hasBrisPick":false,"currentRace":false,"hasExpertPick":false},
-                {"raceType":"","purse":"0","maxClaimPrice":"0","grade":"","raceNumber":8,"raceDate":"2025-10-27","postTime":"2025-10-27T12:47:20-04:00","postTimeStamp":1761583640000,"mtp":0,"status":"Closed","distance":"303 Y","distanceLong":"303 YARDS","ageRestrictions":"","sexRestrictions":"","wagers":"Win Place Exacta Quinella Trifecta Central Park","country":"ENG","carryover":[],"formattedPurse":"$0","hasSilks":false,"displayRaceName":"","displayRaceDescription":"","surfaceConditionMap":{},"hasBrisPick":false,"currentRace":false,"hasExpertPick":false},
-                {"raceType":"","purse":"0","maxClaimPrice":"0","grade":"","raceNumber":9,"raceDate":"2025-10-27","postTime":"2025-10-27T13:06:22-04:00","postTimeStamp":1761584782000,"mtp":0,"status":"Closed","distance":"303 Y","distanceLong":"303 YARDS","ageRestrictions":"","sexRestrictions":"","wagers":"Win Place Exacta Quinella Trifecta Central Park","country":"ENG","carryover":[],"formattedPurse":"$0","hasSilks":false,"displayRaceName":"","displayRaceDescription":"","surfaceConditionMap":{},"hasBrisPick":false,"currentRace":false,"hasExpertPick":false},
-                {"raceType":"","purse":"0","maxClaimPrice":"0","grade":"","raceNumber":10,"raceDate":"2025-10-27","postTime":"2025-10-27T13:23:59-04:00","postTimeStamp":1761585839000,"mtp":3,"status":"Open","distance":"537 Y","distanceLong":"537 YARDS","ageRestrictions":"","sexRestrictions":"","wagers":"Win Place Exacta Quinella Trifecta Central Park","country":"ENG","carryover":[],"formattedPurse":"$0","hasSilks":false,"displayRaceName":"","displayRaceDescription":"","surfaceConditionMap":{},"hasBrisPick":false,"currentRace":true,"hasExpertPick":false},
-                {"raceType":"","purse":"0","maxClaimPrice":"0","grade":"","raceNumber":11,"raceDate":"2025-10-27","postTime":"2025-10-27T13:43:00-04:00","postTimeStamp":1761586980000,"mtp":99,"status":"Open","distance":"303 Y","distanceLong":"303 YARDS","ageRestrictions":"","sexRestrictions":"","wagers":"Win Place Exacta Quinella Trifecta Central Park","country":"ENG","carryover":[],"formattedPurse":"$0","hasSilks":false,"displayRaceName":"","displayRaceDescription":"","surfaceConditionMap":{},"hasBrisPick":false,"currentRace":false,"hasExpertPick":false}
-            ]
-            ```
+        Fetches all race data for a given date from the Twinspires JSON API.
+        It first fetches a list of all tracks, then fetches the race card for each track.
         """
-        self.logger.info("Fetching data for TwinSpires")
-        # Placeholder: returning None as the actual implementation is pending.
-        return None
+        import asyncio
+        self.logger.info("Fetching track list from TwinSpires")
+        tracks_url = "adw/todays-tracks?affid=0"
+        tracks_response = await self.make_request(self.http_client, "GET", tracks_url)
+        if not tracks_response:
+            return None
+
+        tracks_data = tracks_response.json()
+        self.logger.info(f"Found {len(tracks_data)} tracks. Fetching race cards.")
+
+        race_card_tasks = []
+        for track in tracks_data:
+            track_id = track.get("trackId")
+            race_type = track.get("raceType")
+            if track_id and race_type:
+                url = f"adw/todays-tracks/{track_id}/{race_type}/races?affid=0"
+                race_card_tasks.append(self.make_request(self.http_client, "GET", url))
+
+        race_card_responses = await asyncio.gather(*race_card_tasks, return_exceptions=True)
+
+        # Filter out exceptions and return only successful responses, including track info
+        results = []
+        for track, resp in zip(tracks_data, race_card_responses):
+            if resp and not isinstance(resp, Exception):
+                results.append({"track": track, "races": resp.json()})
+
+        return results
 
     def _parse_races(self, raw_data: Any) -> List[Race]:
         """
-        TODO: Implement the logic to parse the JSON data from the Twinspires API.
+        Parses the JSON data from the Twinspires API into Race objects.
         """
+        from datetime import datetime
         if not raw_data:
             return []
 
-        # Placeholder: returning an empty list as the actual implementation is pending.
-        return []
+        self.logger.info("Parsing TwinSpires race data.")
+        races = []
+        for track_data in raw_data:
+            track = track_data.get("track", {})
+            race_cards = track_data.get("races", [])
+
+            for race_card in race_cards:
+                try:
+                    start_time = datetime.fromisoformat(race_card.get("postTime").replace("Z", "+00:00"))
+
+                    # TODO: Find the API endpoint for runner data.
+                    # The runner data is not included in the race card, so a third API call
+                    # will be needed here to get the runners for each race.
+                    # For now, we will create the race with an empty runners list.
+
+                    races.append(
+                        Race(
+                            id=f"ts_{track.get('trackId')}_{race_card.get('raceNumber')}",
+                            venue=track.get("trackName"),
+                            race_number=race_card.get("raceNumber"),
+                            start_time=start_time,
+                            discipline=track.get("raceType", "Unknown"),
+                            runners=[], # Placeholder
+                            source=self.SOURCE_NAME,
+                        )
+                    )
+                except Exception as e:
+                    self.logger.warning(
+                        "Failed to parse race card, skipping.",
+                        race_card=race_card,
+                        error=e,
+                        exc_info=True,
+                    )
+
+        return races
+
+    async def _get_races_async(self, date: str) -> List[Race]:
+        raw_data = await self._fetch_data(date)
+        return self._parse_races(raw_data)
 
     def get_races(self, date: str) -> List[Race]:
         """
         Orchestrates the fetching and parsing of race data for a given date.
         This method will be called by the FortunaEngine.
         """
-        # This is a synchronous wrapper for the async orchestrator
-        # The actual implementation will use the async methods.
         self.logger.info(f"Getting races for {date} from {self.SOURCE_NAME}")
-        return []
+        # This is a synchronous wrapper for the async orchestrator
+        # It's a temporary measure to allow me to see the API response.
+        import asyncio
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        races = loop.run_until_complete(self._get_races_async(date))
+        return races

--- a/tests/adapters/test_twinspires_adapter.py
+++ b/tests/adapters/test_twinspires_adapter.py
@@ -1,63 +1,63 @@
 # tests/adapters/test_twinspires_adapter.py
-from datetime import datetime
-from decimal import Decimal
-from unittest.mock import AsyncMock
-from unittest.mock import MagicMock
-
 import pytest
-
+import respx
+import httpx
+from httpx import Response
 from python_service.adapters.twinspires_adapter import TwinSpiresAdapter
+from python_service.models import Race
 
+# A mock settings object to satisfy the adapter's config dependency
+class MockSettings:
+    pass
 
 @pytest.fixture
-def twinspires_adapter():
-    mock_config = MagicMock()
-    return TwinSpiresAdapter(config=mock_config)
+def adapter():
+    return TwinSpiresAdapter(config=MockSettings())
 
-
-def read_fixture(file_path):
-    with open(file_path, "r") as f:
-        return f.read()
-
-
-@pytest.mark.skip(reason="Twinspires adapter is a placeholder and not yet implemented.")
 @pytest.mark.asyncio
-async def test_twinspires_adapter_get_races_successfully(twinspires_adapter):
-    """Verify adapter correctly fetches and parses data via get_races."""
-    mock_html = read_fixture("tests/fixtures/twinspires_sample.html")
-    race_date = "2025-10-26"
+@respx.mock
+async def test_get_races_with_mock_data(adapter):
+    """
+    Test that the adapter can correctly parse a mock API response.
+    This test uses a mocked API response to avoid live calls and ensure reproducibility.
+    """
+    mock_track_data = [
+        {"trackId":"cp1","trackName":"Central Park","raceType":"Greyhound"},
+        {"trackId":"fl","trackName":"Finger Lakes","raceType":"Thoroughbred"},
+        {"trackId":"mr","trackName":"Monticello Raceway","raceType":"Harness"},
+    ]
 
-    # Patch the internal _fetch_data method to return the mock HTML
-    twinspires_adapter._fetch_data = AsyncMock(return_value={"html": mock_html, "date": race_date})
+    mock_race_card_data = [
+        {"raceNumber": 1, "postTime": "2025-11-12T10:36:17-04:00", "distance": "303 Y"},
+        {"raceNumber": 2, "postTime": "2025-11-12T10:54:15-04:00", "distance": "537 Y"},
+    ]
 
-    races = twinspires_adapter.get_races(race_date)
+    # Mock the initial 'todays-tracks' call
+    respx.get(adapter.base_url + "/adw/todays-tracks?affid=0").mock(
+        return_value=Response(200, json=mock_track_data)
+    )
 
-    assert len(races) == 1
-    race = races[0]
+    # Mock the race card calls for each track
+    for track in mock_track_data:
+        track_id = track.get("trackId")
+        race_type = track.get("raceType")
+        respx.get(f"{adapter.base_url}/adw/todays-tracks/{track_id}/{race_type}/races?affid=0").mock(
+            return_value=Response(200, json=mock_race_card_data)
+        )
 
-    assert race.venue == "Churchill Downs"
-    assert race.race_number == 5
-    assert len(race.runners) == 3  # One runner is scratched
+    # The adapter needs a real http_client to work with the mock
+    async with httpx.AsyncClient() as client:
+        adapter.http_client = client
+        # Call the method under test
+        races = await adapter._get_races_async(date="2025-11-12")
 
-    braveheart = next((r for r in race.runners if r.name == "Braveheart"), None)
-    assert braveheart is not None
-    assert braveheart.odds["TwinSpires"].win == Decimal("3.5")
+    # Assertions
+    assert isinstance(races, list)
+    assert len(races) == 6 # 3 tracks * 2 races each
 
-    gallant_gus = next((r for r in race.runners if r.name == "Gallant Gus"), None)
-    assert gallant_gus is not None
-    assert gallant_gus.odds["TwinSpires"].win == Decimal("4.0")
-
-    # Check that the start time was parsed correctly
-    assert race.start_time == datetime(2025, 10, 26, 16, 30)
-
-
-@pytest.mark.skip(reason="Twinspires adapter is a placeholder and not yet implemented.")
-@pytest.mark.asyncio
-async def test_get_races_handles_fetch_failure(twinspires_adapter):
-    """Tests that get_races returns an empty list when _fetch_data returns None."""
-    race_date = "2025-10-26"
-    twinspires_adapter._fetch_data = AsyncMock(return_value=None)
-
-    races = twinspires_adapter.get_races(race_date)
-
-    assert races == []
+    # Check the first race for correct parsing
+    first_race = races[0]
+    assert first_race.venue == "Central Park"
+    assert first_race.race_number == 1
+    assert first_race.discipline == "Greyhound"
+    assert first_race.runners == [] # Expected to be empty for now


### PR DESCRIPTION
This commit delivers two major updates:

1.  **Fixes the WiX Installer Build:** Resolves a `UnicodeEncodeError` and a duplicate symbol error that were causing the alternative WiX installer build to fail. This was achieved by:
    - Setting `PYTHONIOENCODING='utf-8'` in the GitHub Actions workflow.
    - Updating `build_wix/build_msi.py` to handle subprocess output with UTF-8 encoding.
    - Removing a duplicate `<ComponentGroup>` from `build_wix/Product.wxs`.

2.  **Implements the Twinspires Adapter:** Begins "Operation: The Wiretap" by implementing the initial version of the `TwinSpiresAdapter`. This includes:
    - Fetching the list of all tracks for the day.
    - Concurrently fetching the race cards for all three disciplines (Thoroughbred, Harness, Greyhound).
    - Parsing the race-level data into `Race` objects.
    - A new test file (`tests/adapters/test_twinspires_adapter.py`) with mocked API calls.
    - The `ROADMAP_APPENDICES.md` file has been updated to reflect this progress.

The next step for the Twinspires adapter is to identify and implement the endpoint for fetching runner data.