### PR TITLE
fix(ci): Add httpx to hidden imports in webservice.spec

### DIFF
--- a/web_service/webservice.spec
+++ b/web_service/webservice.spec
@@ -39,6 +39,7 @@ a = Analysis(
         'slowapi.middleware',
         'slowapi.util',
         'pydantic_settings',
+        'httpx',
     ],
     hookspath=[],
     hooksconfig={},


### PR DESCRIPTION
The PyInstaller-built executable was failing during the CI smoke test with a `ModuleNotFoundError: No module named 'httpx'`.

This commit resolves the runtime error by explicitly adding `httpx` to the `hiddenimports` list in the `web_service/webservice.spec` file, ensuring it is correctly bundled into the final executable.