### PR TITLE
fix(ci): Resolve NameError and improve CI stability

### DIFF
--- a/.github/workflows/build-electron-from-webservice.yml
+++ b/.github/workflows/build-electron-from-webservice.yml
@@ -148,6 +148,15 @@ jobs:
           }
           Write-Host "❌ Health check failed after $maxAttempts attempts."
           exit 1
+      - name: '🕵️‍♀️ Diagnose Backend Failure'
+        if: failure()
+        shell: pwsh
+        run: |
+          Write-Host "--- Backend STDOUT (backend-out.log) ---"
+          if (Test-Path backend-out.log) { Get-Content backend-out.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "--- Backend STDERR (backend-err.log) ---"
+          if (Test-Path backend-err.log) { Get-Content backend-err.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "----------------------------------------"
       - name: Frontend UI Verification
         shell: pwsh
         run: |

--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -153,6 +153,35 @@ jobs:
           Pop-Location
           Set-Content -Path "frontend.pid" -Value $frontendProcess.Id
           Start-Sleep -Seconds 10
+      - name: Deep Integration Test (Poll Health Endpoint)
+        shell: pwsh
+        run: |
+          $healthUrl = "http://127.0.0.1:${{ env.FORTUNA_PORT }}/health"
+          $maxAttempts = 15
+          $delaySeconds = 2
+          For ($i=1; $i -le $maxAttempts; $i++) {
+            try {
+              $response = Invoke-WebRequest -Uri $healthUrl -UseBasicParsing -TimeoutSec 2
+              if ($response.StatusCode -eq 200) {
+                Write-Host "✅ Health check passed on attempt $i."
+                return
+              }
+            } catch {
+              Write-Host "Attempt $i of $maxAttempts failed. Retrying in $delaySeconds seconds..."
+              Start-Sleep -Seconds $delaySeconds
+            }
+          }
+          Write-Host "❌ Health check failed after $maxAttempts attempts."
+          exit 1
+      - name: '🕵️‍♀️ Diagnose Backend Failure'
+        if: failure()
+        shell: pwsh
+        run: |
+          Write-Host "--- Backend STDOUT (backend-out.log) ---"
+          if (Test-Path backend-out.log) { Get-Content backend-out.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "--- Backend STDERR (backend-err.log) ---"
+          if (Test-Path backend-err.log) { Get-Content backend-err.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "----------------------------------------"
       - name: Frontend UI Verification
         shell: pwsh
         run: |

--- a/.github/workflows/build-web-service-msi-jules.yml
+++ b/.github/workflows/build-web-service-msi-jules.yml
@@ -169,6 +169,15 @@ jobs:
           }
           Write-Host "❌ Health check failed after $maxAttempts attempts."
           exit 1
+      - name: '🕵️‍♀️ Diagnose Backend Failure'
+        if: failure()
+        shell: pwsh
+        run: |
+          Write-Host "--- Backend STDOUT (backend-out.log) ---"
+          if (Test-Path backend-out.log) { Get-Content backend-out.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "--- Backend STDERR (backend-err.log) ---"
+          if (Test-Path backend-err.log) { Get-Content backend-err.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "----------------------------------------"
       - name: Frontend UI Verification
         shell: pwsh
         run: |

--- a/.github/workflows/build-web-service-msi.yml
+++ b/.github/workflows/build-web-service-msi.yml
@@ -136,6 +136,35 @@ jobs:
           $backendProcess = Start-Process -FilePath "./fortuna-backend.exe" -PassThru -RedirectStandardOutput "backend-out.log" -RedirectStandardError "backend-err.log"
           Set-Content -Path "backend.pid" -Value $backendProcess.Id
           Start-Sleep -Seconds 10
+      - name: Deep Integration Test (Poll Health Endpoint)
+        shell: pwsh
+        run: |
+          $healthUrl = "${{ env.SMOKE_FRONTEND_URL }}/health"
+          $maxAttempts = 15
+          $delaySeconds = 2
+          For ($i=1; $i -le $maxAttempts; $i++) {
+            try {
+              $response = Invoke-WebRequest -Uri $healthUrl -UseBasicParsing -TimeoutSec 2
+              if ($response.StatusCode -eq 200) {
+                Write-Host "✅ Health check passed on attempt $i."
+                return
+              }
+            } catch {
+              Write-Host "Attempt $i of $maxAttempts failed. Retrying in $delaySeconds seconds..."
+              Start-Sleep -Seconds $delaySeconds
+            }
+          }
+          Write-Host "❌ Health check failed after $maxAttempts attempts."
+          exit 1
+      - name: '🕵️‍♀️ Diagnose Backend Failure'
+        if: failure()
+        shell: pwsh
+        run: |
+          Write-Host "--- Backend STDOUT (backend-out.log) ---"
+          if (Test-Path backend-out.log) { Get-Content backend-out.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "--- Backend STDERR (backend-err.log) ---"
+          if (Test-Path backend-err.log) { Get-Content backend-err.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "----------------------------------------"
       - name: Frontend UI Verification
         shell: pwsh
         run: |

--- a/.github/workflows/build-webservice-as-a-service.yml
+++ b/.github/workflows/build-webservice-as-a-service.yml
@@ -161,6 +161,15 @@ jobs:
           }
           Write-Host "❌ Health check failed after $maxAttempts attempts."
           exit 1
+      - name: '🕵️‍♀️ Diagnose Backend Failure'
+        if: failure()
+        shell: pwsh
+        run: |
+          Write-Host "--- Backend STDOUT (backend-out.log) ---"
+          if (Test-Path backend-out.log) { Get-Content backend-out.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "--- Backend STDERR (backend-err.log) ---"
+          if (Test-Path backend-err.log) { Get-Content backend-err.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "----------------------------------------"
       - name: Frontend UI Verification
         shell: pwsh
         run: |

--- a/web_service/backend/api.py
+++ b/web_service/backend/api.py
@@ -12,7 +12,7 @@ from fastapi import Depends, FastAPI, HTTPException, Query, Request, WebSocket
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from slowapi import Limiter
+from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from slowapi.util import get_remote_address
@@ -73,18 +73,29 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# --- Robust Pathing for Frozen Executables ---
+def resource_path(relative_path: str) -> str:
+    """ Get absolute path to resource, works for dev and for PyInstaller """
+    if getattr(sys, 'frozen', False):
+        # PyInstaller creates a temp folder and stores path in _MEIPASS
+        base_path = sys._MEIPASS
+    else:
+        # In development, the base path is the project root.
+        # This assumes the script is run from the project root.
+        base_path = os.path.abspath(".")
+
+    return os.path.join(base_path, relative_path)
+
+
 # --- Static File Serving Logic (Corrected for PyInstaller) ---
 if os.getenv("FORTUNA_MODE") == "webservice":
     log.info("Application starting in 'webservice' mode, attempting to serve static files.")
 
-    if getattr(sys, 'frozen', False):
-        # When running as a PyInstaller bundle
-        static_dir = os.path.join(sys._MEIPASS, 'ui')
-        log.info(f"Running FROZEN, serving static files from: {static_dir}")
-    else:
-        # When running in a local development environment
-        static_dir = "web_service/frontend/out"
-        log.info(f"Running in DEV, serving static files from: {static_dir}")
+    # Use the robust resource_path function to find the 'ui' directory.
+    # The spec file bundles 'web_service/frontend/out' into the 'ui' folder in the executable's root.
+    static_dir_key = "ui" if getattr(sys, 'frozen', False) else "web_service/frontend/out"
+    static_dir = resource_path(static_dir_key)
+    log.info("Resolved static files directory", path=static_dir)
 
     if not os.path.isdir(static_dir):
         log.error("Static files directory not found! Frontend will not be served.", path=static_dir)


### PR DESCRIPTION
This commit fixes a critical `NameError` that caused all PyInstaller-built executables to crash on startup, leading to smoke test failures. It also incorporates the diagnostic and stability improvements from the previous attempt.

- **Critical Fix:** Added the missing `_rate_limit_exceeded_handler` import to `web_service/backend/api.py` to resolve the `NameError`. The import was already present in `python_service/api.py`.
- **Improved Diagnostics:** Instrumented all five CI workflows with a new step to print backend logs upon failure, ensuring clear error reporting.
- **Improved Stability:** Added a polling health check to the smoke tests in `build-msi.yml` and `build-web-service-msi.yml` to prevent race conditions.
- **Pathing Refactor:** Proactively refactored the static file pathing logic in both `python_service/api.py` and `web_service/backend/api.py` to use a robust `resource_path` function, preventing a class of common PyInstaller runtime errors.