### PR TITLE
Fix(wix): Correct Product.wxs schema for service installation

### DIFF
--- a/build_wix/Product.wxs
+++ b/build_wix/Product.wxs
@@ -25,29 +25,29 @@
                 <Directory Id="INSTALLFOLDER" Name="Fortuna App Service">
                     <!-- Component for the backend executable and service -->
                     <Component Id="cmp_fortuna_backend_exe" Guid="*">
-                        <File Id="file_fortuna_backend_exe" KeyPath="yes" Source="$(var.SourceDir)\fortuna-backend.exe" />
+                        <File Id="file_fortuna_backend_exe" KeyPath="yes" Source="$(var.SourceDir)\fortuna-backend.exe">
+                            <!-- FIX: Install the EXE as a Windows Service -->
+                            <util:ServiceInstall
+                                Id="ServiceInstaller"
+                                Name="FortunaBackendService"
+                                DisplayName="Fortuna Faucet Backend Service"
+                                Type="ownProcess"
+                                Start="auto"
+                                ErrorControl="normal"
+                                Account="LocalSystem"
+                                Vital="yes"
+                            />
 
-                        <!-- FIX: Install the EXE as a Windows Service -->
-                        <util:ServiceInstall
-                            Id="ServiceInstaller"
-                            Name="FortunaBackendService"
-                            DisplayName="Fortuna Faucet Backend Service"
-                            Type="ownProcess"
-                            Start="auto"
-                            ErrorControl="normal"
-                            Account="LocalSystem"
-                            Vital="yes"
-                        />
-
-                        <!-- FIX: Start and Stop the service during install/uninstall -->
-                        <util:ServiceControl
-                            Id="ServiceStarter"
-                            Start="install"
-                            Stop="both"
-                            Remove="uninstall"
-                            Name="FortunaBackendService"
-                            Wait="yes"
-                        />
+                            <!-- FIX: Start and Stop the service during install/uninstall -->
+                            <util:ServiceControl
+                                Id="ServiceStarter"
+                                Start="install"
+                                Stop="both"
+                                Remove="uninstall"
+                                Name="FortunaBackendService"
+                                Wait="yes"
+                            />
+                        </File>
                     </Component>
 
                     <!-- Directory for the UI -->


### PR DESCRIPTION
Moves the util:ServiceInstall and util:ServiceControl elements to be children of the File element. This corrects the WiX schema and allows the MSI to build successfully.