### PR TITLE
Fix(tests): Stabilize unit test suite to unblock CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,18 +16,21 @@ class TestSettings:
     redis_url: str = "redis://localhost:6379"
     database_url: str = "sqlite+aiosqlite:///:memory:"
     testing: bool = True
+    # Add sensible defaults for engine/HTTP client initialization
+    HTTP_POOL_CONNECTIONS: int = 100
+    HTTP_MAX_KEEPALIVE: int = 20
+    API_KEY: str = "test-api-key-123"
+    MAX_CONCURRENT_REQUESTS: int = 50
+    # Add dummy values for adapter tests
+    GREYHOUND_API_URL: str = "http://test-greyhound-api.com"
+    THE_RACING_API_KEY: str = "test-racing-api-key"
 
 def get_test_settings() -> TestSettings:
     return TestSettings()
 
 # --- 3. Event Loop (Function Scope) ---
-# FIX: Changed scope to 'function' to match pytest-asyncio defaults and prevent shutdown errors
-@pytest.fixture(scope="function")
-def event_loop() -> Generator:
-    """Create an instance of the default event loop for each test case."""
-    loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
+# FIX: The explicit event_loop fixture is removed. pytest-asyncio will now manage the loop.
+# This prevents a RuntimeError with the ThreadPoolExecutor during the app's lifespan startup.
 
 # --- 4. Redis Client Fixture ---
 @pytest.fixture

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,7 +37,7 @@ async def test_get_races_endpoint_success(mock_fetch_all_odds, client):
     headers = {"X-API-Key": "a_secure_test_api_key_that_is_long_enough"}
 
     # ACT
-    response = client.get(f"/api/races?race_date={today.isoformat()}", headers=headers)
+    response = await client.get(f"/api/races?race_date={today.isoformat()}", headers=headers)
 
     # ASSERT
     assert response.status_code == 200
@@ -73,7 +73,7 @@ async def test_get_tipsheet_endpoint_success(tmp_path, client):
             await db.commit()
 
         # ACT
-        response = client.get(f"/api/tipsheet?date={post_time.date().isoformat()}")
+        response = await client.get(f"/api/tipsheet?date={post_time.date().isoformat()}")
 
         # ASSERT
         assert response.status_code == 200
@@ -84,23 +84,26 @@ async def test_get_tipsheet_endpoint_success(tmp_path, client):
         assert response_data[0]["score"] == 85.5
 
 
-def test_health_check_unauthenticated(client):
+@pytest.mark.asyncio
+async def test_health_check_unauthenticated(client):
     """Ensures the /health endpoint is accessible without an API key."""
-    response = client.get("/health")
+    response = await client.get("/health")
     assert response.status_code == 200
     json_response = response.json()
     assert json_response["status"] == "healthy"
 
 
-def test_api_key_authentication_failure(client):
+@pytest.mark.asyncio
+async def test_api_key_authentication_failure(client):
     """Ensures that endpoints are protected and fail with an invalid API key."""
-    response = client.get("/api/races/qualified/trifecta", headers={"X-API-KEY": "invalid_key"})
+    response = await client.get("/api/races/qualified/trifecta", headers={"X-API-KEY": "invalid_key"})
     assert response.status_code == 403
     assert "Invalid or missing API Key" in response.json()["detail"]
 
 
-def test_api_key_authentication_missing(client):
+@pytest.mark.asyncio
+async def test_api_key_authentication_missing(client):
     """Ensures that endpoints are protected and fail with a missing API key."""
-    response = client.get("/api/races/qualified/trifecta")
+    response = await client.get("/api/races/qualified/trifecta")
     assert response.status_code == 403
     assert "Not authenticated" in response.json()["detail"]

--- a/tests/test_manual_override.py
+++ b/tests/test_manual_override.py
@@ -9,7 +9,8 @@ from tests.conftest import get_test_settings
 
 # Override settings for tests
 app.dependency_overrides[get_settings] = get_test_settings
-API_KEY = get_test_settings().API_KEY
+_settings = get_test_settings()
+API_KEY = getattr(_settings, "API_KEY", "test-override-key-123")
 
 
 @pytest.fixture


### PR DESCRIPTION
This commit addresses a series of cascading failures in the Python unit test suite that were blocking the 'HatTrick Ultimate' and 'Production' CI/CD workflows.

The primary issue was an `AttributeError` during test collection in `tests/test_manual_override.py` due to a missing `API_KEY` in the test settings.

This led to the discovery of several other issues:
- The `TestSettings` object in `tests/conftest.py` was missing several required attributes for the `OddsEngine` and `Adapters` to initialize correctly.
- Multiple API tests in `tests/test_api.py` were not correctly `await`ing asynchronous client calls.
- A custom `event_loop` fixture was causing `RuntimeError`s by conflicting with the FastAPI application's lifespan management.

These issues have been resolved by:
- Using `getattr` for safe access to `API_KEY`.
- Populating `TestSettings` with sensible defaults.
- Adding the required `async` and `await` keywords to the API tests.
- Removing the problematic `event_loop` fixture.

While the test suite still exhibits some instability related to `asyncio` lifecycle management, these changes resolve the critical blockers and significantly improve the overall health of the tests.