### PR TITLE
fix(ci): correct PowerShell syntax in all build workflows

### DIFF
--- a/.github/workflows/build-web-service-msi-gpt5.yml
+++ b/.github/workflows/build-web-service-msi-gpt5.yml
@@ -348,7 +348,7 @@ jobs:
 
       - name: Report Cache Status
         run: |
-          if ('${{ steps.cache-frontend.outputs.cache-hit }}' == 'true') {
+          if ('${{ steps.cache-frontend.outputs.cache-hit }}' -eq 'true') {
             Write-Host "✅ Frontend build restored from cache." -ForegroundColor Green
           } else {
             Write-Host "ℹ️ No cache hit. A new build was performed." -ForegroundColor Yellow
@@ -472,7 +472,7 @@ jobs:
 
       - name: Report Cache Status
         run: |
-          if ('${{ steps.cache-backend.outputs.cache-hit }}' == 'true') {
+          if ('${{ steps.cache-backend.outputs.cache-hit }}' -eq 'true') {
             Write-Host "✅ Backend build restored from cache." -ForegroundColor Green
           } else {
             Write-Host "ℹ️ No cache hit. A new build was performed." -ForegroundColor Yellow


### PR DESCRIPTION
Replaced the incorrect '==' operator with the correct '-eq' operator for string comparison in all GitHub Actions workflows to resolve a parser error during execution. This change was applied to all instances of the error found in the repository.