### PR TITLE
fix(ci): Correct dependency cycle and paths in MSI workflows

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -128,7 +128,6 @@ jobs:
   repo-preflight:
     name: '🧪 Repo Preflight & Integrity'
     runs-on: windows-latest
-    needs: system-check
     timeout-minutes: 5
     outputs:
       frontend_lock_hash: ${{ steps.hashes.outputs.frontend_lock_hash }}

--- a/.github/workflows/build-web-service-msi-gpt5.yml
+++ b/.github/workflows/build-web-service-msi-gpt5.yml
@@ -121,7 +121,7 @@ jobs:
             "${{ env.FRONTEND_DIR }}/package-lock.json",
             "${{ env.BACKEND_DIR }}/requirements.txt",
             "${{ env.BACKEND_DIR }}/main.py",
-            "web_service/${{ env.BACKEND_SPEC }}",
+            "${{ env.BACKEND_SPEC }}",
             "${{ env.WIX_DIR }}/Product_WithService.wxs"
           )
           foreach ($path in $paths) {
@@ -413,8 +413,8 @@ jobs:
       - name: Create Required Backend Directories
         run: |
           Set-StrictMode -Version Latest
-          New-Item -ItemType Directory -Path "${{ env.BACKEND_DIR }}/data" -Force | Out-Null
-          New-Item -ItemType Directory -Path "${{ env.BACKEND_DIR }}/json" -Force | Out-Null
+          New-Item -ItemType Directory -Path "python_service/data" -Force | Out-Null
+          New-Item -ItemType Directory -Path "python_service/json" -Force | Out-Null
           Write-Host "✅ Created required backend directories for PyInstaller." -ForegroundColor Green
 
       - name: Build with PyInstaller
@@ -422,7 +422,7 @@ jobs:
           FORTUNA_VERSION: ${{ needs.repo-preflight.outputs.semver }}
         run: |
           Set-StrictMode -Version Latest
-          pyinstaller "web_service/${{ env.BACKEND_SPEC }}" --clean --log-level=WARN --noconfirm
+          pyinstaller "${{ env.BACKEND_SPEC }}" --clean --log-level=WARN --noconfirm
 
       - name: Verify Executable
         run: |


### PR DESCRIPTION
This commit resolves multiple critical errors preventing the MSI workflows from running:

1.  **Dependency Cycle in `build-msi.yml`:** Removes an invalid `needs: system-check` dependency from the `repo-preflight` job. This was causing a circular dependency error because the `system-check` job does not exist in this workflow.

2.  **Spec File Path in `build-web-service-msi-gpt5.yml`:** Corrects the file path for `fortuna-backend-webservice.spec` by removing a redundant `web_service/` prefix. This ensures the workflow can locate the spec file in its correct position at the repository root.

3.  **Directory Creation in `build-web-service-msi-gpt5.yml`:** Updates the `Create Required Backend Directories` step to create `python_service/data` and `python_service/json` instead of the incorrect `web_service/backend/data` and `web_service/backend/json`. This aligns the workflow with the paths expected by the `fortuna-backend-webservice.spec` file.