### PR TITLE
Fix(electron): Correct invalid 'startMenu' key in MSI config

### DIFF
--- a/electron/electron-builder-config.yml
+++ b/electron/electron-builder-config.yml
@@ -22,5 +22,4 @@ msi:
   createDesktopShortcut: true
   createStartMenuShortcut: true
   shortcutName: "Fortuna Faucet"
-  startMenu:
-    folder: "Fortuna Faucet"
+  menuCategory: "Fortuna Faucet"


### PR DESCRIPTION
Replaced the deprecated `startMenu` property in `electron-builder-config.yml` with the correct `menuCategory` property.

This resolves the CI/CD build failure during the MSI packaging step caused by an invalid configuration schema.