### PR TITLE
fix(backend): Correct sys.path for PyInstaller builds

### DIFF
--- a/web_service/backend/main.py
+++ b/web_service/backend/main.py
@@ -23,8 +23,8 @@ def _configure_sys_path():
     """
     if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
         # Running in a PyInstaller bundle.
-        # The project root is one level above the executable's directory.
-        project_root = os.path.abspath(os.path.join(sys._MEIPASS, ".."))
+        # The project root IS the _MEIPASS directory itself.
+        project_root = os.path.abspath(sys._MEIPASS)
     else:
         # Running as a normal script.
         # The project root is two levels above this file's directory.


### PR DESCRIPTION
The smoke test in the CI/CD workflow was failing with an ASGI import error. This was caused by an incorrect `sys.path` configuration in `web_service/backend/main.py` when running the application as a PyInstaller executable.

The code incorrectly set the project root to the parent of the `_MEIPASS` temporary directory. This change corrects the path to point to the `_MEIPASS` directory itself, ensuring that the packaged application can find its internal modules. This is the standard and correct approach for one-file PyInstaller builds.