### PR TITLE
fix(ci): Correct artifact paths in MSI workflows

### DIFF
--- a/.github/workflows/build-msi-hat-trick-fusion.yml
+++ b/.github/workflows/build-msi-hat-trick-fusion.yml
@@ -216,7 +216,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: hat-trick-msi
-          path: build_wix/bin/x64/Release/*.msi
+          path: build_wix/bin/x64/Release/*
 
   smoke-test:
     name: HatTrick Fusion Smoke Test

--- a/.github/workflows/build-msi-unified.yml
+++ b/.github/workflows/build-msi-unified.yml
@@ -338,7 +338,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: msi-installer-${{ needs.build-executable.outputs.build_id }}
-          path: ${{ env.WIX_DIR }}/bin/x64/Release/*.msi
+          path: ${{ env.WIX_DIR }}/bin/x64/Release/*
           retention-days: 1
 
   smoke-test:

--- a/.github/workflows/build-web-service-msi-jules.yml
+++ b/.github/workflows/build-web-service-msi-jules.yml
@@ -992,9 +992,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: fortuna-service-msi-${{ github.run_id }}
-          path: |
-            ${{ env.WIX_DIR }}/bin/x64/Release/*.msi
-            ${{ env.WIX_DIR }}/bin/x64/Release/*.sha256
+          path: ${{ env.WIX_DIR }}/bin/x64/Release/*
           retention-days: 10
 
   create-release:


### PR DESCRIPTION
Corrects the `upload-artifact` path in the `hat-trick-fusion`, `unified`, and `jules` MSI installer workflows.

The previous path pattern (`*.msi`) only uploaded the installer's database file, excluding the required data cabinet (`.cab`) file generated by the WiX v4 toolset. This resulted in an incomplete artifact and caused the smoke test installation to fail with a "1311: Source file not found" error.

The path has been changed to `*` to ensure all files from the release directory are uploaded, guaranteeing a complete and installable artifact.