### PR TITLE
Fix: Correct WiX schema for Windows Service installation

### DIFF
--- a/build_wix/Product_WithService.wxs
+++ b/build_wix/Product_WithService.wxs
@@ -27,41 +27,37 @@
         <Directory Id="LogsFolder" Name="logs" />
 
         <Component Id="FortunaBackendService" Guid="a1b1a73a-4424-4221-897b-0331984639e2">
-          <File Id="FortunaBackendExe"
-                Source="$(var.SourceDir)/fortuna-backend.exe"
-                KeyPath="yes" />
-
-          <util:ServiceInstall Id="InstallFortunaService"
-                               Name="FortunaBackendService"
-                               DisplayName="Fortuna Faucet Backend"
-                               Description="Handles data aggregation for Fortuna Faucet."
-                               Account="LocalService"
-                               Start="auto"
-                               Type="ownProcess"
-                               Vital="yes"
-                               ErrorControl="critical" />
-
-          <util:ServiceControl Id="StartFortunaService"
-                               Name="FortunaBackendService"
-                               Start="install"
-                               Stop="both"
-                               Remove="uninstall"
-                               Wait="yes" />
-
-          <firewall:FirewallException Id="FWException"
-                                      Name="Fortuna Faucet"
-                                      Port="8000"
-                                      Protocol="tcp"
-                                      Scope="any" />
+          <File Id="FortunaBackendExe" Source="$(var.SourceDir)/fortuna-backend.exe" KeyPath="yes">
+            <ServiceInstall Id="InstallFortunaService"
+                            Name="FortunaBackendService"
+                            DisplayName="Fortuna Faucet Backend"
+                            Description="Handles data aggregation for Fortuna Faucet."
+                            Account="NetworkService"
+                            Start="auto"
+                            Type="ownProcess"
+                            Vital="yes"
+                            ErrorControl="critical" />
+            <ServiceControl Id="StartFortunaService"
+                            Name="FortunaBackendService"
+                            Start="install"
+                            Stop="both"
+                            Remove="uninstall"
+                            Wait="yes" />
+            <firewall:FirewallException Id="FWException"
+                                        Name="Fortuna Faucet"
+                                        Port="8000"
+                                        Protocol="tcp"
+                                        Scope="any" />
+          </File>
         </Component>
 
         <Component Id="DataAndLogsFolders" Guid="f9e0a2d2-8533-4a6c-921c-55913e11f75b">
           <RegistryValue Root="HKLM" Key="Software\Fortuna Faucet" Name="FoldersCreated" Type="integer" Value="1" KeyPath="yes" />
           <CreateFolder Directory="DataFolder">
-            <util:PermissionEx User="LocalService" GenericAll="yes" />
+            <util:PermissionEx User="NetworkService" GenericAll="yes" />
           </CreateFolder>
           <CreateFolder Directory="LogsFolder">
-            <util:PermissionEx User="LocalService" GenericAll="yes" />
+            <util:PermissionEx User="NetworkService" GenericAll="yes" />
           </CreateFolder>
         </Component>
 


### PR DESCRIPTION
Refactors the `Product_WithService.wxs` file to align with the WiX v4 schema. The `ServiceInstall`, `ServiceControl`, and `firewall:FirewallException` elements are now correctly nested within the `File` element for the service executable, resolving WIX0005 build errors.

Additionally, the service account has been changed from `LocalService` to `NetworkService`, and the `PermissionEx` elements for the data and logs directories have been updated accordingly. This provides the service with the necessary permissions to operate correctly after installation.