### PR TITLE
fix(ci): Resolve executable typo and NameError in workflows

### DIFF
--- a/.github/workflows/build-electron-from-webservice.yml
+++ b/.github/workflows/build-electron-from-webservice.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Run Backend and Frontend
         shell: pwsh
         run: |
-          $backendProcess = Start-Process -FilePath "./fortuna-webservice-backend.exe" -PassThru -RedirectStandardOutput "backend-out.log" -RedirectStandardError "backend-err.log"
+          $backendProcess = Start-Process -FilePath "./fortuna-webservice.exe" -PassThru -RedirectStandardOutput "backend-out.log" -RedirectStandardError "backend-err.log"
           Set-Content -Path "backend.pid" -Value $backendProcess.Id
           Push-Location ./frontend
           $frontendProcess = Start-Process python -ArgumentList "-m http.server ${{ env.SMOKE_FRONTEND_PORT }}" -PassThru -RedirectStandardOutput "../frontend-out.log" -RedirectStandardError "../frontend-err.log"
@@ -148,6 +148,15 @@ jobs:
           }
           Write-Host "❌ Health check failed after $maxAttempts attempts."
           exit 1
+      - name: '🕵️‍♀️ Diagnose Backend Failure'
+        if: failure()
+        shell: pwsh
+        run: |
+          Write-Host "--- Backend STDOUT (backend-out.log) ---"
+          if (Test-Path backend-out.log) { Get-Content backend-out.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "--- Backend STDERR (backend-err.log) ---"
+          if (Test-Path backend-err.log) { Get-Content backend-err.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "----------------------------------------"
       - name: Frontend UI Verification
         shell: pwsh
         run: |

--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -153,6 +153,35 @@ jobs:
           Pop-Location
           Set-Content -Path "frontend.pid" -Value $frontendProcess.Id
           Start-Sleep -Seconds 10
+      - name: Deep Integration Test (Poll Health Endpoint)
+        shell: pwsh
+        run: |
+          $healthUrl = "http://127.0.0.1:${{ env.FORTUNA_PORT }}/health"
+          $maxAttempts = 15
+          $delaySeconds = 2
+          For ($i=1; $i -le $maxAttempts; $i++) {
+            try {
+              $response = Invoke-WebRequest -Uri $healthUrl -UseBasicParsing -TimeoutSec 2
+              if ($response.StatusCode -eq 200) {
+                Write-Host "✅ Health check passed on attempt $i."
+                return
+              }
+            } catch {
+              Write-Host "Attempt $i of $maxAttempts failed. Retrying in $delaySeconds seconds..."
+              Start-Sleep -Seconds $delaySeconds
+            }
+          }
+          Write-Host "❌ Health check failed after $maxAttempts attempts."
+          exit 1
+      - name: '🕵️‍♀️ Diagnose Backend Failure'
+        if: failure()
+        shell: pwsh
+        run: |
+          Write-Host "--- Backend STDOUT (backend-out.log) ---"
+          if (Test-Path backend-out.log) { Get-Content backend-out.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "--- Backend STDERR (backend-err.log) ---"
+          if (Test-Path backend-err.log) { Get-Content backend-err.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "----------------------------------------"
       - name: Frontend UI Verification
         shell: pwsh
         run: |

--- a/.github/workflows/build-web-service-msi-jules.yml
+++ b/.github/workflows/build-web-service-msi-jules.yml
@@ -169,6 +169,15 @@ jobs:
           }
           Write-Host "❌ Health check failed after $maxAttempts attempts."
           exit 1
+      - name: '🕵️‍♀️ Diagnose Backend Failure'
+        if: failure()
+        shell: pwsh
+        run: |
+          Write-Host "--- Backend STDOUT (backend-out.log) ---"
+          if (Test-Path backend-out.log) { Get-Content backend-out.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "--- Backend STDERR (backend-err.log) ---"
+          if (Test-Path backend-err.log) { Get-Content backend-err.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "----------------------------------------"
       - name: Frontend UI Verification
         shell: pwsh
         run: |

--- a/.github/workflows/build-web-service-msi.yml
+++ b/.github/workflows/build-web-service-msi.yml
@@ -136,6 +136,35 @@ jobs:
           $backendProcess = Start-Process -FilePath "./fortuna-backend.exe" -PassThru -RedirectStandardOutput "backend-out.log" -RedirectStandardError "backend-err.log"
           Set-Content -Path "backend.pid" -Value $backendProcess.Id
           Start-Sleep -Seconds 10
+      - name: Deep Integration Test (Poll Health Endpoint)
+        shell: pwsh
+        run: |
+          $healthUrl = "${{ env.SMOKE_FRONTEND_URL }}/health"
+          $maxAttempts = 15
+          $delaySeconds = 2
+          For ($i=1; $i -le $maxAttempts; $i++) {
+            try {
+              $response = Invoke-WebRequest -Uri $healthUrl -UseBasicParsing -TimeoutSec 2
+              if ($response.StatusCode -eq 200) {
+                Write-Host "✅ Health check passed on attempt $i."
+                return
+              }
+            } catch {
+              Write-Host "Attempt $i of $maxAttempts failed. Retrying in $delaySeconds seconds..."
+              Start-Sleep -Seconds $delaySeconds
+            }
+          }
+          Write-Host "❌ Health check failed after $maxAttempts attempts."
+          exit 1
+      - name: '🕵️‍♀️ Diagnose Backend Failure'
+        if: failure()
+        shell: pwsh
+        run: |
+          Write-Host "--- Backend STDOUT (backend-out.log) ---"
+          if (Test-Path backend-out.log) { Get-Content backend-out.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "--- Backend STDERR (backend-err.log) ---"
+          if (Test-Path backend-err.log) { Get-Content backend-err.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "----------------------------------------"
       - name: Frontend UI Verification
         shell: pwsh
         run: |

--- a/.github/workflows/build-webservice-as-a-service.yml
+++ b/.github/workflows/build-webservice-as-a-service.yml
@@ -161,6 +161,15 @@ jobs:
           }
           Write-Host "❌ Health check failed after $maxAttempts attempts."
           exit 1
+      - name: '🕵️‍♀️ Diagnose Backend Failure'
+        if: failure()
+        shell: pwsh
+        run: |
+          Write-Host "--- Backend STDOUT (backend-out.log) ---"
+          if (Test-Path backend-out.log) { Get-Content backend-out.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "--- Backend STDERR (backend-err.log) ---"
+          if (Test-Path backend-err.log) { Get-Content backend-err.log | ForEach-Object { Write-Host $_ } }
+          Write-Host "----------------------------------------"
       - name: Frontend UI Verification
         shell: pwsh
         run: |

--- a/web_service/backend/api.py
+++ b/web_service/backend/api.py
@@ -12,7 +12,7 @@ from fastapi import Depends, FastAPI, HTTPException, Query, Request, WebSocket
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from slowapi import Limiter
+from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from slowapi.util import get_remote_address
@@ -73,18 +73,29 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# --- Robust Pathing for Frozen Executables ---
+def resource_path(relative_path: str) -> str:
+    """ Get absolute path to resource, works for dev and for PyInstaller """
+    if getattr(sys, 'frozen', False):
+        # PyInstaller creates a temp folder and stores path in _MEIPASS
+        base_path = sys._MEIPASS
+    else:
+        # In development, the base path is the project root.
+        # This assumes the script is run from the project root.
+        base_path = os.path.abspath(".")
+
+    return os.path.join(base_path, relative_path)
+
+
 # --- Static File Serving Logic (Corrected for PyInstaller) ---
 if os.getenv("FORTUNA_MODE") == "webservice":
     log.info("Application starting in 'webservice' mode, attempting to serve static files.")
 
-    if getattr(sys, 'frozen', False):
-        # When running as a PyInstaller bundle
-        static_dir = os.path.join(sys._MEIPASS, 'ui')
-        log.info(f"Running FROZEN, serving static files from: {static_dir}")
-    else:
-        # When running in a local development environment
-        static_dir = "web_service/frontend/out"
-        log.info(f"Running in DEV, serving static files from: {static_dir}")
+    # Use the robust resource_path function to find the 'ui' directory.
+    # The spec file bundles 'web_service/frontend/out' into the 'ui' folder in the executable's root.
+    static_dir_key = "ui" if getattr(sys, 'frozen', False) else "web_service/frontend/out"
+    static_dir = resource_path(static_dir_key)
+    log.info("Resolved static files directory", path=static_dir)
 
     if not os.path.isdir(static_dir):
         log.error("Static files directory not found! Frontend will not be served.", path=static_dir)


### PR DESCRIPTION
This commit provides a comprehensive fix for multiple CI/CD workflow failures.

- Corrected a filename typo in `build-electron-from-webservice.yml` where the smoke test was attempting to run a non-existent executable (`fortuna-webservice-backend.exe` instead of `fortuna-webservice.exe`).
- Fixed a `NameError` in `web_service/backend/api.py` by adding the missing import for `_rate_limit_exceeded_handler`.
- This commit retains the previous improvements, including robust CI health checks, diagnostic logging on failure, and the `resource_path` utility for safe asset pathing in PyInstaller executables.