### PR TITLE
fix(wix): Correct ServiceInstall element for WiX v4

### DIFF
--- a/build_wix/Product_WithService.wxs
+++ b/build_wix/Product_WithService.wxs
@@ -34,17 +34,15 @@
           <Environment Id="FortunaLogDir" Name="FORTUNA_LOG_DIR" Value="[LogsFolder]" Action="set" System="yes" />
           <Environment Id="FortunaMode" Name="FORTUNA_MODE" Value="webservice" Action="set" System="yes" />
 
-          <util:ServiceInstall Id="InstallFortunaService"
+          <ServiceInstall Id="InstallFortunaService"
                                Name="FortunaBackendService"
                                DisplayName="Fortuna Faucet Backend"
                                Description="Handles data aggregation for Fortuna Faucet."
-                               Account="LocalService"
                                Start="auto"
                                Type="ownProcess"
-                               Vital="yes"
                                ErrorControl="normal" />
 
-          <util:ServiceControl Id="StartFortunaService"
+          <ServiceControl Id="StartFortunaService"
                                Name="FortunaBackendService"
                                Start="install"
                                Stop="both"


### PR DESCRIPTION
Removes the 'util:' namespace prefix from the ServiceInstall and ServiceControl elements as they are core components in WiX v4.

Also removes the invalid 'Account' and 'Vital' attributes from the ServiceInstall element, which were causing build failures.

This change allows the MSI installer to build successfully with WiX v4.