### PR TITLE
fix(ci): correct powershell syntax in build workflow

### DIFF
--- a/.github/workflows/build-web-service-msi-gpt5.yml
+++ b/.github/workflows/build-web-service-msi-gpt5.yml
@@ -348,7 +348,7 @@ jobs:
 
       - name: Report Cache Status
         run: |
-          if ('${{ steps.cache-frontend.outputs.cache-hit }}' == 'true') {
+          if ('${{ steps.cache-frontend.outputs.cache-hit }}' -eq 'true') {
             Write-Host "✅ Frontend build restored from cache." -ForegroundColor Green
           } else {
             Write-Host "ℹ️ No cache hit. A new build was performed." -ForegroundColor Yellow


### PR DESCRIPTION
Replaced the '==' operator with the correct '-eq' operator for string comparison in the build-web-service-msi-gpt5.yml workflow to resolve a parser error during execution.