### PR TITLE
fix(workflows): Quote 'uses' paths in core and release workflows

### DIFF
--- a/.github/workflows/build-core-universal.yml
+++ b/.github/workflows/build-core-universal.yml
@@ -36,7 +36,7 @@ jobs:
     outputs:
       semver: ${{ steps.ver.outputs.semver }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: 'actions/checkout@v4'
         with: { fetch-depth: 0 }
 
       - name: 🏷️ Versioning
@@ -61,8 +61,8 @@ jobs:
     needs: preflight
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: 'actions/checkout@v4'
+      - uses: 'actions/setup-node@v4'
         with: { node-version: ${{ inputs.node_version }}, cache: 'npm', cache-dependency-path: 'web_platform/frontend/package-lock.json' }
 
       - name: 🔍 Verify Build Script Exists
@@ -75,7 +75,7 @@ jobs:
       - run: npm ci && npm run build
         working-directory: web_platform/frontend
 
-      - uses: actions/upload-artifact@v4
+      - uses: 'actions/upload-artifact@v4'
         with: { name: frontend-dist, path: web_platform/frontend/out }
 
   # =========================================================
@@ -87,12 +87,12 @@ jobs:
     runs-on: windows-latest
     strategy: { matrix: { arch: [x64, x86] } }
     steps:
-      - uses: actions/checkout@v4
+      - uses: 'actions/checkout@v4'
 
-      - uses: actions/download-artifact@v4
+      - uses: 'actions/download-artifact@v4'
         with: { name: frontend-dist, path: web_platform/frontend/out }
 
-      - uses: actions/setup-python@v5
+      - uses: 'actions/setup-python@v5'
         with: { python-version: ${{ inputs.python_version }}, architecture: ${{ matrix.arch }}, cache: 'pip' }
 
       # FIX: Replaced fragile backtick escape with robust multi-line commands
@@ -115,7 +115,7 @@ jobs:
             --add-data "web_service/backend;backend" `
             --add-data "web_platform/frontend/out;ui" `
             web_service/backend/service_entry.py
-      - uses: actions/upload-artifact@v4
+      - uses: 'actions/upload-artifact@v4'
         with: { name: backend-${{ matrix.arch }}, path: dist/fortuna-backend }
 
   # =========================================================
@@ -127,8 +127,8 @@ jobs:
     runs-on: windows-latest
     strategy: { matrix: { arch: [x64, x86] } }
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: 'actions/checkout@v4'
+      - uses: 'actions/download-artifact@v4'
         with: { name: backend-${{ matrix.arch }}, path: staging/backend }
 
       - name: 📝 Inject Restart Script
@@ -156,7 +156,7 @@ jobs:
             }
           } catch { Write-Warning "Canary scan failed or skipped: $_" }
 
-      - uses: actions/upload-artifact@v4
+      - uses: 'actions/upload-artifact@v4'
         with: { name: msi-${{ matrix.arch }}, path: Fortuna-${{ matrix.arch }}.msi }
 
   # =========================================================
@@ -169,7 +169,7 @@ jobs:
     strategy: { matrix: { arch: [x64, x86] } }
     steps:
       # NO CHECKOUT HERE - Pure Artifacts
-      - uses: actions/download-artifact@v4
+      - uses: 'actions/download-artifact@v4'
         with: { name: msi-${{ matrix.arch }} }
 
       - name: 🧹 Clean & Install
@@ -199,7 +199,7 @@ jobs:
     runs-on: windows-latest
     strategy: { matrix: { arch: [x64, x86] } }
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: 'actions/download-artifact@v4'
         with: { name: msi-${{ matrix.arch }} }
 
       - name: 💿 Re-Install for UI
@@ -212,7 +212,7 @@ jobs:
           npm install playwright; npx playwright install chromium --with-deps
           node -e "const { chromium } = require('playwright'); (async () => { const b = await chromium.launch(); const p = await b.newPage(); await p.goto('http://127.0.0.1:${{ inputs.service_port }}/docs'); await p.screenshot({path: 'proof.png'}); await b.close(); })();"
 
-      - uses: actions/upload-artifact@v4
+      - uses: 'actions/upload-artifact@v4'
         with: { name: proof-${{ matrix.arch }}, path: proof.png }
 
       - name: 🧹 Cleanup

--- a/.github/workflows/release-hattrick.yml
+++ b/.github/workflows/release-hattrick.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-core:
-    uses: ./.github/workflows/build-core-universal.yml
+    uses: './.github/workflows/build-core-universal.yml'
     with:
       enable_forensics: false
       enable_dietician: false
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: 'actions/download-artifact@v4'
         with: { pattern: msi-*, merge-multiple: true, path: release }
-      - uses: softprops/action-gh-release@v1
+      - uses: 'softprops/action-gh-release@v1'
         with: { files: release/* }

--- a/.github/workflows/release-supreme.yml
+++ b/.github/workflows/release-supreme.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   call-core:
-    uses: ./.github/workflows/build-core-universal.yml
+    uses: './.github/workflows/build-core-universal.yml'
     with:
       enable_forensics: true
       enable_dietician: true
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: 'actions/download-artifact@v4'
         with: { pattern: msi-*, merge-multiple: true, path: release }
       - run: cd release && sha256sum *.msi > SHASUMS256.txt
-      - uses: softprops/action-gh-release@v1
+      - uses: 'softprops/action-gh-release@v1'
         with: { files: release/*, generate_release_notes: true }


### PR DESCRIPTION
Encloses all `uses` paths in single quotes within the `build-core-universal.yml`, `release-hattrick.yml`, and `release-supreme.yml` workflow files.

This change prevents potential YAML syntax errors that can occur when the `uses` string is not quoted, ensuring the workflows can be parsed correctly by the GitHub Actions runner.