### PR TITLE
fix(cicd): Resolve PyInstaller ASGI app loading error

### DIFF
--- a/run_web_service.py
+++ b/run_web_service.py
@@ -29,10 +29,13 @@ def main():
         if project_root not in sys.path:
             sys.path.insert(0, project_root)
 
-    # Directly run the Uvicorn server with the correct application import string.
-    # This avoids intermediate import scripts that can confuse the PyInstaller loader.
+    # Directly import the app object. This ensures the import happens while the
+    # sys.path is correctly configured, avoiding the deferred string import
+    # issue with PyInstaller.
+    from web_service.backend.api import app
+
     uvicorn.run(
-        "web_service.backend.api:app",
+        app,
         host="0.0.0.0",
         port=int(os.getenv("FORTUNA_PORT", 8088)),
         reload=False


### PR DESCRIPTION
Resolves a `ModuleNotFoundError: No module named 'web_service'` at runtime by changing how the Uvicorn server is invoked. The entry point script now uses a direct import (`from web_service.backend.api import app`) and passes the `app` object to `uvicorn.run()` instead of a string. This ensures the import happens while the `sys.path` is correctly configured by PyInstaller's bootloader, avoiding issues with Uvicorn's deferred string-based import mechanism.

This commit also includes the comprehensive refactoring from the previous attempt:
- Consolidates three separate `.spec` files into a single, authoritative `fortuna-webservice.spec`.
- Updates all active build workflows to use this unified spec file.
- Upgrades CI smoke tests to robust deep integration tests that poll a `/health` endpoint.
- Adds a step to all workflows to upload backend logs on failure.
- Restricts all workflow triggers to the `main` branch.