### PR TITLE
fix(wix): correct schema for v4 installer

### DIFF
--- a/build_wix/Product_WithService.wxs
+++ b/build_wix/Product_WithService.wxs
@@ -1,5 +1,7 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
-     xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+     xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util"
+     xmlns:heat="http://wixtoolset.org/schemas/v4/wxs/heat"
+     xmlns:firewall="http://wixtoolset.org/schemas/v4/wxs/firewall">
   <Package Name="Fortuna Faucet Web Service"
            Manufacturer="Fortuna Development Team"
            Version="1.0.0.0"
@@ -14,12 +16,10 @@
       <ComponentGroupRef Id="FrontendComponents" /> <!-- This is populated by the HarvestDirectory element -->
     </Feature>
 
-    <ComponentGroup Id="FrontendComponents" Directory="INSTALLFOLDER">
-      <HarvestDirectory Id="HarvestedUI"
-                        DirectoryId="INSTALLFOLDER"
-                        ComponentGroupName="FrontendComponents"
-                        SourceDir="$(var.SourceDir)/ui" />
-    </ComponentGroup>
+    <HarvestDirectory Id="HarvestedUI"
+                      DirectoryRefId="INSTALLFOLDER"
+                      ComponentGroupName="FrontendComponents"
+                      SourceDir="$(var.SourceDir)/ui" />
 
     <StandardDirectory Id="ProgramFiles6432Folder">
       <Directory Id="INSTALLFOLDER" Name="Fortuna Faucet Web Service">
@@ -30,30 +30,31 @@
         <Component Id="FortunaBackendService" Guid="a1b1a73a-4424-4221-897b-0331984639e2">
           <File Id="FortunaBackendExe"
                 Source="$(var.SourceDir)/fortuna-backend.exe"
-                KeyPath="yes" />
+                KeyPath="yes">
 
-          <util:ServiceInstall Id="InstallFortunaService"
-                               Name="FortunaBackendService"
-                               DisplayName="Fortuna Faucet Backend"
-                               Description="Handles data aggregation for Fortuna Faucet."
-                               Account="LocalService"
-                               Start="auto"
-                               Type="ownProcess"
-                               Vital="yes"
-                               ErrorControl="critical" />
+            <util:ServiceInstall Id="InstallFortunaService"
+                                 Name="FortunaBackendService"
+                                 DisplayName="Fortuna Faucet Backend"
+                                 Description="Handles data aggregation for Fortuna Faucet."
+                                 Account="LocalService"
+                                 Start="auto"
+                                 Type="ownProcess"
+                                 Vital="yes"
+                                 ErrorControl="critical" />
 
-          <util:ServiceControl Id="StartFortunaService"
-                               Name="FortunaBackendService"
-                               Start="install"
-                               Stop="both"
-                               Remove="uninstall"
-                               Wait="yes" />
+            <util:ServiceControl Id="StartFortunaService"
+                                 Name="FortunaBackendService"
+                                 Start="install"
+                                 Stop="both"
+                                 Remove="uninstall"
+                                 Wait="yes" />
 
-          <util:FirewallException Id="FWException"
-                                  Name="Fortuna Faucet"
-                                  Port="8000"
-                                  Protocol="tcp"
-                                  Scope="any" />
+            <firewall:FirewallException Id="FWException"
+                                        Name="Fortuna Faucet"
+                                        Port="8000"
+                                        Protocol="tcp"
+                                        Scope="any" />
+          </File>
         </Component>
 
         <Component Id="DataAndLogsFolders" Guid="f9e0a2d2-8533-4a6c-921c-55913e11f75b">
@@ -99,6 +100,8 @@
     <ComponentGroup Id="StartMenuShortcut">
       <ComponentRef Id="ShortcutComponent" />
     </ComponentGroup>
+
+    <ComponentGroup Id="FrontendComponents" Directory="INSTALLFOLDER" />
 
   </Package>
 </Wix>


### PR DESCRIPTION
Updated the Product_WithService.wxs file to resolve WIX0005 build errors.

- Added 'heat' and 'firewall' XML namespaces to the root Wix element.
- Moved the HarvestDirectory element to be a direct child of the Wix element as required by the schema.
- Nested the ServiceInstall, ServiceControl, and FirewallException elements inside the File element for the service executable.
- Corrected the namespace prefix for FirewallException to 'firewall:'.