### PR TITLE
fix(cicd): Correct PyInstaller spec for web service builds

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -409,24 +409,22 @@ jobs:
           exe = EXE(
               pyz,
               a.scripts,
+              a.binaries,
+              a.zipfiles,
+              a.datas,
               [],
-              exclude_binaries=True,
               name='fortuna-backend',
               debug=False,
               bootloader_ignore_signals=False,
               strip=False,
               upx=True,
-              console=True
-          )
-          coll = COLLECT(
-              exe,
-              a.binaries,
-              a.zipfiles,
-              a.datas,
-              strip=False,
-              upx=True,
-              upx_exclude=[],
-              name='fortuna-backend'
+              runtime_tmpdir=None,
+              console=False,
+              disable_windowed_traceback=False,
+              argv_emulation=False,
+              target_arch=None,
+              codesign_identity=None,
+              entitlements_file=None
           )
           "@
           Set-Content -Path "${{ env.BACKEND_SPEC }}" -Value $specContent

--- a/.github/workflows/build-web-service-msi-gpt5.yml
+++ b/.github/workflows/build-web-service-msi-gpt5.yml
@@ -507,24 +507,22 @@ jobs:
           exe = EXE(
               pyz,
               a.scripts,
+              a.binaries,
+              a.zipfiles,
+              a.datas,
               [],
-              exclude_binaries=True,
               name='fortuna-backend',
               debug=False,
               bootloader_ignore_signals=False,
               strip=False,
               upx=True,
-              console=True
-          )
-          coll = COLLECT(
-              exe,
-              a.binaries,
-              a.zipfiles,
-              a.datas,
-              strip=False,
-              upx=True,
-              upx_exclude=[],
-              name='fortuna-backend'
+              runtime_tmpdir=None,
+              console=False,
+              disable_windowed_traceback=False,
+              argv_emulation=False,
+              target_arch=None,
+              codesign_identity=None,
+              entitlements_file=None
           )
           "@
           Set-Content -Path "${{ env.BACKEND_SPEC }}" -Value $specContent


### PR DESCRIPTION
This commit fixes a critical error in the dynamically generated PyInstaller spec file within the `build-web-service-msi-gpt5.yml` and `build-msi.yml` workflows.

The previous spec configuration incorrectly included a `COLLECT` statement and set `console=True`, resulting in a directory-based build that was unsuitable for a background service and caused the application to crash immediately after startup.

- The `COLLECT` object has been removed.
- All necessary components (binaries, zipfiles, datas) are now correctly included within the `EXE` object to produce a true single-file executable.
- The `console` flag has been set to `False`, which is the correct setting for a non-interactive web service.

This change ensures the compiled executable is properly packaged and can run successfully, allowing the smoke test's health check to pass.