### PR TITLE
Fix(CI): Harmonize MSI workflows and fix CodeQL

### DIFF
--- a/.github/workflows/build-msi-hattrickfusion-ultimate.yml
+++ b/.github/workflows/build-msi-hattrickfusion-ultimate.yml
@@ -293,8 +293,11 @@ jobs:
           Set-StrictMode -Version Latest
           if (-not (Test-Path build_wix)) { New-Item -ItemType Directory -Path build_wix | Out-Null }
 
-          # Copy template
+          # Copy template and apply fix
           Copy-Item build_wix/Product_WithService.wxs build_wix/Product.wxs -Force
+          $wxsPath = "build_wix/Product.wxs"
+          (Get-Content $wxsPath -Raw) -replace 'Start="install"', '' | Set-Content -Path $wxsPath -Encoding UTF8 -Force
+          Write-Host "✅ Dynamically removed 'Start=install' attribute from WiX template."
 
           # Stage Executable
           if (Test-Path staging/backend/fortuna-backend.exe) {

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,16 +41,17 @@ jobs:
       if: matrix.language == 'python'
       run: |
         python -m pip install --upgrade pip
-        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-        if [ -f python_service/requirements-dev.txt ]; then pip install -r python_service/requirements-dev.txt; fi
-        if [ -f web_service/backend/requirements-dev.txt ]; then pip install -r web_service/backend/requirements-dev.txt; fi
+        # Find and install all requirements files to ensure all dependencies are met for a full scan
+        find . -type f -name 'requirements*.txt' ! -path './.venv/*' -exec echo "Installing {}" \; -exec python -m pip install -r {} \;
 
-    - name: Install Javascript dependencies and build
+    - name: Install Javascript dependencies
       if: matrix.language == 'javascript'
       run: |
-        if [ -f web_service/frontend/package.json ]; then (cd web_service/frontend && npm install && npm run build); fi
-        if [ -f web_platform/frontend/package.json ]; then (cd web_platform/frontend && npm install && npm run build); fi
-        if [ -f electron/package.json ]; then (cd electron && npm install); fi
+        # Find all package.json files, excluding node_modules, and run npm ci in their directories
+        find . -type f -name 'package.json' ! -path '*/node_modules/*' -exec dirname {} \; | while read dir; do
+          echo "Installing dependencies in $dir"
+          (cd "$dir" && npm ci --prefer-offline --no-audit)
+        done
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/build_wix/Product_WithService.wxs
+++ b/build_wix/Product_WithService.wxs
@@ -47,14 +47,17 @@
     </ComponentGroup>
 
     <ComponentGroup Id="RuntimeDirectoryComponents" Directory="INSTALLFOLDER">
-        <Component Id="DataDirectoryComponent" Guid="a2e3820a-606b-452f-b43f-b82b9a7852a0">
+        <Component Id="DataDirectoryComponent" Guid="*">
             <CreateFolder Directory="Dir_Data" />
+            <RegistryValue Root="HKCU" Key="Software\Fortuna Faucet\Directories" Name="Data" Type="string" Value="1" KeyPath="yes" />
         </Component>
-        <Component Id="JsonDirectoryComponent" Guid="b4d7ea21-821f-4a0b-9303-3a52e1f42d2a">
+        <Component Id="JsonDirectoryComponent" Guid="*">
             <CreateFolder Directory="Dir_Json" />
+            <RegistryValue Root="HKCU" Key="Software\Fortuna Faucet\Directories" Name="Json" Type="string" Value="1" KeyPath="yes" />
         </Component>
-        <Component Id="LogsDirectoryComponent" Guid="d66f6540-3f11-4475-9a67-9c9852f87a32">
+        <Component Id="LogsDirectoryComponent" Guid="*">
             <CreateFolder Directory="Dir_Logs" />
+            <RegistryValue Root="HKCU" Key="Software\Fortuna Faucet\Directories" Name="Logs" Type="string" Value="1" KeyPath="yes" />
         </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
This commit applies several fixes to the active MSI installer workflows and the CodeQL analysis workflow to improve reliability and adhere to best practices.

- **`build-msi-hattrickfusion-ultimate.yml`**:
  - Programmatically removes the `Start="install"` attribute from the WiX template. This is a critical fix to prevent the MSI installation from hanging if the service fails to start immediately.

- **`build_wix/Product_WithService.wxs`**:
  - Replaces hardcoded GUIDs for directory components with `Guid="*"` to enable auto-generation, following WiX v4 best practices.
  - Adds dummy registry values as key paths to components that create empty directories. This resolves potential `WIX0204` validation errors.

- **`codeql.yml`**:
  - Replaces hardcoded dependency file paths with `find` commands to dynamically locate and install all `requirements.txt` and `package.json` files. This ensures a comprehensive and accurate CodeQL scan.