### PR TITLE
fix(ci): Decouple service start from MSI installation

### DIFF
--- a/.github/workflows/build-msi-hat-trick-fusion.yml
+++ b/.github/workflows/build-msi-hat-trick-fusion.yml
@@ -181,7 +181,16 @@ jobs:
         run: |
           Set-StrictMode -Version Latest
           if (-not (Test-Path build_wix)) { New-Item -ItemType Directory -Path build_wix | Out-Null }
-          Copy-Item build_wix/Product_WithService.wxs build_wix/Product.wxs -Force
+
+          # Read the template
+          $wxsContent = Get-Content build_wix/Product_WithService.wxs -Raw
+
+          # 🛠️ FIX: Remove 'Start="install"' so MSI doesn't hang if service fails
+          # We also ensure Wait="true" is only for uninstall/stop, not start
+          $wxsContent = $wxsContent -replace 'Start="install"', ''
+
+          # Write it back to the build location
+          $wxsContent | Set-Content build_wix/Product.wxs -Encoding utf8
 
           if (Test-Path staging/backend/fortuna-backend.exe) {
             Move-Item staging/backend/fortuna-backend.exe staging/backend/fortuna-webservice.exe -Force
@@ -193,7 +202,7 @@ jobs:
           $proj += '    <OutputName>HatTrickFusion</OutputName>'
           $proj += '    <OutputType>Package</OutputType>'
           $proj += '    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>'
-          $proj += '    <DefineConstants>SourceDir=../staging/backend;Version=${{ needs.build-backend.outputs.semver }};ServicePort=${{ env.SERVICE_PORT }}</DefineConstants>'
+          $proj += '    <DefineConstants>SourceDir=../staging/backend;Version=${{ needs.build-backend.outputs.semver }}</DefineConstants>'
           $proj += '    <Platforms>x64</Platforms>'
           $proj += '    <BinderIncludeCabinetFilesInPackage>true</BinderIncludeCabinetFilesInPackage>'
           $proj += '  </PropertyGroup>'
@@ -216,7 +225,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: hat-trick-msi
-          path: build_wix/bin/x64/Release/*.msi
+          path: build_wix/bin/x64/Release/*
 
   smoke-test:
     name: HatTrick Fusion Smoke Test

--- a/.github/workflows/build-msi-unified.yml
+++ b/.github/workflows/build-msi-unified.yml
@@ -308,7 +308,10 @@ jobs:
       - name: Prepare WiX Project
         shell: pwsh
         run: |
-          Copy-Item "${{ env.WIX_DIR }}/Product_WithService.wxs" "${{ env.WIX_DIR }}/Product.wxs" -Force
+          $wxsContent = Get-Content "${{ env.WIX_DIR }}/Product_WithService.wxs" -Raw
+          $wxsContent = $wxsContent -replace 'Start="install"', ''
+          $wxsContent | Set-Content "${{ env.WIX_DIR }}/Product.wxs" -Encoding utf8
+
           $wixProj = @(
             '<Project Sdk="WixToolset.Sdk/${{ env.WIX_VERSION }}">'
             '  <PropertyGroup>'
@@ -338,7 +341,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: msi-installer-${{ needs.build-executable.outputs.build_id }}
-          path: ${{ env.WIX_DIR }}/bin/x64/Release/*.msi
+          path: ${{ env.WIX_DIR }}/bin/x64/Release/*
           retention-days: 1
 
   smoke-test:

--- a/.github/workflows/build-web-service-msi-jules.yml
+++ b/.github/workflows/build-web-service-msi-jules.yml
@@ -954,7 +954,10 @@ jobs:
       - name: Prepare WiX Project
         run: |
           Set-StrictMode -Version Latest
-          Copy-Item "${{ env.WIX_DIR }}/Product_WithService.wxs" "${{ env.WIX_DIR }}/Product.wxs" -Force
+          $wxsContent = Get-Content "${{ env.WIX_DIR }}/Product_WithService.wxs" -Raw
+          $wxsContent = $wxsContent -replace 'Start="install"', ''
+          $wxsContent | Set-Content "${{ env.WIX_DIR }}/Product.wxs" -Encoding utf8
+
           $wixProj = @(
             '<Project Sdk="WixToolset.Sdk/${{ env.WIX_VERSION }}">'
             '  <PropertyGroup>'
@@ -992,9 +995,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: fortuna-service-msi-${{ github.run_id }}
-          path: |
-            ${{ env.WIX_DIR }}/bin/x64/Release/*.msi
-            ${{ env.WIX_DIR }}/bin/x64/Release/*.sha256
+          path: ${{ env.WIX_DIR }}/bin/x64/Release/*
           retention-days: 10
 
   create-release:


### PR DESCRIPTION
Resolves a critical installation timeout issue in the `hat-trick-fusion`, `unified`, and `jules` MSI workflows.

The WiX template (`Product_WithService.wxs`) included a `<ServiceControl Start="install" Wait="true" />` element. This caused the MSI installer to hang and eventually time out with a 1603 error if the service failed to start immediately upon installation. This prevented the capture of any service-related error logs, as the failed installation would roll back and delete all installed files.

This commit modifies all three workflows to dynamically remove the `Start="install"` attribute from the WiX source file at build time. This decouples the file installation from the service startup. The MSI now only handles installing the files, while the smoke test is responsible for starting the service. This ensures that the installation step will succeed reliably and that any service startup failures can be properly logged and diagnosed in subsequent steps.