### PR TITLE
Fix(wix): Correct multiple WiX build errors

### DIFF
--- a/build_wix/Product_WithService.wxs
+++ b/build_wix/Product_WithService.wxs
@@ -24,13 +24,17 @@
     <ui:WixUI Id="WixUI_InstallDir"
               InstallDirectory="INSTALLFOLDER" />
 
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
-
   </Package>
 
   <Fragment>
+    <!-- 1. DEFINE THE DIRECTORY STRUCTURE WITH IDs -->
     <StandardDirectory Id="ProgramFiles64Folder">
-      <Directory Id="INSTALLFOLDER" Name="Fortuna Faucet" />
+      <Directory Id="INSTALLFOLDER" Name="Fortuna Faucet">
+        <!-- Define the subfolders and give them IDs -->
+        <Directory Id="Dir_Data" Name="data" />
+        <Directory Id="Dir_Json" Name="json" />
+        <Directory Id="Dir_Logs" Name="logs" />
+      </Directory>
     </StandardDirectory>
 
     <StandardDirectory Id="ProgramMenuFolder">
@@ -49,8 +53,7 @@
                         Description="Data aggregation and analysis engine for horse racing."
                         Start="auto"
                         Type="ownProcess"
-                        ErrorControl="normal"
-                        Environment="FORTUNA_PORT=$(var.ServicePort)" />
+                        ErrorControl="normal" />
 
         <ServiceControl Id="ServiceControl"
                         Name="FortunaWebService"
@@ -70,18 +73,25 @@
                                 Port="8102"
                                 Protocol="tcp"
                                 Scope="any" />
+
+        <!-- This forces the app to listen on 8102 instead of default 8000 -->
+        <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\FortunaWebService">
+            <RegistryValue Name="Environment" Type="multiString" Value="PORT=8102[~]FORTUNA_PORT=8102" />
+        </RegistryKey>
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="RuntimeDirectoryComponents" Directory="INSTALLFOLDER">
-        <Component Id="DataDirectoryComponent" Guid="a2e3820a-606b-452f-b43f-b82b9a7852a0">
-            <CreateFolder Directory="data" />
+    <!-- 2. REFERENCE THE IDs IN THE COMPONENTS -->
+    <ComponentGroup Id="RuntimeDirectoryComponents">
+        <!-- Use Directory="Dir_Data" (the ID), not "data" (the name) -->
+        <Component Id="DataDirectoryComponent" Directory="Dir_Data" Guid="a2e3820a-606b-452f-b43f-b82b9a7852a0">
+            <CreateFolder />
         </Component>
-        <Component Id="JsonDirectoryComponent" Guid="b4d7ea21-821f-4a0b-9303-3a52e1f42d2a">
-            <CreateFolder Directory="json" />
+        <Component Id="JsonDirectoryComponent" Directory="Dir_Json" Guid="b4d7ea21-821f-4a0b-9303-3a52e1f42d2a">
+            <CreateFolder />
         </Component>
-        <Component Id="LogsDirectoryComponent" Guid="d66f6540-3f11-4475-9a67-9c9852f87a32">
-            <CreateFolder Directory="logs" />
+        <Component Id="LogsDirectoryComponent" Directory="Dir_Logs" Guid="d66f6540-3f11-4475-9a67-9c9852f87a32">
+            <CreateFolder />
         </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
This commit resolves several build-breaking errors in the WiX source file (Product_WithService.wxs):

- **WIX0091 (Duplicate Symbol):** Removes the redundant <Property Id="WIXUI_INSTALLDIR">, which is implicitly defined by the <ui:WixUI> element.
- **WIX0094 (Identifier Not Found):** Defines explicit Directory IDs for runtime folders (data, json, logs) and updates components to reference these IDs.
- **WIX0004 (Invalid Attribute):** Replaces the invalid 'Environment' attribute on <ServiceInstall> with the correct <RegistryKey> method to configure the service port.