### PR TITLE
fix(ci): resolve unicode and smoke test failures in msi workflows

### DIFF
--- a/.github/workflows/build-electron-clean-room.yml
+++ b/.github/workflows/build-electron-clean-room.yml
@@ -39,32 +39,35 @@ jobs:
         shell: python
         env:
           BACKEND_DIR: ${{ env.BACKEND_DIR }}
+          PYTHONUTF8: '1'
         run: |
-          import os, sys
+          import os
           from pathlib import Path
+          from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
-          # Install Deps
-          os.system(f"pip install -r {os.environ['BACKEND_DIR']}/requirements-dev.txt")
-          os.system("pip install pyinstaller==6.6.0")
+          # 1. Prepare Paths
+          bk_dir = os.environ['BACKEND_DIR']
+          entry = f"{bk_dir}/main.py"
 
-          # Ensure __init__ exists for package discovery
-          init_path = Path(f"{os.environ['BACKEND_DIR']}/__init__.py")
+          # 2. Ensure __init__.py exists (The "Clean Room" check)
+          init_path = Path(f"{bk_dir}/__init__.py")
           if not init_path.exists():
-              init_path.write_text("# Clean Room Injection")
+              init_path.write_text("# Hybrid Injection")
 
-          # Generate Spec (The "Clean" a.pure Injection)
-          spec = f"""
+          # 3. Generate Spec with a.pure Injection (The "HatTrick" Logic)
+          # This replaces the "Zip Injection" hack from the old Electron workflow
+          spec_content = f"""
           # -*- mode: python ; coding: utf-8 -*-
           from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
           block_cipher = None
 
           a = Analysis(
-              ['{os.environ['BACKEND_DIR']}/main.py'],
+              ['{entry}'],
               pathex=[],
               binaries=[],
               datas=collect_data_files('uvicorn') + collect_data_files('slowapi'),
-              hiddenimports=collect_submodules('{os.environ['BACKEND_DIR']}'),
+              hiddenimports=collect_submodules('{bk_dir}'),
               hookspath=[],
               runtime_hooks=[],
               excludes=['tests', 'pytest'],
@@ -74,22 +77,28 @@ jobs:
               noarchive=False,
           )
 
-          # The Fix: Inject __init__ as a module
-          a.pure += [('{os.environ['BACKEND_DIR']}', '{init_path.as_posix()}', 'PYMODULE')]
+          # THE UPGRADE: Inject __init__ into PURE archive
+          a.pure += [('{bk_dir}', '{init_path.as_posix()}', 'PYMODULE')]
 
           pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
           exe = EXE(
               pyz, a.scripts, [], exclude_binaries=True, name='fortuna-backend',
               debug=False, bootloader_ignore_signals=False, strip=False, upx=True, console=True
           )
+
+          # Electron needs a folder (COLLECT), not just a file
           coll = COLLECT(
-              exe, a.binaries, a.zipfiles, a.datas, strip=False, upx=True, name='fortuna-backend'
+              exe, a.binaries, a.zipfiles, a.datas,
+              strip=False, upx=True, name='fortuna-backend'
           )
           """
-          with open("backend.spec", "w") as f: f.write(spec)
 
-          # Build
-          os.system("pyinstaller backend.spec --clean --noconfirm --distpath electron/dist --workpath build/service")
+          with open("hybrid.spec", "w") as f: f.write(spec_content)
+
+          # 4. Build
+          # Output directly to where Electron expects it (dist/service)
+          os.system("pyinstaller hybrid.spec --clean --noconfirm --distpath dist/service --workpath build/temp")
 
       # --- FRONTEND ---
       - uses: actions/setup-node@v4

--- a/.github/workflows/build-electron-hybrid.yml
+++ b/.github/workflows/build-electron-hybrid.yml
@@ -63,6 +63,7 @@ jobs:
         shell: python
         env:
           BACKEND_DIR: ${{ env.BACKEND_DIR }}
+          PYTHONUTF8: '1'
         run: |
           import os
           from pathlib import Path

--- a/.github/workflows/build-msi-hat-trick-fusion.yml
+++ b/.github/workflows/build-msi-hat-trick-fusion.yml
@@ -202,7 +202,7 @@ jobs:
           $proj += '    <OutputName>HatTrickFusion</OutputName>'
           $proj += '    <OutputType>Package</OutputType>'
           $proj += '    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>'
-          $proj += '    <DefineConstants>SourceDir=../staging/backend;Version=${{ needs.build-backend.outputs.semver }}</DefineConstants>'
+          $proj += '    <DefineConstants>SourceDir=../staging/backend;Version=${{ needs.build-backend.outputs.semver }};ServicePort=${{ env.SERVICE_PORT }}</DefineConstants>'
           $proj += '    <Platforms>x64</Platforms>'
           $proj += '    <BinderIncludeCabinetFilesInPackage>true</BinderIncludeCabinetFilesInPackage>'
           $proj += '  </PropertyGroup>'

--- a/.github/workflows/build-msi-unified.yml
+++ b/.github/workflows/build-msi-unified.yml
@@ -325,7 +325,7 @@ jobs:
             '    <OutputName>Fortuna-WebService-Pragmatic</OutputName>'
             '    <OutputType>Package</OutputType>'
             '    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>'
-            '    <DefineConstants>SourceDir=../staging;Version=${{ needs.path-finder.outputs.semver }}</DefineConstants>'
+            '    <DefineConstants>SourceDir=../staging/backend;Version=${{ needs.path-finder.outputs.semver }};ServicePort=${{ env.SERVICE_PORT }}</DefineConstants>'
             # FIX: Embed the CAB file so we don't get Error 1311
             '    <BinderIncludeCabinetFilesInPackage>true</BinderIncludeCabinetFilesInPackage>'
             '  </PropertyGroup>'

--- a/.github/workflows/build-web-service-msi-jules.yml
+++ b/.github/workflows/build-web-service-msi-jules.yml
@@ -981,7 +981,7 @@ jobs:
             '    <OutputName>${{ steps.stage.outputs.msi_name }}</OutputName>'
             '    <OutputType>Package</OutputType>'
             '    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>'
-            '    <DefineConstants>SourceDir=staging;Version=${{ env.BUILD_VERSION }}</DefineConstants>'
+            '    <DefineConstants>SourceDir=staging;Version=${{ env.BUILD_VERSION }};ServicePort=${{ env.SERVICE_PORT }}</DefineConstants>'
             '    <Platforms>x64</Platforms>'
             '    <Version>${{ env.BUILD_VERSION }}</Version>'
             '    <BinderIncludeCabinetFilesInPackage>true</BinderIncludeCabinetFilesInPackage>'

--- a/build_wix/Product_WithService.wxs
+++ b/build_wix/Product_WithService.wxs
@@ -59,9 +59,18 @@
 
   <!-- 3. RUNTIME DIRECTORIES -->
   <ComponentGroup Id="RuntimeDirectoryComponents" Directory="INSTALLFOLDER">
-      <Component Id="DataDirectoryComponent" Guid="a2e3820a-606b-452f-b43f-b82b9a7852a0"><CreateFolder Directory="Dir_Data" /></Component>
-      <Component Id="JsonDirectoryComponent" Guid="b4d7ea21-821f-4a0b-9303-3a52e1f42d2a"><CreateFolder Directory="Dir_Json" /></Component>
-      <Component Id="LogsDirectoryComponent" Guid="d66f6540-3f11-4475-9a67-9c9852f87a32"><CreateFolder Directory="Dir_Logs" /></Component>
+      <Component Id="DataDirectoryComponent" Guid="a2e3820a-606b-452f-b43f-b82b9a7852a0">
+        <CreateFolder Directory="Dir_Data" />
+        <RegistryValue Root="HKCU" Key="Software\Fortuna Faucet\Directories" Name="Data" Type="string" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="JsonDirectoryComponent" Guid="b4d7ea21-821f-4a0b-9303-3a52e1f42d2a">
+        <CreateFolder Directory="Dir_Json" />
+        <RegistryValue Root="HKCU" Key="Software\Fortuna Faucet\Directories" Name="Json" Type="string" Value="1" KeyPath="yes" />
+      </Component>
+      <Component Id="LogsDirectoryComponent" Guid="d66f6540-3f11-4475-9a67-9c9852f87a32">
+        <CreateFolder Directory="Dir_Logs" />
+        <RegistryValue Root="HKCU" Key="Software\Fortuna Faucet\Directories" Name="Logs" Type="string" Value="1" KeyPath="yes" />
+      </Component>
   </ComponentGroup>
 
   <!-- 4. SHORTCUTS (Fixed WIX0010) -->


### PR DESCRIPTION
This commit addresses multiple failures across the MSI and Electron build workflows.

- **`build-electron-hybrid.yml`:**
  - Adds `PYTHONUTF8: '1'` to the PyInstaller build step to resolve a `UnicodeEncodeError` on Windows runners.
- **`build-electron-clean-room.yml`:**
  - Replaces the PyInstaller build logic with the more robust "HatTrick" spec generation from the hybrid workflow. This is intended to fix the smoke test failure where the packaged application's processes would not start.
- **All MSI Workflows (`hat-trick`, `unified`, `jules`):**
  - Corrects the `DefineConstants` in all three workflows to ensure the `ServicePort` is passed to the WiX compiler.
  - Fixes a `WIX0204` build error in the shared `Product_WithService.wxs` template by adding a key path to directory-only components.