### PR TITLE
fix(ci): set PYTHONUTF8=1 to resolve UnicodeEncodeError

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -513,6 +513,8 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 15
     needs: build-python-service
+    env:
+      PYTHONUTF8: '1'
     steps:
       - name: 📥 Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-web-service-msi-gpt5.yml
+++ b/.github/workflows/build-web-service-msi-gpt5.yml
@@ -348,7 +348,7 @@ jobs:
 
       - name: Report Cache Status
         run: |
-          if ('${{ steps.cache-frontend.outputs.cache-hit }}' == 'true') {
+          if ('${{ steps.cache-frontend.outputs.cache-hit }}' -eq 'true') {
             Write-Host "✅ Frontend build restored from cache." -ForegroundColor Green
           } else {
             Write-Host "ℹ️ No cache hit. A new build was performed." -ForegroundColor Yellow
@@ -472,7 +472,7 @@ jobs:
 
       - name: Report Cache Status
         run: |
-          if ('${{ steps.cache-backend.outputs.cache-hit }}' == 'true') {
+          if ('${{ steps.cache-backend.outputs.cache-hit }}' -eq 'true') {
             Write-Host "✅ Backend build restored from cache." -ForegroundColor Green
           } else {
             Write-Host "ℹ️ No cache hit. A new build was performed." -ForegroundColor Yellow
@@ -516,6 +516,8 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 15
     needs: build-backend
+    env:
+      PYTHONUTF8: '1'
     steps:
       - name: 📥 Checkout Repository
         uses: actions/checkout@v4
@@ -829,6 +831,8 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 30
     needs: [build-frontend, build-backend, diagnose-asgi-imports]
+    env:
+      PYTHONUTF8: '1'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This commit resolves a `UnicodeEncodeError` that occurred in diagnostic and smoke test jobs running on Windows. The error was caused by the default console encoding being unable to handle Unicode characters (emojis) in the Python script output.

The fix involves setting the `PYTHONUTF8: '1'` environment variable for the affected jobs in `build-electron-msi-gpt5.yml` and `build-web-service-msi-gpt5.yml`. This forces the Python interpreter to use UTF-8 for its standard I/O, which is a robust solution that allows for proper handling of Unicode characters without modifying the scripts.