### PR TITLE
fix(ci): Correct relative paths in webservice.spec

### DIFF
--- a/web_service/webservice.spec
+++ b/web_service/webservice.spec
@@ -6,17 +6,17 @@ block_cipher = None
 
 # Collect frontend build output
 frontend_datas = []
-frontend_out = 'web_service/frontend/out'
+frontend_out = 'frontend/out'
 if os.path.exists(frontend_out):
     frontend_datas = [(frontend_out, 'ui')]
 
 a = Analysis(
-    ['web_service/backend/main.py'],
+    ['backend/main.py'],
     pathex=[],
     binaries=[],
     datas=[
-        ('web_service/backend/data', 'data'),
-        ('web_service/backend/json', 'json'),
+        ('backend/data', 'data'),
+        ('backend/json', 'json'),
         ('python_service', 'python_service'),
         *frontend_datas,
     ],


### PR DESCRIPTION
The PyInstaller build was failing in the GitHub Actions workflow because the paths in `web_service/webservice.spec` were incorrect. The workflow executes `pyinstaller` from the project root, but the spec file's paths were also written relative to the project root (e.g., `web_service/backend/main.py`).

PyInstaller resolves script and data paths relative to the location of the `.spec` file itself. This caused a duplicated path segment (`.../web_service/web_service/...`) and a "script not found" error.

This commit corrects all paths within the spec file to be relative to its own directory, aligning the local and CI build environments and resolving the workflow failure.