### PR TITLE
ci: Harden Python executable paths in workflow

### DIFF
--- a/.github/workflows/build-web-service-msi.yml
+++ b/.github/workflows/build-web-service-msi.yml
@@ -72,6 +72,7 @@ jobs:
 
       # --- SETUP PYTHON ---
       - name: Setup Python
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -85,16 +86,17 @@ jobs:
           path: web_service/frontend/out
 
       - name: Install Dependencies
+        shell: pwsh
         run: |
-          python -m pip install --upgrade pip
-          pip install -r python_service/requirements-dev.txt
-          pip install playwright pytest-playwright
+          ${{ steps.setup-python.outputs.python-path }} -m pip install --upgrade pip
+          ${{ steps.setup-python.outputs.python-path }} -m pip install -r python_service/requirements-dev.txt
+          ${{ steps.setup-python.outputs.python-path }} -m pip install playwright pytest-playwright
 
       # --- CACHE PLAYWRIGHT BROWSERS ---
       - name: Get Playwright Version
         id: playwright-version
         shell: pwsh
-        run: echo "VERSION=$(python -c 'from importlib.metadata import version; print(version("playwright"))')" >> $env:GITHUB_OUTPUT
+        run: echo "VERSION=$(${{ steps.setup-python.outputs.python-path }} -c 'from importlib.metadata import version; print(version("playwright"))')" >> $env:GITHUB_OUTPUT
 
       - name: Cache Playwright Browsers
         uses: actions/cache@v4
@@ -105,11 +107,13 @@ jobs:
 
       - name: Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: python -m playwright install --with-deps chromium
+        shell: pwsh
+        run: ${{ steps.setup-python.outputs.python-path }} -m playwright install --with-deps chromium
 
       # --- BUILD EXE ---
       - name: Backend - Build with PyInstaller
-        run: pyinstaller fortuna-webservice.spec --clean --noconfirm
+        shell: pwsh
+        run: ${{ steps.setup-python.outputs.python-path }} -m pyinstaller fortuna-webservice.spec --clean --noconfirm
 
       # --- SMOKE TEST ---
       - name: '🛡️ Open Firewall'


### PR DESCRIPTION
Resolves a `PackageNotFoundError` for `playwright` during the `build-and-test` job.

The root cause was that subsequent steps were not using the Python version specified by the `actions/setup-python` action, instead defaulting to a different version on the runner's PATH.

This fix hardens the workflow by:
1. Assigning an `id` to the `setup-python` step.
2. Using the explicit path from the step's output (`${{ steps.setup-python.outputs.python-path }}`) for all subsequent calls to `python`, `pip`, and `pyinstaller`.

This ensures that the correct, intended Python environment is used for all dependency installation and script execution steps, making the workflow more robust and reliable.