### PR TITLE
fix(build): Correct webservice.spec and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,47 @@ npm run dev --prefix web_platform/frontend
 ```
 
 ---
+## Web Service Development Environment
+
+This section details the setup for the new web service architecture, which is independent of the original Electron application.
+
+### Backend (`web_service/backend/`)
+
+1.  **Navigate to the backend directory:**
+    ```bash
+    cd web_service/backend
+    ```
+2.  **Create a virtual environment:**
+    ```bash
+    python -m venv .venv
+    ```
+3.  **Activate the virtual environment:**
+    *   Windows: `.venv\Scripts\activate`
+    *   macOS/Linux: `source .venv/bin/activate`
+4.  **Install dependencies:**
+    ```bash
+    pip install -r requirements-dev.txt
+    ```
+5.  **Run the development server:**
+    ```bash
+    python main.py
+    ```
+
+### Frontend (`web_platform/frontend/`)
+
+1.  **Navigate to the frontend directory:**
+    ```bash
+    cd web_platform/frontend
+    ```
+2.  **Install dependencies:**
+    ```bash
+    npm install
+    ```
+3.  **Run the development server:**
+    ```bash
+    npm run dev
+    ```
+---
 
 ## Configuration
 

--- a/web_service/webservice.spec
+++ b/web_service/webservice.spec
@@ -7,8 +7,6 @@ a = Analysis(
     pathex=[],
     binaries=[],
     datas=[
-        ('backend/data', 'data'),
-        ('backend/json', 'json'),
         ('backend/adapters', 'adapters'),
         ('frontend/out', 'ui'),
     ],


### PR DESCRIPTION
Removes non-existent 'data' and 'json' directories from the `datas` tuple in the `web_service/webservice.spec` file to resolve the PyInstaller build failure.

Adds a "Web Service Development Environment" section to the main `README.md` file with instructions for setting up and running the backend and frontend servers for local development.