### PR TITLE
fix(ci): parallelize builds and fix wix heat task

### DIFF
--- a/.github/workflows/build-web-service-msi.yml
+++ b/.github/workflows/build-web-service-msi.yml
@@ -44,7 +44,6 @@ jobs:
   build-backend:
     name: '🐍 Build Backend'
     timeout-minutes: 20
-    needs: [build-frontend]
     runs-on: windows-latest
     env:
       PYTHONUTF8: "1"
@@ -57,11 +56,6 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
           cache-dependency-path: 'python_service/requirements.txt'
-      - name: Download Frontend Artifact
-        uses: actions/download-artifact@v4.1.8
-        with:
-          name: frontend-build-output-${{ github.sha }}
-          path: web_platform/frontend/out
       - name: '✅ [MONITOR] Ensure Required Directories Exist'
         shell: pwsh
         run: |

--- a/build_wix/harvest.wixproj
+++ b/build_wix/harvest.wixproj
@@ -9,7 +9,6 @@
         OutputFile="frontend_components.wxs"
         ComponentGroupName="FrontendComponents"
         DirectoryRefId="INSTALLFOLDER"
-        SuppressRootDirectory="true"
-        PreprocessorVariables="wix.FrontendSourceDir=staging\ui" />
+        SuppressRootDirectory="true" />
   </Target>
 </Project>


### PR DESCRIPTION
- Removes the `needs` dependency from the `build-backend` job in the web service workflow to allow frontend and backend builds to run in parallel.
- Removes the redundant frontend artifact download from the `build-backend` job.
- Corrects the `HeatDirectory` task in `harvest.wixproj` by removing the unsupported `PreprocessorVariables` attribute, aligning it with WiX v4 syntax.