### PR TITLE
fix: Resolve WiX build errors and implement Twinspires adapter

### DIFF
--- a/build_wix/build_msi.py
+++ b/build_wix/build_msi.py
@@ -47,8 +47,15 @@ def main():
 
     # 4. Link WiX project into MSI
     print("--- Step 4: Linking MSI with 'light' ---")
+    import glob
+    obj_files = glob.glob(str(obj_dir / '*.wixobj'))
+    if not obj_files:
+        sys.exit('✗ Linking failed: No .wixobj files found to link.')
+
     output_msi = PROJECT_ROOT / 'dist' / 'Fortuna-Backend-Service.msi'
-    run_command(['light', '-o', str(output_msi), f'{obj_dir}/*.wixobj'])
+
+    light_cmd = ['light', '-o', str(output_msi)] + obj_files
+    run_command(light_cmd)
     print(f'✓ MSI created successfully at {output_msi}')
 
     print('\n=== BUILD COMPLETE ===')


### PR DESCRIPTION
This commit delivers two major updates:

1.  **Fixes the WiX Installer Build:** Resolves a series of critical errors that were causing the alternative WiX installer build to fail. This includes:
    - A `UnicodeEncodeError` fixed by setting the `PYTHONIOENCODING` environment variable in the CI workflow and adding explicit UTF-8 encoding to the build script.
    - A duplicate symbol error fixed by removing a redundant `<ComponentGroup>` from `build_wix/Product.wxs`.
    - A linker error (`exit status 103`) fixed by using Python's `glob` module to correctly expand the wildcard for `.wixobj` files.

2.  **Implements the Twinspires Adapter:** Begins "Operation: The Wiretap" by implementing the initial version of the `TwinSpiresAdapter`. This includes:
    - Fetching the list of all tracks for the day.
    - Concurrently fetching the race cards for all three disciplines (Thoroughbred, Harness, Greyhound).
    - Parsing the race-level data into `Race` objects.
    - A new test file (`tests/adapters/test_twinspires_adapter.py`) with mocked API calls.
    - The `ROADMAP_APPENDICES.md` file has been updated to reflect this progress.