### PR TITLE
fix(ci): Correct spec file path in web service workflow

### DIFF
--- a/.github/workflows/build-web-service-msi-gpt5.yml
+++ b/.github/workflows/build-web-service-msi-gpt5.yml
@@ -121,7 +121,7 @@ jobs:
             "${{ env.FRONTEND_DIR }}/package-lock.json",
             "${{ env.BACKEND_DIR }}/requirements.txt",
             "${{ env.BACKEND_DIR }}/main.py",
-            "web_service/${{ env.BACKEND_SPEC }}",
+            "${{ env.BACKEND_SPEC }}",
             "${{ env.WIX_DIR }}/Product_WithService.wxs"
           )
           foreach ($path in $paths) {
@@ -422,7 +422,7 @@ jobs:
           FORTUNA_VERSION: ${{ needs.repo-preflight.outputs.semver }}
         run: |
           Set-StrictMode -Version Latest
-          pyinstaller "web_service/${{ env.BACKEND_SPEC }}" --clean --log-level=WARN --noconfirm
+          pyinstaller "${{ env.BACKEND_SPEC }}" --clean --log-level=WARN --noconfirm
 
       - name: Verify Executable
         run: |


### PR DESCRIPTION
Corrects the path to `fortuna-backend-webservice.spec` in the `build-web-service-msi-gpt5.yml` workflow.

The `repo-preflight` and `build-backend` jobs were incorrectly prepending `web_service/` to the spec file path, causing a "file not found" error. This change removes the redundant prefix, aligning the workflow with the actual location of the spec file in the repository root.