### PR TITLE
Fix(wix): Use RegistryValue to set service environment variables

### DIFF
--- a/build_wix/Product_WithService.wxs
+++ b/build_wix/Product_WithService.wxs
@@ -49,8 +49,7 @@
                         Description="Data aggregation and analysis engine for horse racing."
                         Start="auto"
                         Type="ownProcess"
-                        ErrorControl="normal"
-                        Environment="FORTUNA_PORT=$(var.ServicePort)" />
+                        ErrorControl="normal" />
 
         <ServiceControl Id="ServiceControl"
                         Name="FortunaWebService"
@@ -70,6 +69,11 @@
                                 Port="8102"
                                 Protocol="tcp"
                                 Scope="any" />
+
+        <!-- This forces the app to listen on 8102 instead of default 8000 -->
+        <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\FortunaWebService">
+            <RegistryValue Name="Environment" Type="multiString" Value="PORT=8102[~]FORTUNA_PORT=8102" />
+        </RegistryKey>
       </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
Replaced the invalid `Environment` attribute on the `<ServiceInstall>` element with the correct `<RegistryKey>` and `<RegistryValue>` implementation.

This resolves a WIX0004 schema validation error that would occur during the build. It also ensures the `FORTUNA_PORT` environment variable is correctly injected into the service's runtime environment, fixing a bug where the service would default to port 8000 instead of the intended port 8102.