### PR TITLE
Fix: Resolve silent startup failure in packaged web service

### DIFF
--- a/run_web_service.py
+++ b/run_web_service.py
@@ -30,11 +30,6 @@ def main():
         if project_root not in sys.path:
             sys.path.insert(0, project_root)
 
-    # Directly import the app object. This ensures the import happens while the
-    # sys.path is correctly configured, avoiding the deferred string import
-    # issue with PyInstaller.
-    from web_service.backend.api import app
-
     # CRITICAL FIX FOR PYINSTALLER on WINDOWS: Force event loop policy
     # This resolves a silent network binding failure where Uvicorn reports startup
     # but the OS never actually binds the port.
@@ -43,7 +38,7 @@ def main():
         print("[BOOT] Applied WindowsSelectorEventLoopPolicy for PyInstaller", file=sys.stderr)
 
     uvicorn.run(
-        app,
+        "web_service.backend.api:app",
         host="0.0.0.0",
         port=int(os.getenv("FORTUNA_PORT", 8088)),
         reload=False


### PR DESCRIPTION
The CI/CD smoke test was failing because the PyInstaller-packaged web service executable would start, log that it was listening on a port, but then exit silently before the network socket was actually bound. This was confirmed by forensic analysis showing no process listening on the target port.

The root cause was a subtle interaction between PyInstaller's bootloader, the `asyncio` event loop on Windows, and Uvicorn's process management.

The fix is to change the `uvicorn.run()` call in the main entry point (`run_web_service.py`) to use a string import (`"web_service.backend.api:app"`) instead of a direct object import. This is a best practice for packaged applications, as it allows Uvicorn to control the application import within its worker processes, resolving the race condition that led to the silent crash.