### PR TITLE
Fix(workflows): Harden and correct CI/CD workflows

### DIFF
--- a/.github/workflows/build-electron-from-ws-claude.yml
+++ b/.github/workflows/build-electron-from-ws-claude.yml
@@ -146,16 +146,6 @@ jobs:
           pip install playwright
           python -m playwright install chromium
 
-      - name: Launch Electron App in Background
-        working-directory: electron
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $process = Start-Process "npm" -ArgumentList "start" -PassThru -RedirectStandardOutput "electron-out.log" -RedirectStandardError "electron-err.log"
-          Set-Content -Path "electron.pid" -Value $process.Id
-          Write-Host "✅ Electron app launched with PID: $($process.Id)"
-          Start-Sleep -Seconds 15 # Wait for app to initialize
-
       - name: Verify Electron App with Playwright
         shell: pwsh
         run: |
@@ -166,22 +156,23 @@ jobs:
 
           async def run_verification():
               async with async_playwright() as p:
-                  # Electron apps launch on a random port, so we can't connect via URL.
-                  # Instead, we launch a browser context and assume the Electron window is the first one.
-                  browser = await p.chromium.launch(headless=False) # Must be headful to see window
-                  page = browser.contexts[0].pages[0]
-                  await page.wait_for_load_state('domcontentloaded', timeout=20000)
-
                   try:
-                      await expect(page.locator("h1:has-text('Fortuna Faucet')")).to_be_visible(timeout=10000)
+                      # Correctly launch and connect to the Electron app
+                      app = await p._electron.launch(args=['electron/main.js'])
+                      page = await app.first_window()
+                      await page.wait_for_load_state('domcontentloaded', timeout=30000)
+
+                      # Perform verification on the Electron window content
+                      await expect(page.locator("h1:has-text('Fortuna Faucet')")).to_be_visible(timeout=15000)
                       await page.screenshot(path=os.environ["SMOKE_SCREENSHOT_PATH"])
                       print("✅ Electron UI verification successful")
-                      await browser.close()
+                      await app.close()
                       sys.exit(0)
                   except Exception as e:
                       print(f"❌ Error during Electron verification: {e}", file=sys.stderr)
-                      await page.screenshot(path=os.environ["SMOKE_FAILURE_SCREENSHOT_PATH"])
-                      await browser.close()
+                      # No need to take a failure screenshot here as the context might be invalid
+                      if 'app' in locals() and app:
+                          await app.close()
                       sys.exit(1)
 
           if __name__ == "__main__":

--- a/.github/workflows/build-web-service-msi-claude.yml
+++ b/.github/workflows/build-web-service-msi-claude.yml
@@ -195,6 +195,15 @@ jobs:
             -ErrorAction SilentlyContinue
           Write-Host "✅ Firewall rule configured for port ${{ env.FORTUNA_PORT }}" -ForegroundColor Green
 
+      - name: Create Runtime Directories
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          New-Item -ItemType Directory -Path "./data" -Force | Out-Null
+          New-Item -ItemType Directory -Path "./logs" -Force | Out-Null
+          New-Item -ItemType Directory -Path "./json" -Force | Out-Null
+          Write-Host "✅ Created runtime directories: data, logs, json" -ForegroundColor Green
+
       - name: Start Web Service
         shell: pwsh
         run: |
@@ -387,6 +396,13 @@ jobs:
         uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
         with:
           dotnet-version: '8.0.x'
+
+      - name: Copy WiX Source File
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          Copy-Item -Path "wix/product_webservice.wxs" -Destination "build_wix/Product_WithService.wxs" -Force
+          Write-Host "✅ Copied WiX source file to build directory." -ForegroundColor Green
 
       - name: Remove Conflicting WXS File
         shell: pwsh

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,11 +43,20 @@ jobs:
         # See https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-    - name: Install dependencies
+    - name: Install Python dependencies
+      if: matrix.language == 'python'
       run: |
         python -m pip install --upgrade pip
-        pip install -r python_service/requirements-dev.txt
-        npm install --prefix web_service/frontend
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+        if [ -f python_service/requirements-dev.txt ]; then pip install -r python_service/requirements-dev.txt; fi
+        if [ -f web_service/backend/requirements-dev.txt ]; then pip install -r web_service/backend/requirements-dev.txt; fi
+
+    - name: Install Javascript dependencies and build
+      if: matrix.language == 'javascript'
+      run: |
+        if [ -f web_service/frontend/package.json ]; then (cd web_service/frontend && npm install && npm run build); fi
+        if [ -f web_platform/frontend/package.json ]; then (cd web_platform/frontend && npm install && npm run build); fi
+        if [ -f electron/package.json ]; then (cd electron && npm install); fi
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun


### PR DESCRIPTION
This commit applies critical fixes to three key GitHub Actions workflows to improve their reliability and correctness.

1.  **build-web-service-msi-claude.yml:**
    *   Adds a step to create the required `data`, `logs`, and `json` directories before the smoke test, preventing a common backend startup crash.
    *   Adds a step to copy the `product_webservice.wxs` file to the `build_wix` directory, ensuring the MSI packager can find its source files.

2.  **build-electron-from-ws-claude.yml:**
    *   Replaces the incorrect Playwright verification script with a new version that correctly uses Playwright's `_electron.launch()` method to connect directly to the running application.
    *   Removes the now-redundant background launch step that conflicted with the new, correct verification script.

3.  **codeql.yml:**
    *   Replaces the single, faulty dependency installation step with two conditional steps to ensure that the Python job only installs Python packages and the JavaScript job only installs Node.js packages. This ensures all modules are correctly set up for analysis.