### PR TITLE
fix(ci): Resolve Electron icon build and Omega health check failures

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -329,16 +329,16 @@ jobs:
 
           Write-Host "✓ electron-builder config valid"
 
-      - name: 🩹 Dynamically Patch MSI Icon Config
+      - name: 🔍 Verify Electron Assets
         shell: pwsh
+        working-directory: electron
         run: |
-          $configFile = 'electron/electron-builder-config.yml'
-          $config = Get-Content $configFile -Raw
-          # Use a regular expression to add 'icon: null' under the 'msi:' key
-          $updatedConfig = $config -replace '(?m)(^msi:\s*$)', "`$1`n  icon: null"
-          Set-Content -Path $configFile -Value $updatedConfig
-          Write-Host "✅ Patched electron-builder config to disable MSI icon."
-          Get-Content $configFile | Write-Host
+          $iconPath = "assets/icon.ico"
+          if (-not (Test-Path $iconPath)) {
+            Write-Error "❌ FATAL: Icon file missing at $iconPath (Resolved: $(Resolve-Path $iconPath))"
+            exit 1
+          }
+          Write-Host "✅ Icon found at: $iconPath"
 
       - name: 🔨 Build Electron Application
         shell: pwsh

--- a/.github/workflows/build-web-service-msi-gpt5.yml
+++ b/.github/workflows/build-web-service-msi-gpt5.yml
@@ -908,6 +908,7 @@ jobs:
     needs: [build-frontend, build-backend, diagnose-asgi-imports]
     env:
       PYTHONUTF8: '1'
+      FORTUNA_ENV: 'smoke-test'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/electron/electron-builder-config.yml
+++ b/electron/electron-builder-config.yml
@@ -27,17 +27,18 @@ fileAssociations:
     name: "Fortuna Project File"
     role: "Editor"
     description: "Opens Fortuna Faucet project payloads"
+icon: assets/icon.ico
 win:
   target:
     - target: "msi"
       arch:
         - x64
-  icon: "assets/icon.ico"
   legalTrademarks: "Fortuna Labs"
   publisherName:
     - "Fortuna Labs LLC"
 msi:
-  icon: null
+  installerIcon: assets/icon.ico
+  uninstallerIcon: assets/icon.ico
   oneClick: false
   perMachine: true
   runAfterFinish: true

--- a/electron/package.json
+++ b/electron/package.json
@@ -15,12 +15,5 @@
  },
  "dependencies": {
  "electron-updater": "^6.1.1"
- },
- "build": {
- "publish": [{
- "provider": "github",
- "owner": "masonj0",
- "repo": "fortuna"
- }]
  }
 }


### PR DESCRIPTION
This commit addresses two separate CI/CD issues:

1.  **Electron MSI Icon Build (`build-electron-msi-gpt5.yml`):**
    - Removes the conflicting `build` configuration from `electron/package.json` to ensure the `electron-builder-config.yml` is used as the single source of truth. This resolves an `LGHT0094` linker error where the icon identifier could not be found.
    - Corrects the icon path in `electron-builder-config.yml` to use the recommended structure.

2.  **Omega Workflow Health Check (`build-web-service-msi-gpt5.yml`):**
    - Adds the `FORTUNA_ENV: 'smoke-test'` environment variable to the `smoke-test` job. This signals the backend application to bind to the CI-friendly `0.0.0.0` host, resolving the fatal health check failure caused by the client being unable to connect to the server.