### PR TITLE
fix(backend): Resolve ModuleNotFoundError in PyInstaller build

### DIFF
--- a/run_web_service.py
+++ b/run_web_service.py
@@ -1,0 +1,40 @@
+import sys
+import os
+
+# This script is the official entry point for the PyInstaller-built web service.
+# Its sole purpose is to correctly configure the system path to ensure the
+# 'web_service' package can be found, then execute the application.
+
+def launch():
+    """
+    Configures sys.path and launches the main application.
+    """
+    # When the application is a frozen executable, the directory containing the
+    # .exe is the effective root for our package.
+    if getattr(sys, 'frozen', False):
+        # The `_MEIPASS` attribute is a special path created by PyInstaller
+        # that points to the temporary folder where bundled files are extracted.
+        # However, for package resolution, we need the directory *containing*
+        # the executable itself.
+        project_root = os.path.dirname(os.path.abspath(sys.executable))
+    else:
+        # In a normal development environment, the project root is the
+        # directory containing this script.
+        project_root = os.path.dirname(os.path.abspath(__file__))
+
+    # Add the project root to the Python path.
+    # This allows the interpreter to find the 'web_service' package.
+    sys.path.insert(0, project_root)
+
+    # Now that the path is configured, we can safely import and run the main application.
+    try:
+        from web_service.backend.main import main
+    except ModuleNotFoundError:
+        print("Fatal Error: Could not find the 'web_service' package.", file=sys.stderr)
+        print(f"Current sys.path: {sys.path}", file=sys.stderr)
+        sys.exit(1)
+
+    main()
+
+if __name__ == "__main__":
+    launch()

--- a/web_service/backend/main.py
+++ b/web_service/backend/main.py
@@ -3,6 +3,10 @@ import sys
 import os
 from multiprocessing import freeze_support
 
+from web_service.backend.config import get_settings
+from web_service.backend.port_check import check_port_and_exit_if_in_use
+
+
 # Force UTF-8 encoding for stdout and stderr, crucial for PyInstaller on Windows
 os.environ["PYTHONUTF8"] = "1"
 
@@ -14,27 +18,12 @@ def main():
     """
     Primary entry point for the Fortuna Faucet backend application.
     This function configures and runs the Uvicorn server.
-    It's crucial to launch the app this way to ensure PyInstaller's bootloader
-    can correctly resolve the package context.
+    It is launched by an entry-point script that handles path configuration.
     """
-    # When packaged, we need to adjust the Python path to ensure that the
-    # top-level 'web_service' package can be found.
+    # When packaged, we need to ensure multiprocessing works correctly.
     if getattr(sys, "frozen", False):
         # CRITICAL for multiprocessing support in frozen mode on Windows.
         freeze_support()
-
-        # Add the directory containing the executable to the path.
-        # This is the most reliable way to ensure the package is found.
-        project_root = os.path.dirname(os.path.abspath(sys.executable))
-        sys.path.insert(0, project_root)
-
-        # Also add the parent directory in case the executable is nested.
-        parent_dir = os.path.abspath(os.path.join(project_root, os.pardir))
-        sys.path.insert(0, parent_dir)
-
-    # It's critical to import dependencies *after* the path has been manipulated.
-    from web_service.backend.config import get_settings
-    from web_service.backend.port_check import check_port_and_exit_if_in_use
 
     settings = get_settings()
 

--- a/web_service/webservice.spec
+++ b/web_service/webservice.spec
@@ -11,7 +11,7 @@ if os.path.exists(frontend_out):
     frontend_datas = [(frontend_out, 'ui')]
 
 a = Analysis(
-    ['backend/main.py'],
+    ['run_web_service.py'],
     pathex=[],
     binaries=[],
     datas=[


### PR DESCRIPTION
Introduces a dedicated entry-point script (`run_web_service.py`) to robustly handle `sys.path` configuration for the packaged web service.

This change fixes a `ModuleNotFoundError` that occurred when running the PyInstaller-built executable. The previous method of path manipulation inside `main.py` was unreliable in the CI/CD environment.

- Adds `run_web_service.py` as the new, safe entry point.
- Updates `web_service/webservice.spec` to use the new script.
- Simplifies `web_service/backend/main.py` by removing the now-redundant path logic.