### PR TITLE
Fix(wix): Isolate harvest project to prevent build errors

### DIFF
--- a/build_wix/harvest.wixproj
+++ b/build_wix/harvest.wixproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputPath>.</OutputPath>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The WiX build was failing with WIX0150 errors because the `harvest.wixproj` file, intended only for harvesting frontend files, was also attempting to compile `Product_WithService.wxs`. This was incorrect because the harvest project's build context does not define the `SourceDir` variable required by the main product file.

This commit resolves the issue by adding `<EnableDefaultCompileItems>false</EnableDefaultCompileItems>` to the `harvest.wixproj` file. This prevents the MSBuild project from automatically including and compiling other `.wxs` files in the directory, restricting it to its sole purpose of running the Heat harvester. This ensures the build process is correctly scoped and eliminates the compilation errors.