### PR TITLE
feat: Stabilize CI workflows with soft fail and env variables

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -15,6 +15,10 @@ env:
   ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
   BACKEND_DIR: 'web_service/backend'
   PYTHONUTF8: '1'
+  API_KEY: mock_key
+  FORTUNA_ENV: smoke-test
+  TVG_API_KEY: mock
+  GREYHOUND_API_URL: http://mock
 
 jobs:
   validate-environment:
@@ -163,7 +167,7 @@ jobs:
           Write-Host "Running Test Suite (Threshold: $MAX_ALLOWED_FAILURES failures)..."
           # 2. Run Pytest and generate an XML report.
           # We use 'cmd /c' and '|| true' to ensure the script doesn't die immediately on exit code 1.
-          cmd /c "pytest --junitxml=test-report.xml" || Write-Host "Pytest finished with issues."
+          cmd /c "pytest ${{ env.BACKEND_DIR }}/tests --junitxml=test-report.xml" || Write-Host "Pytest finished with issues."
           # 3. Parse the XML Report
           if (Test-Path "test-report.xml") {
               [xml]$xml = Get-Content "test-report.xml"
@@ -192,6 +196,7 @@ jobs:
                   exit 1
               } else {
                   Write-Host "✅ ACCEPTABLE: Failure count is within tolerance. Proceeding with build..." -ForegroundColor Green
+                  exit 0 # Explicitly exit with success code to override pytest's failure code
               }
           } else {
               Write-Error "❌ FATAL: No test report generated. Pytest failed to start."

--- a/.github/workflows/build-msi-hattrickfusion-ultimate.yml
+++ b/.github/workflows/build-msi-hattrickfusion-ultimate.yml
@@ -155,12 +155,49 @@ jobs:
           pip install pyinstaller==6.6.0 pytest pytest-asyncio httpx asgi-lifespan fakeredis
           pip freeze > backend-freeze.txt
 
-      - name: 🧪 Run Unit Tests (TDD)
+      - name: 🧪 Run Unit Tests (Quality Gate)
         shell: pwsh
         run: |
-          Write-Host "Running Test Suite..."
-          # If this fails, we stop here. Shift Left.
-          pytest
+          # 1. Define the Failure Threshold
+          $MAX_ALLOWED_FAILURES = 30
+          Write-Host "Running Test Suite (Threshold: $MAX_ALLOWED_FAILURES failures)..."
+          # 2. Run Pytest and generate an XML report.
+          # We use 'cmd /c' and '|| true' to ensure the script doesn't die immediately on exit code 1.
+          cmd /c "pytest ${{ env.BACKEND_DIR }}/tests --junitxml=test-report.xml" || Write-Host "Pytest finished with issues."
+          # 3. Parse the XML Report
+          if (Test-Path "test-report.xml") {
+              [xml]$xml = Get-Content "test-report.xml"
+              # Sum up failures and errors
+              $failures = 0
+              $errors = 0
+              # Handle different XML structures (sometimes root is testsuites, sometimes testsuite)
+              if ($xml.testsuites) {
+                  $failures = [int]$xml.testsuites.failures
+                  $errors = [int]$xml.testsuites.errors
+              } elseif ($xml.testsuite) {
+                  $failures = [int]$xml.testsuite.failures
+                  $errors = [int]$xml.testsuite.errors
+              }
+              $total_issues = $failures + $errors
+              Write-Host "----------------------------------------"
+              Write-Host "📊 TEST RESULTS SUMMARY"
+              Write-Host "   Failures: $failures"
+              Write-Host "   Errors:   $errors"
+              Write-Host "   Total:    $total_issues"
+              Write-Host "   Limit:    $MAX_ALLOWED_FAILURES"
+              Write-Host "----------------------------------------"
+              # 4. The Decision Logic
+              if ($total_issues -gt $MAX_ALLOWED_FAILURES) {
+                  Write-Error "❌ CRITICAL: Too many tests failed ($total_issues). Limit is $MAX_ALLOWED_FAILURES."
+                  exit 1
+              } else {
+                  Write-Host "✅ ACCEPTABLE: Failure count is within tolerance. Proceeding with build..." -ForegroundColor Green
+                  exit 0 # Explicitly exit with success code to override pytest's failure code
+              }
+          } else {
+              Write-Error "❌ FATAL: No test report generated. Pytest failed to start."
+              exit 1
+          }
 
       - name: Cache PyInstaller Dist
         id: cache-backend


### PR DESCRIPTION
- Injects missing environment variables (API_KEY, FORTUNA_ENV, etc.) into the `build-electron-msi-gpt5.yml` workflow to prevent runtime configuration errors.
- Implements a "soft fail" quality gate in both `build-electron-msi-gpt5.yml` and `build-msi-hattrickfusion-ultimate.yml`. This allows the build to proceed even if up to 30 unit tests fail, per the project's architectural decision.
- Fixes a critical bug in the quality gate logic. Previously, a non-zero exit code from `pytest` would cause the step to fail before the tolerance logic could be evaluated. The script now correctly handles the `pytest` exit code and uses an explicit `exit 0` to ensure the step succeeds when the failure count is within the defined threshold.
- Improves the robustness of the `pytest` commands in both workflows by explicitly specifying the path to the test directories, preventing ambiguity.
- Verifies that the requested WiX service timeout fix (`Wait='no'`) was already present in the codebase.