### PR TITLE
fix(ci): prevent diagnostic scripts from crashing on missing logs

### DIFF
--- a/.github/workflows/build-msi-hat-trick-fusion.yml
+++ b/.github/workflows/build-msi-hat-trick-fusion.yml
@@ -306,13 +306,19 @@ jobs:
           name: visual-proof-${{ github.run_id }}
           path: proof-of-life.png
 
-      - name: "💀 CSI: Windows (Post-Mortem Diagnostics)"
-        if: failure()
-        shell: pwsh
-        run: |
-          Write-Host "=== SERVICE STATUS ==="
-          Get-Service "FortunaService" | Select-Object Status, StartType, DisplayName
-          Write-Host "=== EVENT LOGS (Last 20 Errors) ==="
-          Get-EventLog -LogName System -EntryType Error -Newest 20 | Where-Object { $_.Message -like "*Fortuna*" }
-          Write-Host "=== PORT 8102 CHECK ==="
-          netstat -an | findstr "8102"
+    - name: Collect Diagnostics
+      if: always()
+      shell: pwsh
+      run: |
+        $diag = "diagnostics"
+        New-Item -ItemType Directory -Force -Path $diag
+
+        # FIX: Safe copy for install.log
+        if (Test-Path "install.log") {
+            Copy-Item "install.log" -Destination $diag
+        } else {
+            Write-Host "⚠️ install.log not found"
+        }
+
+        # Safe copy for other logs
+        Get-ChildItem -Filter "*.log" | Copy-Item -Destination $diag

--- a/.github/workflows/build-msi-hattrickfusion-ultimate.yml
+++ b/.github/workflows/build-msi-hattrickfusion-ultimate.yml
@@ -550,16 +550,23 @@ jobs:
           name: visual-proof-${{ github.run_id }}
           path: proof-of-life.png
 
-      - name: 📊 Capture Diagnostics
-        if: failure()
-        shell: pwsh
-        run: |
-          $diag = "diagnostics"
-          New-Item -ItemType Directory -Path $diag -Force
-          Copy-Item install.log $diag
-          Get-EventLog -LogName Application -Source "FortunaWebService" -Newest 50 | Out-File "$diag/events.txt"
-          Get-Service FortunaWebService | Out-File "$diag/service_state.txt"
-          netstat -anob > "$diag/netstat.txt"
+    - name: Collect Diagnostics
+      if: always()
+      shell: pwsh
+      run: |
+        $diag = "diagnostics"
+        New-Item -ItemType Directory -Force -Path $diag
+
+        # FIX: Check if install.log exists before copying
+        if (Test-Path "install.log") {
+            Copy-Item "install.log" -Destination $diag
+        } else {
+            Write-Host "⚠️ install.log not found (Installer may not have run)"
+        }
+
+        # Collect other logs safely
+        if (Test-Path "build_wix") { Copy-Item "build_wix" -Destination $diag -Recurse }
+        if (Test-Path "backend_debug.log") { Copy-Item "backend_debug.log" -Destination $diag }
       - name: 📤 Upload Diagnostics
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Integrates safe-copy logic into the diagnostic steps of the `hat-trick-fusion` and `hattrickfusion-ultimate` MSI build workflows.

Uses `Test-Path` to check for the existence of `install.log` and other files before attempting to copy them.

This prevents the build from failing if the installation step did not run or produce a log file, making post-failure analysis more reliable.