### PR TITLE
Fix: Correct PowerShell variable syntax in CI workflow

### DIFF
--- a/.github/workflows/build-web-service-msi.yml
+++ b/.github/workflows/build-web-service-msi.yml
@@ -459,7 +459,7 @@ jobs:
               }
 
               try {
-                Write-Host "Attempt $i/$maxAttempts: Checking /health endpoint..." -ForegroundColor Gray
+                Write-Host "Attempt $i/${maxAttempts}: Checking /health endpoint..." -ForegroundColor Gray
                 $response = Invoke-WebRequest `
                   -Uri 'http://127.0.0.1:8000/health' `
                   -TimeoutSec 2 `
@@ -498,7 +498,7 @@ jobs:
 
           if (-not $serverReady) {
             Write-Host "❌ SMOKE TEST FAILED: Backend did not become healthy" -ForegroundColor Red
-            Write-Host "Attempts: $attemptCount/$maxAttempts" -ForegroundColor Red
+            Write-Host "Attempts: ${attemptCount}/${maxAttempts}" -ForegroundColor Red
 
             if (Test-Path $stdOutPath) {
               Write-Host "`n--- STDOUT (last 30 lines) ---" -ForegroundColor Yellow


### PR DESCRIPTION
Corrects two instances of invalid variable interpolation within the `smoke-test-backend` job in the `build-web-service-msi.yml` workflow.

In PowerShell, when a variable in a double-quoted string is immediately followed by a character that could be part of the variable name (like `/`), it must be enclosed in curly braces (e.g., `${variable}`) to avoid a parser error. This change applies that fix.