### PR TITLE
fix(ci): fix wix build and restore required build dependency

### DIFF
--- a/build_wix/harvest.wixproj
+++ b/build_wix/harvest.wixproj
@@ -9,7 +9,6 @@
         OutputFile="frontend_components.wxs"
         ComponentGroupName="FrontendComponents"
         DirectoryRefId="INSTALLFOLDER"
-        SuppressRootDirectory="true"
-        PreprocessorVariables="wix.FrontendSourceDir=staging\ui" />
+        SuppressRootDirectory="true" />
   </Target>
 </Project>


### PR DESCRIPTION
- Corrects the `HeatDirectory` task in `harvest.wixproj` by removing the unsupported `PreprocessorVariables` attribute, aligning it with WiX v4 syntax. This resolves the initial build failure.
- Reverts the `build-web-service-msi.yml` workflow to a sequential build order (`build-backend` needs `build-frontend`). This is required for the web service architecture, where PyInstaller bundles the frontend assets, and it resolves the `Unable to find.../frontend/out` error.