### PR TITLE
Fix: Update CI/CD triggers to run on development branch

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - session/jules1130
   workflow_dispatch:
 
 concurrency:
@@ -445,7 +446,9 @@ jobs:
     name: '🔬 Smoke Test (Install & Launch)'
     runs-on: windows-latest
     timeout-minutes: 15
-    needs: [build-electron-msi, diagnose-asgi-imports]
+    needs:
+      - build-electron-msi
+      - diagnose-asgi-imports
     steps:
       - name: 📥 Download MSI Installer
         uses: actions/download-artifact@v4
@@ -513,7 +516,7 @@ jobs:
     name: '🔍 ASGI Import Killer (Pre-Smoke Diagnostic)'
     runs-on: windows-latest
     timeout-minutes: 15
-    needs: build-backend
+    needs: build-python-service
     env:
       PYTHONUTF8: '1'
     steps:

--- a/.github/workflows/build-web-service-msi-gpt5.yml
+++ b/.github/workflows/build-web-service-msi-gpt5.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - session/jules1130
     tags:
       - 'v*'
     paths:


### PR DESCRIPTION
This change updates the `build-web-service-msi-gpt5.yml` and `build-electron-msi-gpt5.yml` workflows to trigger on pushes to the `session/jules1130` branch. This will allow for the verification of the previous fixes in a non-production branch.