### PR TITLE
feat(ci): Parallelize Electron build workflow

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -43,7 +43,6 @@ jobs:
 
   build-backend:
     name: '🐍 Build Backend'
-    needs: [build-frontend]
     timeout-minutes: 20
     runs-on: windows-latest
     env:
@@ -69,11 +68,6 @@ jobs:
         run: |
           if (-not (Test-Path "python_service/main.py")) { throw "❌ FATAL: python_service/main.py not found" }
           Write-Host "✅ Critical files verified."
-      - name: Download Frontend Artifact
-        uses: actions/download-artifact@v4.1.8
-        with:
-          name: frontend-build-output-${{ github.sha }}
-          path: web_platform/frontend/out
       - name: Backend - Install Dependencies
         shell: pwsh
         run: |


### PR DESCRIPTION
This commit modifies the `build-msi.yml` GitHub Actions workflow to run the `build-frontend` and `build-backend` jobs in parallel.

Analysis of the PyInstaller spec file (`fortuna-backend-electron.spec`) confirmed that the backend build for the Electron application does not have a dependency on the frontend build artifacts.

- Removed `needs: [build-frontend]` from the `build-backend` job.
- Removed the obsolete "Download Frontend Artifact" step from the `build-backend` job.

This change will reduce the overall build time for the Electron MSI installer. The `build-web-service-msi.yml` workflow remains unchanged as its backend build requires the frontend assets.