### PR TITLE
fix(wix): Correct license file path in WiX template

### DIFF
--- a/build_wix/Product_WithService.wxs
+++ b/build_wix/Product_WithService.wxs
@@ -32,7 +32,7 @@
 
     <!-- UI Configuration -->
     <ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLFOLDER" />
-    <WixVariable Id="WixUILicenseRtf" Value="build_wix/license.rtf" />
+    <WixVariable Id="WixUILicenseRtf" Value="license.rtf" />
     <!-- Note: If you don't have a license.rtf, remove the line above, or WiX will error. -->
 
   </Package>


### PR DESCRIPTION
The WiX build was failing with a WIX0103 error because the path to the license file was incorrect. The build process runs inside the 'build_wix' directory, but the path was specified as 'build_wix/license.rtf', causing the compiler to look for a non-existent 'build_wix/build_wix/license.rtf' file.

This change corrects the path to 'license.rtf', which is the correct relative path from the build's working directory.