### PR TITLE
fix(cicd): Correct MSI installer workflows for web and electron builds

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - session/jules1130
+      - session/jules1130b
   workflow_dispatch:
 
 concurrency:
@@ -448,7 +448,6 @@ jobs:
     timeout-minutes: 15
     needs:
       - build-electron-msi
-      - diagnose-asgi-imports
     steps:
       - name: 📥 Download MSI Installer
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - session/jules1130
+      - session/jules1130b
     tags:
       - 'v*'
   pull_request:
@@ -40,9 +40,9 @@ env:
   # === PATH CONFIGURATION ===
   FRONTEND_DIR: 'web_platform/frontend'
   FRONTEND_BUILD_DIR: 'web_platform/frontend/out'
-  BACKEND_DIR: 'python_service'
+  BACKEND_DIR: 'web_service/backend'
   WIX_DIR: 'build_wix'
-  BACKEND_SPEC: 'fortuna-backend-webservice.spec'
+  BACKEND_SPEC: 'webservice.spec'
 
   # === RUNTIME CONFIG ===
   SERVICE_PORT: '8102'
@@ -95,7 +95,6 @@ jobs:
             "${{ env.FRONTEND_DIR }}/package-lock.json",
             "${{ env.BACKEND_DIR }}/requirements.txt",
             "${{ env.BACKEND_DIR }}/main.py",
-            "${{ env.BACKEND_SPEC }}",
             "${{ env.WIX_DIR }}/Product_WithService.wxs"
           )
           foreach ($path in $paths) {
@@ -359,6 +358,79 @@ jobs:
           if (Test-Path "${{ env.BACKEND_DIR }}/requirements-dev.txt") {
             pip install -r "${{ env.BACKEND_DIR }}/requirements-dev.txt"
           }
+
+      - name: Create webservice.spec for PyInstaller
+        run: |
+          $specContent = @"
+          # -*- mode: python ; coding: utf-8 -*-
+          import os
+          from pathlib import Path
+          from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+          block_cipher = None
+          project_root = Path(SPECPATH).parent
+          version_string = os.environ.get("FORTUNA_VERSION", "0.0.0")
+
+          # Explicitly include the frontend UI files
+          datas = [
+              (str(project_root / 'staging/ui'), 'ui')
+          ]
+          # Include necessary data files from installed packages
+          datas += collect_data_files("uvicorn")
+          datas += collect_data_files("slowapi")
+          datas += collect_data_files("structlog")
+          datas += collect_data_files("certifi")
+
+          hiddenimports = set()
+          hiddenimports.update(collect_submodules("web_service.backend"))
+          hiddenimports.update([
+              "uvicorn.logging", "uvicorn.loops.auto", "uvicorn.lifespan.on",
+              "uvicorn.protocols.http.h11_impl", "uvicorn.protocols.websockets.wsproto_impl",
+              "fastapi.routing", "starlette.staticfiles", "anyio._backends._asyncio",
+              "httpcore", "httpx", "slowapi", "structlog", "tenacity", "aiosqlite",
+              "pydantic_core", "pydantic_settings.sources", "web_service.backend.main"
+          ])
+
+          a = Analysis(
+              ['web_service/backend/main.py'],
+              pathex=[str(project_root)],
+              binaries=[],
+              datas=datas,
+              hiddenimports=sorted(hiddenimports),
+              hookspath=[],
+              runtime_hooks=[],
+              excludes=['tests', 'pytest', 'python_service'], # CRITICAL: Exclude the other service
+              win_no_prefer_redirects=False,
+              win_private_assemblies=False,
+              cipher=block_cipher,
+              noarchive=False
+          )
+          pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+          exe = EXE(
+              pyz,
+              a.scripts,
+              [],
+              exclude_binaries=True,
+              name='fortuna-backend',
+              debug=False,
+              bootloader_ignore_signals=False,
+              strip=False,
+              upx=True,
+              console=True
+          )
+          coll = COLLECT(
+              exe,
+              a.binaries,
+              a.zipfiles,
+              a.datas,
+              strip=False,
+              upx=True,
+              upx_exclude=[],
+              name='fortuna-backend'
+          )
+          "@
+          Set-Content -Path "${{ env.BACKEND_SPEC }}" -Value $specContent
+          Write-Host "✅ Custom webservice.spec created."
 
       - name: Create Required Backend Directories
         run: |

--- a/.github/workflows/build-web-service-msi-gpt5.yml
+++ b/.github/workflows/build-web-service-msi-gpt5.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - session/jules1130
+      - session/jules1130b
     tags:
       - 'v*'
     paths:
@@ -40,9 +40,9 @@ env:
   FORCE_COLOR: '3'
   FRONTEND_DIR: 'web_platform/frontend'
   FRONTEND_BUILD_DIR: 'web_platform/frontend/out'
-  BACKEND_DIR: 'python_service'
+  BACKEND_DIR: 'web_service/backend'
   WIX_DIR: 'build_wix'
-  BACKEND_SPEC: 'fortuna-backend-webservice.spec'
+  BACKEND_SPEC: 'webservice.spec'
   SERVICE_PORT: '8102'
   HEALTH_ENDPOINT: '/health'
   API_KEY: ${{ secrets.TEST_API_KEY }}
@@ -124,7 +124,6 @@ jobs:
             "${{ env.FRONTEND_DIR }}/package-lock.json",
             "${{ env.BACKEND_DIR }}/requirements.txt",
             "${{ env.BACKEND_DIR }}/main.py",
-            "${{ env.BACKEND_SPEC }}",
             "${{ env.WIX_DIR }}/Product_WithService.wxs"
           )
           foreach ($path in $paths) {
@@ -457,12 +456,86 @@ jobs:
           Set-StrictMode -Version Latest
           pip freeze | Out-File backend-freeze.txt -Encoding utf8
 
+      - name: Create webservice.spec for PyInstaller
+        if: steps.cache-backend.outputs.cache-hit != 'true'
+        run: |
+          $specContent = @"
+          # -*- mode: python ; coding: utf-8 -*-
+          import os
+          from pathlib import Path
+          from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+          block_cipher = None
+          project_root = Path(SPECPATH).parent
+          version_string = os.environ.get("FORTUNA_VERSION", "0.0.0")
+
+          # Explicitly include the frontend UI files
+          datas = [
+              (str(project_root / 'staging/ui'), 'ui')
+          ]
+          # Include necessary data files from installed packages
+          datas += collect_data_files("uvicorn")
+          datas += collect_data_files("slowapi")
+          datas += collect_data_files("structlog")
+          datas += collect_data_files("certifi")
+
+          hiddenimports = set()
+          hiddenimports.update(collect_submodules("web_service.backend"))
+          hiddenimports.update([
+              "uvicorn.logging", "uvicorn.loops.auto", "uvicorn.lifespan.on",
+              "uvicorn.protocols.http.h11_impl", "uvicorn.protocols.websockets.wsproto_impl",
+              "fastapi.routing", "starlette.staticfiles", "anyio._backends._asyncio",
+              "httpcore", "httpx", "slowapi", "structlog", "tenacity", "aiosqlite",
+              "pydantic_core", "pydantic_settings.sources", "web_service.backend.main"
+          ])
+
+          a = Analysis(
+              ['web_service/backend/main.py'],
+              pathex=[str(project_root)],
+              binaries=[],
+              datas=datas,
+              hiddenimports=sorted(hiddenimports),
+              hookspath=[],
+              runtime_hooks=[],
+              excludes=['tests', 'pytest', 'python_service'], # CRITICAL: Exclude the other service
+              win_no_prefer_redirects=False,
+              win_private_assemblies=False,
+              cipher=block_cipher,
+              noarchive=False
+          )
+          pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+          exe = EXE(
+              pyz,
+              a.scripts,
+              [],
+              exclude_binaries=True,
+              name='fortuna-backend',
+              debug=False,
+              bootloader_ignore_signals=False,
+              strip=False,
+              upx=True,
+              console=True
+          )
+          coll = COLLECT(
+              exe,
+              a.binaries,
+              a.zipfiles,
+              a.datas,
+              strip=False,
+              upx=True,
+              upx_exclude=[],
+              name='fortuna-backend'
+          )
+          "@
+          Set-Content -Path "${{ env.BACKEND_SPEC }}" -Value $specContent
+          Write-Host "✅ Custom webservice.spec created."
+
       - name: Create Required Backend Directories
         if: steps.cache-backend.outputs.cache-hit != 'true'
         run: |
           Set-StrictMode -Version Latest
-          New-Item -ItemType Directory -Path "python_service/data" -Force | Out-Null
-          New-Item -ItemType Directory -Path "python_service/json" -Force | Out-Null
+          New-Item -ItemType Directory -Path "web_service/backend/data" -Force | Out-Null
+          New-Item -ItemType Directory -Path "web_service/backend/json" -Force | Out-Null
           Write-Host "✅ Created required backend directories for PyInstaller." -ForegroundColor Green
 
       - name: Build with PyInstaller
@@ -721,15 +794,15 @@ jobs:
             'print("PHASE 6 APPLICATION DIRECTORY STRUCTURE")',
             'print("="*80)',
             'cwd = Path.cwd()',
-            'python_service = cwd / "python_service"',
+            'backend_dir = cwd / "${{ env.BACKEND_DIR }}"',
             'print(f"\nCurrent directory: {cwd}")',
-            'print(f"\npython_service exists: {python_service.exists()}")',
-            'if python_service.exists():',
+            'print(f"\nBackend directory exists: {backend_dir.exists()}")',
+            'if backend_dir.exists():',
             '    print(f"  Contents:")',
-            '    for item in python_service.iterdir():',
+            '    for item in backend_dir.iterdir():',
             '        print(f"    - {item.name}")',
-            '    main_py = python_service / "main.py"',
-            '    api_py = python_service / "api.py"',
+            '    main_py = backend_dir / "main.py"',
+            '    api_py = backend_dir / "api.py"',
             '    print(f''\n  main.py: {main_py.stat().st_size if main_py.exists() else "N/A"} bytes'')',
             '    print(f''  api.py: {api_py.stat().st_size if api_py.exists() else "N/A"} bytes'')'
           )
@@ -745,20 +818,21 @@ jobs:
             'print("\n" + "="*80)',
             'print("PHASE 7 APPLICATION MODULE IMPORTS (CRITICAL)")',
             'print("="*80)',
-            'print("\n[Step 1] Importing python_service...")',
+            'backend_module = "${{ env.BACKEND_DIR }}".replace("/", ".")'
+            'print(f"\n[Step 1] Importing {backend_module}...")',
             'try:',
-            '    import python_service',
-            '    print(f"✅ python_service imported")',
-            '    print(f"   Location: {python_service.__file__}")',
+            '    __import__(backend_module)',
+            '    print(f"✅ {backend_module} imported")',
             'except Exception as e:',
-            '    print(f"❌ FATAL: python_service import failed")',
+            '    print(f"❌ FATAL: {backend_module} import failed")',
             '    print(f"   Error: {type(e).__name__}: {e}")',
             '    traceback.print_exc()',
             '    sys.exit(1)',
             'print(''\\n[Step 2] Retrieving "app" object from main...'')',
+            'main_module = f"{backend_module}.main"',
             'try:',
-            '    from python_service.main import app',
-            '    print(f"✅ app object retrieved")',
+            '    from web_service.backend.main import app',
+            '    print(f"✅ app object retrieved from {main_module}")',
             '    print(f"   Type: {type(app)}")',
             '    print(f"   Class: {app.__class__.__name__}")',
             '    print(f"   Module: {app.__class__.__module__}")',


### PR DESCRIPTION
This commit resolves critical misconfigurations in the GitHub Actions workflows responsible for building the Windows MSI installers.

- **`build-web-service-msi-gpt5.yml` & `build-msi.yml`:**
  - Corrected the `BACKEND_DIR` to point to `web_service/backend` instead of `python_service`.
  - Replaced the use of a shared, incorrect `.spec` file with a dynamically generated `webservice.spec` file that correctly uses `web_service/backend/main.py` as its entry point and excludes `python_service`.
  - Updated all associated paths in build, test, and diagnostic jobs to align with the `web_service` target.

- **`build-electron-msi-gpt5.yml`:**
  - Removed a redundant job dependency in the `smoke-test` job to improve workflow efficiency.

- **All Workflows:**
  - Updated the branch triggers to the correct `session/jules1130b` branch to ensure proper execution.