### PR TITLE
fix(ci): correct pytest working directory in workflows

### DIFF
--- a/.github/workflows/build-web-service-msi-gpt5.yml
+++ b/.github/workflows/build-web-service-msi-gpt5.yml
@@ -249,8 +249,7 @@ jobs:
           python -c 'import importlib.util, sys; sys.exit(0 if importlib.util.find_spec("pytest") else 1)'
           if ($LASTEXITCODE -eq 0) {
             Write-Host "🧪 pytest detected, running suite..."
-            cd "${{ env.BACKEND_DIR }}"
-            python -m pytest --maxfail=1 --disable-warnings
+            python -m pytest "${{ env.BACKEND_DIR }}" --maxfail=1 --disable-warnings
           } else {
             Write-Host "ℹ️ pytest not installed; skipping tests."
           }

--- a/.github/workflows/build-web-service-msi.yml
+++ b/.github/workflows/build-web-service-msi.yml
@@ -244,8 +244,7 @@ jobs:
           python -c 'import importlib.util, sys; sys.exit(0 if importlib.util.find_spec("pytest") else 1)'
           if ($LASTEXITCODE -eq 0) {
             Write-Host "🧪 pytest detected, running suite..."
-            cd "${{ env.BACKEND_DIR }}"
-            python -m pytest --maxfail=1 --disable-warnings
+            python -m pytest "${{ env.BACKEND_DIR }}" --maxfail=1 --disable-warnings
           } else {
             Write-Host "ℹ️ pytest not installed; skipping tests."
           }


### PR DESCRIPTION
Corrects the `pytest` command in the `backend-quality` jobs of the `build-web-service-msi-gpt5.yml` and `build-web-service-msi.yml` workflows.

The tests were failing with a `ModuleNotFoundError` because the test command was being run from within the `python_service` directory, while the tests use absolute imports that require the command to be run from the repository root.

This fix removes the `cd` command and instead passes the path to the test directory directly to `pytest`, ensuring the tests are discovered and run correctly from the project root.