### PR TITLE
Fix: Resolve WiX build failure by removing duplicate ComponentGroup

### DIFF
--- a/build_wix/Product_WithService.wxs
+++ b/build_wix/Product_WithService.wxs
@@ -66,7 +66,5 @@
             </Component>
         </DirectoryRef>
 
-        <ComponentGroup Id="FrontendFiles" Directory="UIDirectory" />
-
     </Package>
 </Wix>


### PR DESCRIPTION
Removes the hardcoded `FrontendFiles` ComponentGroup from the main `Product_WithService.wxs` file.

This group is already being auto-generated by the `heat` harvesting process into `Frontend.wxs`. The duplicate definition caused a `WIX0091` error, failing the CI build.

The `Product_WithService.wxs` file retains a `ComponentGroupRef` to correctly include the auto-generated components, resolving the conflict.