### PR TITLE
fix(ci): Resolve YAML syntax, encoding, and service startup errors

### DIFF
--- a/.github/workflows/build-electron-hybrid.yml
+++ b/.github/workflows/build-electron-hybrid.yml
@@ -320,7 +320,7 @@ jobs:
             exit 1
           }
 
-      - name: 💀 CSI: Windows (Post-Mortem Diagnostics)
+      - name: "💀 CSI: Windows (Post-Mortem Diagnostics)"
         if: failure()
         shell: pwsh
         run: |

--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -1021,7 +1021,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
-      - name: 💀 CSI: Windows (Post-Mortem Diagnostics)
+      - name: "💀 CSI: Windows (Post-Mortem Diagnostics)"
         if: failure()
         shell: pwsh
         run: |

--- a/.github/workflows/build-msi-hat-trick-fusion.yml
+++ b/.github/workflows/build-msi-hat-trick-fusion.yml
@@ -413,9 +413,9 @@ jobs:
                   page.wait_for_timeout(2000)
                   page.screenshot(path='proof-of-life.png', full_page=True)
                   browser.close()
-              print('✅ Screenshot captured.')
+              print('[SUCCESS] Screenshot captured.')
           except Exception as e:
-              print(f'❌ Screenshot failed: {e}')
+              print(f'[FAILED] Screenshot failed: {e}')
               # We do not fail the build for this; it is a bonus artifact.
               sys.exit(0)
           " $port
@@ -444,7 +444,7 @@ jobs:
         with:
           name: hat-trick-fusion-logs-${{ github.run_id }}
           path: installer-diag
-      - name: 💀 CSI: Windows (Post-Mortem Diagnostics)
+      - name: "💀 CSI: Windows (Post-Mortem Diagnostics)"
         if: failure()
         shell: pwsh
         run: |

--- a/.github/workflows/build-msi-hattrickfusion-ultimate.yml
+++ b/.github/workflows/build-msi-hattrickfusion-ultimate.yml
@@ -208,7 +208,7 @@ jobs:
               pathex=[],
               binaries=[],
               datas=collect_data_files('uvicorn') + collect_data_files('slowapi') + [('{frontend_out}', 'ui')],
-              hiddenimports=collect_submodules('{mod_path}') + ['win32timezone'],
+              hiddenimports=collect_submodules('{mod_path}') + ['win32timezone', 'win32serviceutil', 'win32service', 'win32event'],
               hookspath=[],
               runtime_hooks=[],
               excludes=['tests', 'pytest'],
@@ -485,12 +485,12 @@ jobs:
           for _ in range(60):
             try:
               with socket.create_connection(("127.0.0.1", port), timeout=1):
-                print("✅ Socket bound.")
+                print("[SUCCESS] Socket bound.")
                 sys.exit(0)
             except:
               time.sleep(1)
 
-          print("[X] Port bind timeout")
+          print("[FAILED] Port bind timeout")
           subprocess.run(["sc.exe", "query", "FortunaWebService"])
           sys.exit(1)
 
@@ -533,7 +533,7 @@ jobs:
           name: smoke-test-failure-${{ needs.path-finder.outputs.build_id }}
           path: diagnostics/
           retention-days: 30
-      - name: 💀 CSI: Windows (Post-Mortem Diagnostics)
+      - name: "💀 CSI: Windows (Post-Mortem Diagnostics)"
         if: failure()
         shell: pwsh
         run: |

--- a/fortuna-backend-webservice.spec
+++ b/fortuna-backend-webservice.spec
@@ -107,6 +107,7 @@ hiddenimports.update(
         "selectolax",
         "pydantic_core",
         "pydantic_settings.sources",
+        "win32timezone",
     ]
 )
 


### PR DESCRIPTION
This commit addresses several critical issues causing CI/CD pipeline failures:

1.  **YAML Syntax Errors:** Quotes have been added to step names containing colons (e.g., `CSI: Windows`) in `build-msi-hattrickfusion-ultimate.yml`, `build-electron-msi-gpt5.yml`, `build-electron-hybrid.yml`, and `build-msi-hat-trick-fusion.yml`. This prevents the GitHub Actions parser from crashing.

2.  **UnicodeEncodeError:** Emojis have been removed from Python `print` statements within the workflow files and replaced with text-based equivalents (e.g., `[SUCCESS]`). This resolves `UnicodeEncodeError` exceptions on Windows runners.

3.  **Service Error 1053:** The `win32timezone` module has been added to the `hiddenimports` list in `fortuna-backend-webservice.spec` and relevant inline specs. This ensures PyInstaller bundles the necessary time-handling libraries, fixing the "StartService FAILED 1053" error during smoke tests.