### PR TITLE
fix(ci): Align artifact paths in all web service workflows

### DIFF
--- a/.github/workflows/build-electron-from-webservice.yml
+++ b/.github/workflows/build-electron-from-webservice.yml
@@ -127,8 +127,8 @@ jobs:
         shell: pwsh
         run: |
           Get-ChildItem -Path "./artifacts/backend-ws-executable-${{ github.sha }}" | ForEach-Object { Move-Item -Path $_.FullName -Destination "." -Force }
-          New-Item -ItemType Directory -Path "./frontend" -Force
-          Get-ChildItem -Path "./artifacts/frontend-build-ws-output-${{ github.sha }}" | ForEach-Object { Move-Item -Path $_.FullName -Destination "./frontend" -Force }
+          New-Item -ItemType Directory -Path "./web_service/frontend/out" -Force
+          Get-ChildItem -Path "./artifacts/frontend-build-ws-output-${{ github.sha }}" | ForEach-Object { Move-Item -Path $_.FullName -Destination "./web_service/frontend/out" -Force }
       - name: Run Backend and Frontend
         shell: pwsh
         run: |

--- a/.github/workflows/build-web-service-msi.yml
+++ b/.github/workflows/build-web-service-msi.yml
@@ -28,18 +28,18 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: 'web_platform/frontend/package-lock.json'
+          cache-dependency-path: 'web_service/frontend/package-lock.json'
       - name: Frontend - Install & Build
         shell: pwsh
         run: |
-          cd web_platform/frontend
+          cd web_service/frontend
           npm ci
           npm run build
       - name: Verify Frontend Build
         continue-on-error: true
         shell: pwsh
         run: |
-          $outDir = 'web_platform/frontend/out'
+          $outDir = 'web_service/frontend/out'
           if (-not (Test-Path $outDir)) { throw "❌ FATAL: Build output directory 'out' not created" }
           $fileCount = (Get-ChildItem -Path $outDir -Recurse -File | Measure-Object).Count
           if ($fileCount -eq 0) { throw "❌ FATAL: Build output directory is empty" }
@@ -47,7 +47,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: frontend-build
-          path: web_platform/frontend/out
+          path: web_service/frontend/out
           retention-days: 1
 
   # ============================================================================
@@ -68,14 +68,11 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
           cache-dependency-path: 'python_service/requirements.txt'
-      - name: Create Staging Directory for UI
-        shell: pwsh
-        run: New-Item -ItemType Directory -Path "staging/ui" -Force | Out-Null
       - name: Download Frontend Artifact
         uses: actions/download-artifact@v4
         with:
           name: frontend-build
-          path: staging/ui
+          path: web_service/frontend/out
       - name: Install Python Dependencies
         shell: pwsh
         run: |

--- a/.github/workflows/build-webservice-as-a-service.yml
+++ b/.github/workflows/build-webservice-as-a-service.yml
@@ -60,14 +60,11 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
           cache-dependency-path: 'web_service/backend/requirements.txt'
-      - name: Create Staging Directory for UI
-        shell: pwsh
-        run: New-Item -ItemType Directory -Path "staging/ui" -Force | Out-Null
       - name: Download Frontend Artifact
         uses: actions/download-artifact@v4
         with:
           name: frontend-build-ws-service
-          path: staging/ui
+          path: web_service/frontend/out
       - name: Install Python Dependencies
         shell: pwsh
         run: |


### PR DESCRIPTION
The CI builds were failing because the PyInstaller process could not find the frontend build assets. This was caused by a mismatch between where the workflow was placing the downloaded frontend artifact and where the `.spec` files were configured to look for it.

This commit resolves the issue by modifying the GitHub Actions workflows to download and place the frontend artifacts directly into the `web_service/frontend/out` directory. This is the location that the PyInstaller spec files (`fortuna-webservice.spec` and `fortuna-backend-webservice.spec`) are hardcoded to expect.

This approach is more robust than modifying the spec files, as it honors their original configuration and simplifies the workflow by removing the need for an intermediate `staging/ui` directory. The fix has been applied consistently across all relevant workflows:

- `build-web-service-msi.yml`
- `build-webservice-as-a-service.yml`
- `build-electron-from-webservice.yml`