### PR TITLE
fix(electron): correct MSI icon configuration

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -329,16 +329,16 @@ jobs:
 
           Write-Host "✓ electron-builder config valid"
 
-      - name: 🩹 Dynamically Patch MSI Icon Config
+      - name: 🔍 Verify Electron Assets
         shell: pwsh
+        working-directory: electron
         run: |
-          $configFile = 'electron/electron-builder-config.yml'
-          $config = Get-Content $configFile -Raw
-          # Use a regular expression to add 'icon: null' under the 'msi:' key
-          $updatedConfig = $config -replace '(?m)(^msi:\s*$)', "`$1`n  icon: null"
-          Set-Content -Path $configFile -Value $updatedConfig
-          Write-Host "✅ Patched electron-builder config to disable MSI icon."
-          Get-Content $configFile | Write-Host
+          $iconPath = "assets/icon.ico"
+          if (-not (Test-Path $iconPath)) {
+            Write-Error "❌ FATAL: Icon file missing at $iconPath (Resolved: $(Resolve-Path $iconPath))"
+            exit 1
+          }
+          Write-Host "✅ Icon found at: $iconPath"
 
       - name: 🔨 Build Electron Application
         shell: pwsh

--- a/electron/electron-builder-config.yml
+++ b/electron/electron-builder-config.yml
@@ -27,17 +27,18 @@ fileAssociations:
     name: "Fortuna Project File"
     role: "Editor"
     description: "Opens Fortuna Faucet project payloads"
+icon: assets/icon.ico
 win:
   target:
     - target: "msi"
       arch:
         - x64
-  icon: "assets/icon.ico"
   legalTrademarks: "Fortuna Labs"
   publisherName:
     - "Fortuna Labs LLC"
 msi:
-  icon: null
+  installerIcon: assets/icon.ico
+  uninstallerIcon: assets/icon.ico
   oneClick: false
   perMachine: true
   runAfterFinish: true


### PR DESCRIPTION
Corrects the electron-builder configuration to properly embed the application icon in the MSI installer.

- Replaces the dynamic, regex-based patching of the config in the CI workflow with a simple, robust verification step.
- Updates `electron-builder-config.yml` to use a root-level `icon` property and the correct `installerIcon` and `uninstallerIcon` keys for the MSI target, ensuring a declarative and unambiguous build.

This resolves the issue where the icon was missing from the final installer.