### PR TITLE
fix(ci): Implement correct two-stage WiX build process

### DIFF
--- a/.github/workflows/build-web-service-msi.yml
+++ b/.github/workflows/build-web-service-msi.yml
@@ -174,6 +174,18 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
+      - name: Harvest Frontend Files
+        working-directory: build_wix/harvester
+        shell: pwsh
+        run: dotnet build harvest.wixproj -c Release -p:Platform=x64
+      - name: Verify Harvested File
+        shell: pwsh
+        run: |
+          $harvestedFile = "build_wix/frontend_components.wxs"
+          if (-not (Test-Path $harvestedFile)) {
+            throw "❌ FATAL: Harvested file '$harvestedFile' was not created."
+          }
+          Write-Host "✅ WiX harvester ran successfully." -ForegroundColor Green
       - name: Generate WiX Project File
         working-directory: build_wix
         shell: pwsh
@@ -193,6 +205,7 @@ jobs:
             </ItemGroup>
             <ItemGroup>
               <Compile Include="Product_WithService.wxs" />
+              <Compile Include="frontend_components.wxs" />
             </ItemGroup>
           </Project>
           "@

--- a/build_wix/Product_WithService.wxs
+++ b/build_wix/Product_WithService.wxs
@@ -14,6 +14,7 @@
 
     <Feature Id="MainApplication" Title="Main Application" Level="1">
       <ComponentGroupRef Id="ServiceComponents" />
+      <ComponentGroupRef Id="FrontendComponents" />
       <ComponentGroupRef Id="ShortcutsComponentGroup" />
     </Feature>
 
@@ -34,17 +35,15 @@
           <Environment Id="FortunaLogDir" Name="FORTUNA_LOG_DIR" Value="[LogsFolder]" Action="set" System="yes" />
           <Environment Id="FortunaMode" Name="FORTUNA_MODE" Value="webservice" Action="set" System="yes" />
 
-          <util:ServiceInstall Id="InstallFortunaService"
+          <ServiceInstall Id="InstallFortunaService"
                                Name="FortunaBackendService"
                                DisplayName="Fortuna Faucet Backend"
                                Description="Handles data aggregation for Fortuna Faucet."
-                               Account="LocalService"
                                Start="auto"
                                Type="ownProcess"
-                               Vital="yes"
                                ErrorControl="normal" />
 
-          <util:ServiceControl Id="StartFortunaService"
+          <ServiceControl Id="StartFortunaService"
                                Name="FortunaBackendService"
                                Start="install"
                                Stop="both"


### PR DESCRIPTION
This commit resolves persistent MSI build failures by overhauling the WiX installer configuration and the CI workflow.

1.  **Corrected WiX Build Workflow:**
    - The `build-web-service-msi.yml` workflow is modified to perform a proper two-stage build.
    - It now runs the harvester project (`heat.exe`) first to generate a `frontend_components.wxs` file containing all the UI assets.
    - The main installer build step now correctly includes this generated file, ensuring the frontend is packaged.

2.  **Fixed WiX Source Files:**
    - `Product_WithService.wxs` is updated to include a `<ComponentGroupRef>` for the newly harvested `FrontendComponents`.
    - Invalid WiX v3 attributes (`Account`, `Vital`) and the incorrect `util:` namespace have been removed from the `ServiceInstall` and `ServiceControl` elements, making them compliant with WiX v4.