### PR TITLE
fix(ci): Correct port usage in electron smoke test

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -865,19 +865,22 @@ jobs:
           $logDir = "C:\Temp\fortuna-logs-$(Get-Random)"
           New-Item -ItemType Directory -Path $logDir -Force | Out-Null
 
+          # Set the environment variable for the process
+          $env:FORTUNA_PORT = "${{ env.FORTUNA_PORT }}"
+
           $proc = Start-Process -FilePath $exe.FullName -ArgumentList "--no-sandbox" -PassThru -RedirectStandardOutput "$logDir\stdout.log" -RedirectStandardError "$logDir\stderr.log"
 
-          Write-Host "Electron launched (PID: $($proc.Id))"
-          Write-Host "Waiting for backend to start listening on port 8102..."
+          Write-Host "Electron launched (PID: $($proc.Id)) with FORTUNA_PORT=$($env:FORTUNA_PORT)"
+          Write-Host "Waiting for backend to start listening on port $($env:FORTUNA_PORT)..."
 
           # Wait for port to be ready
           $portReady = $false
           for ($i = 0; $i -lt 60; $i++) {
             try {
               $tcp = New-Object System.Net.Sockets.TcpClient
-              $tcp.Connect('127.0.0.1', 8102)
+              $tcp.Connect('127.0.0.1', $env:FORTUNA_PORT)
               $tcp.Close()
-              Write-Host "✅ Port 8102 is OPEN!"
+              Write-Host "✅ Port $($env:FORTUNA_PORT) is OPEN!"
               $portReady = $true
               break
             } catch {
@@ -887,7 +890,7 @@ jobs:
           }
 
           if (!$portReady) {
-            Write-Error "❌ Backend never opened port 8102!"
+            Write-Error "❌ Backend never opened port $($env:FORTUNA_PORT)!"
             Write-Host "`n=== ELECTRON STDOUT ==="
             Get-Content "$logDir\stdout.log" -Tail 50
             Write-Host "`n=== ELECTRON STDERR ==="


### PR DESCRIPTION
The `build-electron-msi-gpt5.yml` workflow was failing because the smoke test was not correctly configured to use the `FORTUNA_PORT` environment variable.

This change ensures that:
- The `FORTUNA_PORT` environment variable is passed to the Electron application process during the smoke test.
- The smoke test itself uses the `FORTUNA_PORT` variable to check for the backend service, removing the hardcoded port `8102`.

This makes the smoke test more robust and configurable, resolving the timeout failures.