### PR TITLE
Fix: Correct WiX build by defining SourceDir variable

### DIFF
--- a/.github/workflows/build-web-service-msi.yml
+++ b/.github/workflows/build-web-service-msi.yml
@@ -691,7 +691,9 @@ jobs:
           }
 
           # Build the harvest project - this generates frontend_components.wxs
-          dotnet build build_wix/harvest.wixproj -v:minimal
+          $sourcePath = (Resolve-Path "build_wix/staging").Path
+          Write-Host "Invoking MSBuild with SourceDir: $sourcePath" -ForegroundColor Cyan
+          dotnet build build_wix/harvest.wixproj -p:SourceDir="$sourcePath" -v:minimal
 
           if ($LASTEXITCODE -ne 0) {
             Write-Host "❌ FATAL: MSBuild harvest failed with exit code: $LASTEXITCODE" -ForegroundColor Red


### PR DESCRIPTION
The WiX build was failing in the GitHub Actions workflow because the `heat` tool, used for harvesting files, could not find the source directory. This was due to the `$(var.SourceDir)` preprocessor variable being undefined.

This commit resolves the issue by modifying the `build-web-service-msi.yml` workflow. It now explicitly passes the absolute path of the staging directory to the `dotnet build` command using the `-p:SourceDir` MSBuild property. This ensures the WiX toolset can reliably locate the frontend and backend artifacts, allowing the MSI build to complete successfully.