### PR TITLE
The smoke-test jobs in the web service workflows were failing due to …

### DIFF
--- a/.github/workflows/build-web-service-msi-gpt5.yml
+++ b/.github/workflows/build-web-service-msi-gpt5.yml
@@ -473,7 +473,7 @@ jobs:
       - name: 📥 Download Executable
         uses: actions/download-artifact@v4
         with:
-          name: backend-exe-${{ github.run_id }}
+          name: backend-executable-${{ github.run_id }}
           path: dist
 
       - name: 🏗️ Setup Directories & Capture Baseline
@@ -518,7 +518,7 @@ jobs:
 
           # PE signature check
           $bytes = [System.IO.File]::ReadAllBytes($exe)
-          $peSignature = "$($bytes[0]:X2)$($bytes[1]:X2)"
+          $peSignature = "{0:X2}{1:X2}" -f $bytes[0], $bytes[1]
           if ($peSignature -eq "4D5A") {
             Write-Host "✅ Valid PE signature: $peSignature" -ForegroundColor Green
           } else {

--- a/.github/workflows/build-web-service-msi.yml
+++ b/.github/workflows/build-web-service-msi.yml
@@ -469,7 +469,7 @@ jobs:
       - name: 📥 Download Executable
         uses: actions/download-artifact@v4
         with:
-          name: backend-exe-${{ github.run_id }}
+          name: backend-executable-${{ github.run_id }}
           path: dist
 
       - name: 🏗️ Setup Directories & Capture Baseline
@@ -514,7 +514,7 @@ jobs:
 
           # PE signature check
           $bytes = [System.IO.File]::ReadAllBytes($exe)
-          $peSignature = "$($bytes[0]:X2)$($bytes[1]:X2)"
+          $peSignature = "{0:X2}{1:X2}" -f $bytes[0], $bytes[1]
           if ($peSignature -eq "4D5A") {
             Write-Host "✅ Valid PE signature: $peSignature" -ForegroundColor Green
           } else {


### PR DESCRIPTION
…a PowerShell ParserError. The script attempted to format byte values as hexadecimal strings using an invalid syntax (`"$($byte:X2)"`) inside an interpolated string.

This change replaces the incorrect syntax with the correct PowerShell format operator (`"{0:X2}" -f $byte`), which resolves the parsing error and allows the PE signature check to execute correctly. The fix has been applied to both `build-web-service-msi-gpt5.yml` and `build-web-service-msi.yml`.