### PR TITLE
chore: Deactivate build-web-service-msi.yml workflow

### DIFF
--- a/.github/workflows/build-electron-from-webservice.yml
+++ b/.github/workflows/build-electron-from-webservice.yml
@@ -1,0 +1,150 @@
+name: Build Electron App from Web Service Code
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: '20'
+  PYTHON_VERSION: '3.12'
+
+jobs:
+  build-frontend:
+    name: '📦 Build Frontend (Web Service)'
+    timeout-minutes: 15
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: 'web_service/frontend/package-lock.json'
+      - name: Frontend - Install & Build
+        shell: pwsh
+        run: |
+          cd web_service/frontend
+          npm ci
+          npm run build
+      - name: Verify Frontend Build
+        shell: pwsh
+        run: |
+          $outDir = 'web_service/frontend/out'
+          if (-not (Test-Path $outDir)) {
+            Write-Host "❌ FATAL: Build output directory 'out' not created" -ForegroundColor Red
+            exit 1
+          }
+      - name: Upload Frontend Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-build-ws-output-${{ github.sha }}
+          path: web_service/frontend/out
+          retention-days: 1
+
+  build-backend:
+    name: '🐍 Build Backend (Web Service for Electron)'
+    timeout-minutes: 20
+    runs-on: windows-latest
+    env:
+      PYTHONUTF8: "1"
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+          cache-dependency-path: 'web_service/backend/requirements.txt'
+      - name: Backend - Install Dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r web_service/backend/requirements-dev.txt
+      - name: Backend - Build with PyInstaller
+        shell: pwsh
+        run: |
+          pyinstaller fortuna-webservice-electron.spec --noconfirm
+      - name: Upload Backend Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-ws-executable-${{ github.sha }}
+          path: dist/fortuna-webservice-backend.exe
+          retention-days: 1
+          if-no-files-found: error
+
+  smoke-test-backend:
+    name: '🧪 Smoke Test Backend Executable'
+    timeout-minutes: 10
+    needs: [build-backend]
+    runs-on: windows-latest
+    steps:
+      - name: Download Backend Executable
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-ws-executable-${{ github.sha }}
+      - name: Run Smoke Test
+        shell: pwsh
+        timeout-minutes: 5
+        env:
+          API_KEY: "a_secure_test_api_key_that_is_long_enough_for_smoke_test"
+        run: |
+          $exe = './fortuna-webservice-backend.exe'
+          Start-Process -FilePath $exe -NoNewWindow
+          Start-Sleep -Seconds 15 # Wait for the server to start
+          try {
+            $response = Invoke-WebRequest -Uri 'http://127.0.0.1:8000/health' -UseBasicParsing
+            if ($response.StatusCode -eq 200) {
+              Write-Host "✅ Health check passed!"
+            } else {
+              throw "Health check failed with status $($response.StatusCode)"
+            }
+          } catch {
+            Write-Host "❌ Smoke test failed: $($_.Exception.Message)"
+            Get-Process "fortuna-webservice-backend" | Stop-Process -Force
+            exit 1
+          }
+          Get-Process "fortuna-webservice-backend" | Stop-Process -Force
+
+  package-and-test:
+    name: '🏆 Package & Test Electron Installer (Web Service)'
+    timeout-minutes: 25
+    needs: [build-frontend, smoke-test-backend]
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+      - name: Setup Node.js for Electron
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: 'electron/package-lock.json'
+      - name: Download All Build Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./temp-artifacts
+      - name: Stage Artifacts for Packaging
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path "./electron/web-ui-build" -Force
+          New-Item -ItemType Directory -Path "./electron/resources" -Force
+          Move-Item -Path "./temp-artifacts/frontend-build-ws-output-${{ github.sha }}/*" -Destination "./electron/web-ui-build/out" -Force
+          Move-Item -Path "./temp-artifacts/backend-ws-executable-${{ github.sha }}/fortuna-webservice-backend.exe" -Destination "./electron/resources/fortuna-backend.exe" -Force
+      - name: Electron - Install & Package MSI
+        working-directory: electron
+        shell: pwsh
+        run: |
+          npm ci
+          npx electron-builder --config electron-builder-config.yml --publish never
+      - name: Upload Final MSI Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: fortuna-installer-electron-ws-${{ github.sha }}
+          path: electron/dist/*.msi
+          retention-days: 7

--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -1,13 +1,12 @@
 name: Build Fortuna Faucet MSI Installer - 🏆 PRODUCTION FORTRESS
 
+# Manually deactivated by setting a trigger that will never fire.
+# This keeps the workflow file valid but prevents it from running automatically.
+# Preserved for reference by JB's request on 2025-11-23.
 on:
   push:
-    branches: [main]
-    tags:
-      - 'v*'
-  pull_request:
-    branches: [main]
-  workflow_dispatch:
+    branches:
+      - 'deactivated/do-not-run'
 
 env:
   NODE_VERSION: '20'

--- a/.github/workflows/build-web-service-msi.yml
+++ b/.github/workflows/build-web-service-msi.yml
@@ -1,11 +1,12 @@
 name: Build Fortuna Faucet MSI (WiX v4) - 🏆 PRODUCTION
 
+# Manually deactivated by setting a trigger that will never fire.
+# This keeps the workflow file valid but prevents it from running automatically.
+# Preserved for reference by JB's request on 2025-11-23.
 on:
   push:
-    branches: [main]
-    tags:
-      - 'v*'
-  workflow_dispatch:
+    branches:
+      - 'deactivated/do-not-run'
 
 env:
   NODE_VERSION: '20'

--- a/.github/workflows/build-webservice-as-a-service.yml
+++ b/.github/workflows/build-webservice-as-a-service.yml
@@ -1,0 +1,171 @@
+name: Build Web Service as a Service MSI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: '20'
+  PYTHON_VERSION: '3.12'
+  PYTHONUTF8: "1"
+
+jobs:
+  build-frontend:
+    name: '📦 Build Frontend (Web Service)'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: 'web_service/frontend/package-lock.json'
+      - name: Frontend - Install & Build
+        shell: pwsh
+        run: |
+          cd web_service/frontend
+          npm ci
+          npm run build
+      - name: Verify Frontend Build
+        shell: pwsh
+        run: |
+          $outDir = 'web_service/frontend/out'
+          if (-not (Test-Path $outDir)) { throw "❌ FATAL: Build output directory 'out' not created" }
+      - name: Upload Frontend Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-build-ws-service
+          path: web_service/frontend/out
+          retention-days: 1
+
+  build-backend:
+    name: '🐍 Build Backend (Web Service for Service)'
+    needs: [build-frontend]
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+          cache-dependency-path: 'web_service/backend/requirements.txt'
+      - name: Create Staging Directory for UI
+        shell: pwsh
+        run: New-Item -ItemType Directory -Path "staging/ui" -Force | Out-Null
+      - name: Download Frontend Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-build-ws-service
+          path: staging/ui
+      - name: Install Python Dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r web_service/backend/requirements-dev.txt
+      - name: Backend - Build with PyInstaller
+        shell: pwsh
+        run: pyinstaller fortuna-webservice-service.spec --noconfirm
+      - name: Upload Backend Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-executable-ws-service
+          path: dist/fortuna-webservice.exe
+          retention-days: 1
+
+  smoke-test-backend:
+    name: '🔥 Smoke Test Backend'
+    needs: [build-backend]
+    runs-on: windows-latest
+    env:
+      FORTUNA_MODE: webservice
+      FORTUNA_PORT: 8089 # Use a different port to avoid conflicts
+    steps:
+      - name: Download Backend Executable
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-executable-ws-service
+          path: ./dist
+      - name: Run Backend and Test
+        shell: pwsh
+        run: |
+          Start-Process -FilePath "./dist/fortuna-webservice.exe"
+          Write-Host "Waiting for backend to become available..."
+          Start-Sleep -Seconds 20
+          try {
+            $response = Invoke-WebRequest -Uri "http://127.0.0.1:$env:FORTUNA_PORT/health" -UseBasicParsing
+            if ($response.StatusCode -ne 200) { throw "Health check failed." }
+            $rootResponse = Invoke-WebRequest -Uri "http://127.0.0.1:$env:FORTUNA_PORT/" -UseBasicParsing
+            if ($rootResponse.StatusCode -ne 200 -or !$rootResponse.Content.Contains('<html')) { throw "Root HTML check failed." }
+            Write-Host "✅ Health and Root checks passed on port $env:FORTUNA_PORT!" -ForegroundColor Green
+          } catch {
+            throw "Smoke test failed."
+          } finally {
+            Stop-Process -Name "fortuna-webservice" -Force -ErrorAction SilentlyContinue
+          }
+
+  package-msi-service:
+    name: '💿 Package Service MSI (Web Service)'
+    needs: [smoke-test-backend]
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Download Backend Executable
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-executable-ws-service
+          path: ./dist
+      - name: Stage Artifacts
+        id: stage_files
+        shell: pwsh
+        run: |
+          $staging = "build_wix/staging"
+          New-Item -ItemType Directory -Path $staging -Force
+          Move-Item -Path "./dist/fortuna-webservice.exe" -Destination "$staging/fortuna-webservice.exe" -Force
+          $msiName = "Fortuna-As-A-Service-${{ github.ref_name }}.msi".Replace('/', '-')
+          if ($msiName -match "main") { $msiName = "Fortuna-As-A-Service-Nightly.msi" }
+          echo "msi_name=$msiName" >> $env:GITHUB_OUTPUT
+      - name: Setup .NET 8 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Build MSI
+        working-directory: build_wix
+        shell: pwsh
+        run: |
+          # Use the Product_WithService.wxs configuration
+          $wixProjContent = @"
+          <Project Sdk="WixToolset.Sdk/4.0.5">
+            <PropertyGroup>
+              <OutputName>${{ steps.stage_files.outputs.msi_name }}</OutputName>
+              <OutputType>Package</OutputType>
+              <DefineConstants>SourceDir=staging</DefineConstants>
+              <Platforms>x64</Platforms>
+            </PropertyGroup>
+            <ItemGroup>
+              <PackageReference Include="WixToolset.Util.wixext" Version="4.0.5" />
+              <PackageReference Include="WixToolset.Firewall.wixext" Version="4.0.5" />
+              <PackageReference Include="WixToolset.UI.wixext" Version="4.0.5" />
+              <Compile Include="Product_WithService.wxs" />
+            </ItemGroup>
+          </Project>
+          "@
+          Set-Content -Path "FortunaWebService.wixproj" -Value $wixProjContent -Encoding UTF8
+          dotnet build FortunaWebService.wixproj -c Release -p:Platform=x64
+          $msiPath = "bin/x64/Release/Package.msi" # Default name
+          if (-not (Test-Path $msiPath)) { throw "❌ Service MSI was not created." }
+          New-Item -ItemType Directory -Path "dist" -Force
+          Copy-Item -Path $msiPath -Destination "dist/${{ steps.stage_files.outputs.msi_name }}" -Force
+      - name: Upload MSI Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: fortuna-installer-webservice-as-a-service
+          path: build_wix/dist/*.msi
+          retention-days: 1

--- a/MANIFEST_PART1.json
+++ b/MANIFEST_PART1.json
@@ -1,12 +1,12 @@
 [
-    "ARCHITECTURAL_MANDATE.md",
+    "electron/secure-settings-manager.js",
+    "python_service/db/init.py",
     "python_service/tests/test_manual_override.py",
     "python_service/utils/odds.py",
-    "web_platform/api_gateway/src/services/DatabaseService.ts",
-    "web_platform/frontend/public/workbox-4754cb34.js",
+    "requirements-dev.txt",
+    "web_platform/frontend/src/components/RaceCard.tsx",
     "web_platform/frontend/src/lib/queryClient.ts",
-    "web_platform/frontend/src/types/electron.d.ts",
-    "web_platform/frontend/src/utils/exportManager.ts",
-    "web_service/frontend/src/components/RaceCard.tsx",
+    "web_service/frontend/app/utils/exportManager.ts",
+    "web_service/frontend/public/workbox-4754cb34.js",
     "web_service/frontend/tsconfig.json"
 ]

--- a/MANIFEST_PART2.json
+++ b/MANIFEST_PART2.json
@@ -1,13 +1,15 @@
 [
+    ".github/dependabot.yml",
+    "ARCHITECTURAL_MANDATE.md",
     "VERSION.txt",
     "electron/resources/.gitkeep",
-    "fortuna-backend-webservice.spec",
-    "pyproject.toml",
-    "python_service/core/exceptions.py",
-    "python_service/middleware/error_handler.py",
+    "fortuna-backend-electron.spec",
+    "package.json",
+    "web_platform/api_gateway/src/services/DatabaseService.ts",
     "web_platform/frontend/app/Providers.tsx",
-    "web_platform/frontend/src/components/RaceCard.tsx",
-    "web_service/frontend/public/workbox-4754cb34.js",
-    "web_service/frontend/src/hooks/useWebSocket.ts",
-    "wix/product_webservice.wxs"
+    "web_platform/frontend/public/workbox-4754cb34.js",
+    "web_platform/frontend/src/types/electron.d.ts",
+    "web_service/backend/core/exceptions.py",
+    "web_service/frontend/app/components/RaceCard.tsx",
+    "web_service/webservice.spec"
 ]

--- a/MANIFEST_PART3.json
+++ b/MANIFEST_PART3.json
@@ -1,13 +1,13 @@
 [
     "PSEUDOCODE.MD",
+    "README.md",
     "electron/assets/license.rtf",
-    "fortuna-backend-electron.spec",
-    "python_service/db/init.py",
-    "requirements-dev.txt",
-    "requirements.txt",
-    "scripts/install_fortuna_gui.bat",
+    "fortuna-backend-webservice.spec",
+    "fortuna-webservice-electron.spec",
+    "python_service/adapters/betfair_greyhound_adapter.py",
+    "python_service/core/exceptions.py",
     "web_platform/api_gateway/tsconfig.json",
-    "web_service/backend/core/exceptions.py",
+    "web_service/backend/db/init.py",
     "web_service/backend/fortuna_service.py",
-    "web_service/backend/tests/test_manual_override.py"
+    "web_service/backend/middleware/error_handler.py"
 ]

--- a/MANIFEST_PART4.json
+++ b/MANIFEST_PART4.json
@@ -1,13 +1,14 @@
 [
     "HISTORY.md",
-    "electron/secure-settings-manager.js",
+    "fortuna-webservice-service.spec",
     "package-lock.json",
-    "python_service/adapters/betfair_greyhound_adapter.py",
+    "pytest.ini",
     "python_service/fortuna_service.py",
+    "scripts/install_fortuna_gui.bat",
     "web_platform/api_gateway/src/server.ts",
-    "web_platform/frontend/src/hooks/useWebSocket.ts",
-    "web_platform/frontend/tsconfig.json",
+    "web_platform/frontend/src/utils/exportManager.ts",
+    "web_service/backend/adapters/betfair_greyhound_adapter.py",
+    "web_service/backend/tests/test_manual_override.py",
     "web_service/frontend/app/Providers.tsx",
-    "web_service/frontend/src/types/electron.d.ts",
-    "web_service/webservice.spec"
+    "web_service/frontend/app/types/electron.d.ts"
 ]

--- a/MANIFEST_PART5.json
+++ b/MANIFEST_PART5.json
@@ -1,15 +1,14 @@
 [
-    ".github/dependabot.yml",
     ".github/workflows/build-web-service-msi.yml",
     "AGENTS.md",
-    "README.md",
     "WISDOM.md",
-    "package.json",
-    "pytest.ini",
-    "web_service/backend/adapters/betfair_greyhound_adapter.py",
-    "web_service/backend/db/init.py",
-    "web_service/backend/middleware/error_handler.py",
+    "pyproject.toml",
+    "python_service/middleware/error_handler.py",
+    "requirements.txt",
+    "web_platform/frontend/src/hooks/useWebSocket.ts",
+    "web_platform/frontend/tsconfig.json",
     "web_service/backend/utils/odds.py",
-    "web_service/frontend/src/lib/queryClient.ts",
-    "web_service/frontend/src/utils/exportManager.ts"
+    "web_service/frontend/app/hooks/useWebSocket.ts",
+    "web_service/frontend/app/lib/queryClient.ts",
+    "wix/product_webservice.wxs"
 ]

--- a/fortuna-webservice-electron.spec
+++ b/fortuna-webservice-electron.spec
@@ -1,0 +1,56 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(
+    ['web_service/backend/main.py'],
+    pathex=[],
+    binaries=[],
+    datas=[
+        ('web_service/backend/adapters', 'adapters'),
+    ],
+    hiddenimports=[
+        'uvicorn.logging',
+        'uvicorn.loops',
+        'uvicorn.loops.auto',
+        'uvicorn.protocols',
+        'uvicorn.protocols.http',
+        'uvicorn.protocols.http.auto',
+        'uvicorn.protocols.websockets',
+        'uvicorn.protocols.websockets.auto',
+        'uvicorn.lifespan',
+        'uvicorn.lifespan.on',
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='fortuna-webservice-backend',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/fortuna-webservice-service.spec
+++ b/fortuna-webservice-service.spec
@@ -1,0 +1,57 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(
+    ['web_service/backend/main.py'],
+    pathex=[],
+    binaries=[],
+    datas=[
+        ('web_service/backend/adapters', 'adapters'),
+        ('staging/ui', 'ui'),
+    ],
+    hiddenimports=[
+        'uvicorn.logging',
+        'uvicorn.loops',
+        'uvicorn.loops.auto',
+        'uvicorn.protocols',
+        'uvicorn.protocols.http',
+        'uvicorn.protocols.http.auto',
+        'uvicorn.protocols.websockets',
+        'uvicorn.protocols.websockets.auto',
+        'uvicorn.lifespan',
+        'uvicorn.lifespan.on',
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='fortuna-webservice',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/scripts/generate_manifests.py
+++ b/scripts/generate_manifests.py
@@ -70,7 +70,8 @@ def get_all_project_files():
     top_level_files = [
         "AGENTS.md", "ARCHITECTURAL_MANDATE.md", "HISTORY.md", "README.md",
         "WISDOM.md", "PSEUDOCODE.MD", "VERSION.txt", "fortuna-backend-electron.spec",
-        "fortuna-backend-webservice.spec", "pyproject.toml", "pytest.ini",
+        "fortuna-backend-webservice.spec", "fortuna-webservice-electron.spec",
+        "fortuna-webservice-service.spec", "pyproject.toml", "pytest.ini",
         "requirements.txt", "requirements-dev.txt", "package.json", "package-lock.json"
     ]
     for file_name in top_level_files:


### PR DESCRIPTION
As requested, this commit deactivates the `build-web-service-msi.yml` workflow.

The deactivation is achieved by changing the `on:` trigger to point to a non-existent branch (`deactivated/do-not-run`). This is a clean method to prevent the workflow from running automatically while keeping it syntactically valid and available for reference, which avoids causing parsing errors in the GitHub Actions UI.