### PR TITLE
fix(ci): Resolve multiple YAML and WiX parsing errors

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -865,19 +865,22 @@ jobs:
           $logDir = "C:\Temp\fortuna-logs-$(Get-Random)"
           New-Item -ItemType Directory -Path $logDir -Force | Out-Null
 
+          # Set the environment variable for the process
+          $env:FORTUNA_PORT = "${{ env.FORTUNA_PORT }}"
+
           $proc = Start-Process -FilePath $exe.FullName -ArgumentList "--no-sandbox" -PassThru -RedirectStandardOutput "$logDir\stdout.log" -RedirectStandardError "$logDir\stderr.log"
 
-          Write-Host "Electron launched (PID: $($proc.Id))"
-          Write-Host "Waiting for backend to start listening on port 8102..."
+          Write-Host "Electron launched (PID: $($proc.Id)) with FORTUNA_PORT=$($env:FORTUNA_PORT)"
+          Write-Host "Waiting for backend to start listening on port $($env:FORTUNA_PORT)..."
 
           # Wait for port to be ready
           $portReady = $false
           for ($i = 0; $i -lt 60; $i++) {
             try {
               $tcp = New-Object System.Net.Sockets.TcpClient
-              $tcp.Connect('127.0.0.1', 8102)
+              $tcp.Connect('127.0.0.1', $env:FORTUNA_PORT)
               $tcp.Close()
-              Write-Host "✅ Port 8102 is OPEN!"
+              Write-Host "✅ Port $($env:FORTUNA_PORT) is OPEN!"
               $portReady = $true
               break
             } catch {
@@ -887,7 +890,7 @@ jobs:
           }
 
           if (!$portReady) {
-            Write-Error "❌ Backend never opened port 8102!"
+            Write-Error "❌ Backend never opened port $($env:FORTUNA_PORT)!"
             Write-Host "`n=== ELECTRON STDOUT ==="
             Get-Content "$logDir\stdout.log" -Tail 50
             Write-Host "`n=== ELECTRON STDERR ==="

--- a/.github/workflows/build-msi-hat-trick-fusion.yml
+++ b/.github/workflows/build-msi-hat-trick-fusion.yml
@@ -192,7 +192,7 @@ jobs:
 
           # Dynamically remove the problematic Start="install" attribute
           $wxsPath = 'build_wix/Product.wxs'
-          $wxsContent = [xml](Get-Content $wxsPath)
+          $wxsContent = [xml](Get-Content $wxsPath -Raw)
           $serviceControl = $wxsContent.SelectSingleNode("//*[local-name()='ServiceControl']")
           if ($serviceControl -and $serviceControl.HasAttribute("Start")) {
               $serviceControl.RemoveAttribute("Start")

--- a/.github/workflows/build-msi-hattrickfusion-ultimate.yml
+++ b/.github/workflows/build-msi-hattrickfusion-ultimate.yml
@@ -76,7 +76,7 @@ jobs:
           Write-Host "✅ Frontend built: $($files.Count) files."
 
           foreach ($f in $files) {
-            # FIX: Changed TrimStart('\\\\', '/') to TrimStart('\\', '/') to prevent char conversion error
+            # FIX: Use TrimStart('\','/') to prevent char conversion error.
             $rel = $f.FullName.Substring($outDir.Path.Length).TrimStart('\','/')
             $hash = (Get-FileHash $f.FullName -Algorithm SHA256).Hash.Substring(0,16)
             "$rel`t$($f.Length)`t$hash" | Out-File $manifestPath -Encoding utf8 -Append

--- a/.github/workflows/build-msi-unified.yml
+++ b/.github/workflows/build-msi-unified.yml
@@ -65,11 +65,9 @@ jobs:
 
           python -m pytest web_service/backend
 
-          # Exit code 5 means no tests were found, which is not a failure in thi
-s context.
+          # Exit code 5 means no tests were found, which is not a failure.
           if ($LASTEXITCODE -eq 5) {
-            Write-Host "✅ Pytest returned exit code 5 (No tests found), which is
- acceptable."
+            Write-Host "✅ Pytest returned exit code 5 (No tests found), which is acceptable."
             exit 0
           } elseif ($LASTEXITCODE -ne 0) {
             Write-Error "❌ Pytest failed with exit code $LASTEXITCODE."
@@ -93,8 +91,7 @@ s context.
 
       - name: Set Build ID
         id: vars
-        run: echo "build_id=${{ github.run_id }}-${{ github.run_attempt }}" | Ou
-t-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        run: echo "build_id=${{ github.run_id }}-${{ github.run_attempt }}" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/build_wix/Product_WithService.wxs
+++ b/build_wix/Product_WithService.wxs
@@ -81,7 +81,7 @@
         <Component Id="StartMenuShortcuts" Guid="*" Directory="ApplicationProgramsFolder">
             <util:InternetShortcut Id="DashboardShortcut" Name="Fortuna Dashboard" Target="http://localhost:$(var.ServicePort)" />
             <Shortcut Id="RestartShortcut" Name="Restart Service" Description="Restarts the background service (Run as Admin)" Target="[INSTALLFOLDER]restart_service.bat" />
-            <Shortcut Id="LogsShortcut" Name="View Logs" Description="Opens the log file directory" Target="[Dir_Logs]" />
+            <Shortcut Id="LogsShortcut" Name="View Logs" Description="Opens the log file directory" Target="[System64Folder]explorer.exe" Arguments="[Dir_Logs]" />
             <util:InternetShortcut Id="HelpShortcut" Name="Help & Documentation" Description="View API documentation and help" Target="http://localhost:$(var.ServicePort)/docs" />
             <Shortcut Id="UninstallShortcut" Name="Uninstall Fortuna Faucet" Description="Removes the application" Target="[System64Folder]msiexec.exe" Arguments="/x [ProductCode]" />
             <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall" />


### PR DESCRIPTION
This commit addresses several critical parsing and syntax errors across the GitHub Actions workflows and the WiX installer template that were causing build failures.

The following fixes have been applied:
1.  **YAML Parsing:** Shortened overly long comment lines and fixed broken multi-line `run` commands in `build-msi-unified.yml` and other workflows to prevent the YAML parser from failing.
2.  **PowerShell XML Casting:** Corrected the `[xml](Get-Content ...)` command in `build-msi-hat-trick-fusion.yml` by adding the `-Raw` parameter. This ensures the file is read as a single string, fixing the type conversion error.
3.  **WiX Shortcut Syntax:** Fixed a `WIX0104` error in `build_wix/Product_WithService.wxs` by changing a `<Shortcut>` that was incorrectly targeting a directory. The shortcut now correctly targets `explorer.exe` and passes the directory as an argument.

These changes resolve multiple build-breaking issues and improve the overall stability of the CI/CD pipelines.