### PR TITLE
Fix(CI): Correct WiX source paths using a preprocessor variable

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -353,10 +353,12 @@ jobs:
         run: |
           $wixStagingDir = "build_wix/staging"
           $outputMsi = "dist/Fortuna-Full-App-Service-v4.msi"
+          $frontendSourceDir = Join-Path $env:GITHUB_WORKSPACE "build_wix/staging/ui"
 
           wix build ./build_wix/Product_WithService.wxs ./build_wix/Frontend.wxs `
             -ext WixToolset.Util.wixext `
             -d "SourceDir=$wixStagingDir" `
+            -d "FrontendSourceDir=$frontendSourceDir" `
             -o $outputMsi
 
           Write-Host "✅ MSI created successfully with WiX v4."

--- a/build_wix/Harvest.proj
+++ b/build_wix/Harvest.proj
@@ -19,6 +19,7 @@
                    ComponentGroupName="FrontendFiles"
                    DirectoryRefId="UIDirectory"
                    AutogenerateGuids="true"
-                   SuppressFragments="true" />
+                   SuppressFragments="true"
+                   PreprocessorVariable="var.FrontendSourceDir" />
   </Target>
 </Project>


### PR DESCRIPTION
This commit fixes the `WIX0103` "Cannot find the File" errors that occurred during the WiX build in the CI pipeline.

The `heat` harvesting process in `build_wix/Harvest.proj` now uses a preprocessor variable (`var.FrontendSourceDir`) to define the source paths for the frontend files in the generated `Frontend.wxs`.

The `build-msi.yml` workflow has been updated to define this `FrontendSourceDir` variable, passing an absolute path to the staged UI assets during the `wix build` command.

This ensures that the WiX compiler can correctly locate the harvested files, resolving the path mismatch between the harvesting and compiling steps.