### PR TITLE
Fix(workflows): Resolve PyInstaller module path and WiX namespace errors

### DIFF
--- a/.github/workflows/build-web-service-msi-jules.yml
+++ b/.github/workflows/build-web-service-msi-jules.yml
@@ -547,8 +547,8 @@ jobs:
           entry_point = os.path.join(os.environ['BACKEND_DIR'], "main.py").replace('\\', '/')
           staging_ui_path = Path("staging/ui").resolve().as_posix()
           other_service = "python_service" if "web_service" in os.environ['BACKEND_DIR'] else "web_service"
-          backend_init = "web_service/backend/__init__.py"
-          parent_init = "web_service/__init__.py"
+          backend_init = Path("web_service/backend/__init__.py").resolve().as_posix()
+          parent_init = Path("web_service/__init__.py").resolve().as_posix()
           spec_file = os.environ['BACKEND_SPEC_FILE']
 
           spec_content = f"""


### PR DESCRIPTION
- Corrects the XML namespace for the firewall extension in `build_wix/Product_WithService.wxs` to resolve the `WIX0200` build error.
- Updates the PyInstaller spec generation in `build-web-service-msi-jules.yml` to use absolute paths for `__init__.py` files. This ensures they are correctly injected as `PYMODULE`s, fixing the `diagnose-runtime` job failure.
- Modifies the trigger for `build-electron-msi-gpt5.yml` to `workflow_dispatch` to prevent automatic runs, as requested.