### PR TITLE
fix(wix): modernize wixproj to fix build failure

### DIFF
--- a/build_wix/Product_WithService.wxs
+++ b/build_wix/Product_WithService.wxs
@@ -96,11 +96,5 @@ roup>
 
     <ComponentGroup Id="FrontendComponents" Directory="INSTALLFOLDER" />
 
-    <ComponentGroup Id="FrontendComponents" Directory="INSTALLFOLDER" />
-
-    <ComponentGroup Id="FrontendComponents" Directory="INSTALLFOLDER" />
-
-    <ComponentGroup Id="FrontendComponents" Directory="INSTALLFOLDER" />
-
   </Package>
 </Wix>

--- a/build_wix/harvest.wixproj
+++ b/build_wix/harvest.wixproj
@@ -1,31 +1,14 @@
 <Project Sdk="WixToolset.Sdk/4.0.0">
-  <PropertyGroup>
-    <OutputPath>bin\$(Configuration)\</OutputPath>
-    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="WixToolset.Heat" Version="4.0.0" />
+  </ItemGroup>
 
-  <Target Name="GenerateFrontendWxs" BeforeTargets="Build">
-    <PropertyGroup>
-      <HarvestSourceDir>$(MSBuildThisFileDirectory)staging\ui</HarvestSourceDir>
-      <HarvestOutputFile>$(MSBuildThisFileDirectory)frontend_components.wxs</HarvestOutputFile>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <HarvestDirectory Include="$(HarvestSourceDir)">
-        <ComponentGroupName>FrontendComponents</ComponentGroupName>
-        <DirectoryRefId>INSTALLFOLDER</DirectoryRefId>
-        <SuppressRootDirectory>true</SuppressRootDirectory>
-        <PreprocessorVariables>wix.FrontendSourceDir=$(HarvestSourceDir)</PreprocessorVariables>
-      </HarvestDirectory>
-    </ItemGroup>
-
-    <HeatDirectory
-        Directory="$(HarvestSourceDir)"
-        ComponentGroupName="FrontendComponents"
-        DirectoryRefId="INSTALLFOLDER"
-        OutputFile="$(HarvestOutputFile)"
-        SuppressRootDirectory="true"
-        ToolPath="$(WixToolPath)"
-        />
-  </Target>
+  <ItemGroup>
+    <HarvestDirectory Include="staging\ui">
+      <ComponentGroupName>FrontendComponents</ComponentGroupName>
+      <DirectoryRefId>INSTALLFOLDER</DirectoryRefId>
+      <SuppressRootDirectory>true</SuppressRootDirectory>
+      <PreprocessorVariables>wix.FrontendSourceDir=staging\ui</PreprocessorVariables>
+    </HarvestDirectory>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
- Refactors `harvest.wixproj` to use the modern WiX v4 SDK-style `<HarvestDirectory>` item instead of the obsolete `<HeatDirectory>` task. This resolves the `MSB4036` build error.
- Adds the required `WixToolset.Heat` package reference to the `harvest.wixproj` file.
- Removes duplicate `<ComponentGroup>` definitions from `Product_WithService.wxs` to prevent `WIX0091` errors.