### PR TITLE
The `Electron - Install & Package MSI` step in the `build-msi.yml` wo…

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -187,9 +187,9 @@ jobs:
           $exe = "./electron/resources/fortuna-backend.exe"
           # ... existing integration test ...
       - name: Electron - Install & Package MSI
+        working-directory: electron
         shell: pwsh
         run: |
-          cd electron
           npm ci
           npx electron-builder --config electron-builder-config.yml --publish never
       - name: Code Sign MSI


### PR DESCRIPTION
…rkflow was missing the `working-directory` attribute. This caused `npm ci` to run in the repository root instead of the `electron` directory, preventing the installation of Electron dependencies.

This change adds the `working-directory: electron` directive to the step and removes the now-redundant `cd electron` command from the run script. This ensures the dependencies are installed in the correct location before the build process.