### PR TITLE
fix(ci): Set FORTUNA_ENV in Veteran workflow smoke test

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -482,6 +482,7 @@ jobs:
     needs: build-backend
     env:
       SMOKE_LOG_DIR: 'logs'
+      FORTUNA_ENV: 'smoke-test'
     steps:
       - name: Download Backend Executable
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The smoke test in the `build-msi.yml` workflow was failing because the Uvicorn server was binding to `127.0.0.1` by default, making it inaccessible to the health check within the CI environment.

This change adds the `FORTUNA_ENV: 'smoke-test'` environment variable to the `smoke-test-service` job. This aligns the Veteran workflow with the Omega workflow, ensuring the application starts in a CI-friendly mode and binds to `0.0.0.0`, which resolves the health check failure.