### PR TITLE
fix(ci): Standardize MSI build process and correct artifact paths

### DIFF
--- a/.github/workflows/build-electron-from-webservice.yml
+++ b/.github/workflows/build-electron-from-webservice.yml
@@ -127,8 +127,8 @@ jobs:
         shell: pwsh
         run: |
           Get-ChildItem -Path "./artifacts/backend-ws-executable-${{ github.sha }}" | ForEach-Object { Move-Item -Path $_.FullName -Destination "." -Force }
-          New-Item -ItemType Directory -Path "./frontend" -Force
-          Get-ChildItem -Path "./artifacts/frontend-build-ws-output-${{ github.sha }}" | ForEach-Object { Move-Item -Path $_.FullName -Destination "./frontend" -Force }
+          New-Item -ItemType Directory -Path "./web_service/frontend/out" -Force
+          Get-ChildItem -Path "./artifacts/frontend-build-ws-output-${{ github.sha }}" | ForEach-Object { Move-Item -Path $_.FullName -Destination "./web_service/frontend/out" -Force }
       - name: Run Backend and Frontend
         shell: pwsh
         run: |

--- a/.github/workflows/build-web-service-msi-jules.yml
+++ b/.github/workflows/build-web-service-msi-jules.yml
@@ -292,28 +292,52 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Setup WiX Toolset
-        run: choco install wixtoolset -y
       - name: Download Backend Executable
         uses: actions/download-artifact@v4
         with:
           name: backend-webservice-executable-${{ github.sha }}
-          path: ./staging/
-      - name: Verify Staged Executable
-        continue-on-error: true
+          path: ./dist
+      - name: Stage Artifacts
+        id: stage_files
         shell: pwsh
         run: |
-          $exePath = "./staging/fortuna-webservice.exe"
-          if (-not (Test-Path $exePath)) {
-            throw "❌ FATAL: Web service executable not found at $exePath after download."
-          }
-          Write-Host "✅ Web service executable staged successfully."
-      - name: Setup WiX Toolset
-        run: choco install wixtoolset -y
-      - name: Build MSI with WiX
+          $staging = "build_wix/staging"
+          New-Item -ItemType Directory -Path $staging -Force
+          Move-Item -Path "./dist/fortuna-webservice.exe" -Destination "$staging/fortuna-webservice.exe" -Force
+          $msiName = "Fortuna-Jules-${{ github.ref_name }}.msi".Replace('/', '-')
+          if ($msiName -match "main") { $msiName = "Fortuna-Jules-Nightly.msi" }
+          echo "msi_name=$msiName" >> $env:GITHUB_OUTPUT
+      - name: Setup .NET 8 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Build MSI
+        working-directory: build_wix
         shell: pwsh
         run: |
-          wix build wix/product_webservice.wxs -ext WixToolset.UI.wixext -o fortuna-webservice.msi
+          # Use the Product_WithService.wxs configuration
+          $wixProjContent = @"
+          <Project Sdk="WixToolset.Sdk/4.0.5">
+            <PropertyGroup>
+              <OutputName>${{ steps.stage_files.outputs.msi_name }}</OutputName>
+              <OutputType>Package</OutputType>
+              <DefineConstants>SourceDir=./staging</DefineConstants>
+              <Platforms>x64</Platforms>
+            </PropertyGroup>
+            <ItemGroup>
+              <PackageReference Include="WixToolset.Util.wixext" Version="4.0.5" />
+              <PackageReference Include="WixToolset.Firewall.wixext" Version="4.0.5" />
+              <PackageReference Include="WixToolset.UI.wixext" Version="4.0.5" />
+              <Compile Include="./Product_WithService.wxs" />
+            </ItemGroup>
+          </Project>
+          "@
+          Set-Content -Path "FortunaWebService.wixproj" -Value $wixProjContent -Encoding UTF8
+          dotnet build FortunaWebService.wixproj -c Release -p:Platform=x64
+          $msiPath = "bin/x64/Release/${{ steps.stage_files.outputs.msi_name }}"
+          if (-not (Test-Path $msiPath)) { throw "❌ Service MSI was not created." }
+          New-Item -ItemType Directory -Path "dist" -Force
+          Copy-Item -Path $msiPath -Destination "dist/${{ steps.stage_files.outputs.msi_name }}" -Force
       - name: Upload Final MSI Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-web-service-msi.yml
+++ b/.github/workflows/build-web-service-msi.yml
@@ -28,18 +28,18 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: 'web_platform/frontend/package-lock.json'
+          cache-dependency-path: 'web_service/frontend/package-lock.json'
       - name: Frontend - Install & Build
         shell: pwsh
         run: |
-          cd web_platform/frontend
+          cd web_service/frontend
           npm ci
           npm run build
       - name: Verify Frontend Build
         continue-on-error: true
         shell: pwsh
         run: |
-          $outDir = 'web_platform/frontend/out'
+          $outDir = 'web_service/frontend/out'
           if (-not (Test-Path $outDir)) { throw "❌ FATAL: Build output directory 'out' not created" }
           $fileCount = (Get-ChildItem -Path $outDir -Recurse -File | Measure-Object).Count
           if ($fileCount -eq 0) { throw "❌ FATAL: Build output directory is empty" }
@@ -47,7 +47,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: frontend-build
-          path: web_platform/frontend/out
+          path: web_service/frontend/out
           retention-days: 1
 
   # ============================================================================
@@ -68,14 +68,11 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
           cache-dependency-path: 'python_service/requirements.txt'
-      - name: Create Staging Directory for UI
-        shell: pwsh
-        run: New-Item -ItemType Directory -Path "staging/ui" -Force | Out-Null
       - name: Download Frontend Artifact
         uses: actions/download-artifact@v4
         with:
           name: frontend-build
-          path: staging/ui
+          path: web_service/frontend/out
       - name: Install Python Dependencies
         shell: pwsh
         run: |

--- a/.github/workflows/build-webservice-as-a-service.yml
+++ b/.github/workflows/build-webservice-as-a-service.yml
@@ -60,14 +60,11 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
           cache-dependency-path: 'web_service/backend/requirements.txt'
-      - name: Create Staging Directory for UI
-        shell: pwsh
-        run: New-Item -ItemType Directory -Path "staging/ui" -Force | Out-Null
       - name: Download Frontend Artifact
         uses: actions/download-artifact@v4
         with:
           name: frontend-build-ws-service
-          path: staging/ui
+          path: web_service/frontend/out
       - name: Install Python Dependencies
         shell: pwsh
         run: |
@@ -77,7 +74,7 @@ jobs:
         continue-on-error: true
         shell: pwsh
         run: |
-          $frontendOut = 'staging/ui'
+          $frontendOut = 'web_service/frontend/out'
           if (-not (Test-Path $frontendOut)) {
             Write-Host "❌ FATAL: Frontend build output missing at expected path!" -ForegroundColor Red
             Write-Host "Expected: $frontendOut" -ForegroundColor Red


### PR DESCRIPTION
This commit resolves multiple CI build failures across several workflows.

1.  **Standardize WiX Build Process:** The `build-web-service-msi-jules.yml` workflow was failing with a "'wix' is not recognized" error. This was due to an outdated build step attempting to call the WiX v3 command-line tool directly. This has been replaced with the modern WiX v4 process used in other workflows, which leverages the .NET SDK (`dotnet build`) and a dynamically generated `.wixproj` file. This resolves the error and standardizes the MSI packaging process.

2.  **Align Artifact Paths:** Multiple workflows were failing because the PyInstaller build step could not find the frontend assets. This was caused by inconsistencies between where the workflows placed downloaded artifacts and where the `.spec` files expected to find them.

    This commit corrects the `download-artifact` and staging steps in `build-web-service-msi.yml`, `build-webservice-as-a-service.yml`, and `build-electron-from-webservice.yml` to ensure the frontend assets are always placed in the `web_service/frontend/out` directory, which is the location the PyInstaller configurations expect. This eliminates the need for temporary staging directories and makes the build process more robust and predictable.

3.  **Clean Up Workspace:** An extraneous `jules_payload.json` file, which was a process artifact, was removed to ensure a clean commit.