### PR TITLE
fix(workflows): Resolve multiple CI errors and improve script robustness

### DIFF
--- a/.github/workflows/build-core-universal.yml
+++ b/.github/workflows/build-core-universal.yml
@@ -37,7 +37,8 @@ jobs:
       semver: ${{ steps.ver.outputs.semver }}
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
 
       - name: 🏷️ Versioning
         id: ver
@@ -63,7 +64,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: ${{ inputs.node_version }}, cache: 'npm', cache-dependency-path: 'web_platform/frontend/package-lock.json' }
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: 'npm'
+          cache-dependency-path: 'web_platform/frontend/package-lock.json'
 
       - name: 🔍 Verify Build Script Exists
         shell: pwsh
@@ -76,7 +80,9 @@ jobs:
         working-directory: web_platform/frontend
 
       - uses: actions/upload-artifact@v4
-        with: { name: frontend-dist, path: web_platform/frontend/out }
+        with:
+          name: frontend-dist
+          path: web_platform/frontend/out
 
   # =========================================================
   # 3. BUILD BACKEND
@@ -90,10 +96,15 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v4
-        with: { name: frontend-dist, path: web_platform/frontend/out }
+        with:
+          name: frontend-dist
+          path: web_platform/frontend/out
 
       - uses: actions/setup-python@v5
-        with: { python-version: ${{ inputs.python_version }}, architecture: ${{ matrix.arch }}, cache: 'pip' }
+        with:
+          python-version: ${{ inputs.python_version }}
+          architecture: ${{ matrix.arch }}
+          cache: 'pip'
 
       # FIX: Replaced fragile backtick escape with robust multi-line commands
       - name: 🧾 Arch Constraints
@@ -116,7 +127,9 @@ jobs:
             --add-data "web_platform/frontend/out;ui" `
             web_service/backend/service_entry.py
       - uses: actions/upload-artifact@v4
-        with: { name: backend-${{ matrix.arch }}, path: dist/fortuna-backend }
+        with:
+          name: backend-${{ matrix.arch }}
+          path: dist/fortuna-backend
 
   # =========================================================
   # 4. PACKAGE MSI
@@ -129,7 +142,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
-        with: { name: backend-${{ matrix.arch }}, path: staging/backend }
+        with:
+          name: backend-${{ matrix.arch }}
+          path: staging/backend
 
       - name: 📝 Inject Restart Script
         run: echo net stop FortunaWebService > staging\backend\restart_service.bat & echo net start FortunaWebService >> staging\backend\restart_service.bat
@@ -138,7 +153,11 @@ jobs:
       - name: ⚖️ The Dietician
         if: ${{ inputs.enable_dietician }}
         shell: pwsh
-        run: Write-Host "Payload: $((Get-ChildItem staging -Recurse | Measure-Object -Sum Length).Sum / 1MB) MB"
+        run: |
+          $sizeBytes = (Get-ChildItem staging -Recurse |
+                        Measure-Object -Property Length -Sum).Sum
+          $sizeMB = [math]::Round($sizeBytes / 1MB, 2)
+          Write-Host "Payload: $sizeMB MB"
 
       - name: 🔧 Setup WiX
         run: dotnet tool install --global wix --version ${{ inputs.wix_version }} && echo "$env:USERPROFILE\\.dotnet\\tools" >> $env:GITHUB_PATH
@@ -157,7 +176,9 @@ jobs:
           } catch { Write-Warning "Canary scan failed or skipped: $_" }
 
       - uses: actions/upload-artifact@v4
-        with: { name: msi-${{ matrix.arch }}, path: Fortuna-${{ matrix.arch }}.msi }
+        with:
+          name: msi-${{ matrix.arch }}
+          path: Fortuna-${{ matrix.arch }}.msi
 
   # =========================================================
   # 5. SMOKE TEST (Fast)
@@ -170,7 +191,8 @@ jobs:
     steps:
       # NO CHECKOUT HERE - Pure Artifacts
       - uses: actions/download-artifact@v4
-        with: { name: msi-${{ matrix.arch }} }
+        with:
+          name: msi-${{ matrix.arch }}
 
       - name: 🧹 Clean & Install
         shell: pwsh
@@ -200,7 +222,8 @@ jobs:
     strategy: { matrix: { arch: [x64, x86] } }
     steps:
       - uses: actions/download-artifact@v4
-        with: { name: msi-${{ matrix.arch }} }
+        with:
+          name: msi-${{ matrix.arch }}
 
       - name: 💿 Re-Install for UI
         shell: pwsh
@@ -213,7 +236,9 @@ jobs:
           node -e "const { chromium } = require('playwright'); (async () => { const b = await chromium.launch(); const p = await b.newPage(); await p.goto('http://127.0.0.1:${{ inputs.service_port }}/docs'); await p.screenshot({path: 'proof.png'}); await b.close(); })();"
 
       - uses: actions/upload-artifact@v4
-        with: { name: proof-${{ matrix.arch }}, path: proof.png }
+        with:
+          name: proof-${{ matrix.arch }}
+          path: proof.png
 
       - name: 🧹 Cleanup
         if: always()

--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -304,6 +304,7 @@ jobs:
             " a.zipfiles,",
             " a.datas,",
             " [],",
+            " exclude_binaries=False,",
             " name='fortuna-backend',",
             " debug=False,",
             " bootloader_ignore_signals=False,",
@@ -971,7 +972,7 @@ jobs:
 
           if (Test-Path $exe) {
             Write-Host "Starting backend for 10s health check..."
-            $proc = Start-Process -FilePath $exe -PassThru -WorkingDirectory ${{ env.INSTALL_ROOT }}
+            $proc = Start-Process -FilePath $exe -PassThru -WorkingDirectory "${{ env.INSTALL_ROOT }}"
             Start-Sleep -Seconds 10
             if (!$proc.HasExited) { Stop-Process -Id $proc.Id -Force; Write-Host "✅ Backend Alive" }
             else { Write-Error "❌ Backend crashed"; exit 1 }
@@ -989,7 +990,7 @@ jobs:
           if (-not (Test-Path $exe)) { throw "❌ Backend executable not found at $exe" }
 
           Write-Host "Starting backend..."
-          $proc = Start-Process -FilePath $exe -PassThru -WorkingDirectory $installRoot
+          $proc = Start-Process -FilePath $exe -PassThru -WorkingDirectory "$installRoot"
           try {
             Start-Sleep -Seconds 10
             if ($proc.HasExited) { throw "❌ Backend crashed immediately" }

--- a/.github/workflows/release-hattrick.yml
+++ b/.github/workflows/release-hattrick.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-core:
-    uses: ./.github/workflows/build-core-universal.yml
+    uses: './.github/workflows/build-core-universal.yml'
     with:
       enable_forensics: false
       enable_dietician: false
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: 'actions/download-artifact@v4'
         with: { pattern: msi-*, merge-multiple: true, path: release }
-      - uses: softprops/action-gh-release@v1
+      - uses: 'softprops/action-gh-release@v1'
         with: { files: release/* }

--- a/.github/workflows/release-supreme.yml
+++ b/.github/workflows/release-supreme.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   call-core:
-    uses: ./.github/workflows/build-core-universal.yml
+    uses: './.github/workflows/build-core-universal.yml'
     with:
       enable_forensics: true
       enable_dietician: true
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: 'actions/download-artifact@v4'
         with: { pattern: msi-*, merge-multiple: true, path: release }
       - run: cd release && sha256sum *.msi > SHASUMS256.txt
-      - uses: softprops/action-gh-release@v1
+      - uses: 'softprops/action-gh-release@v1'
         with: { files: release/*, generate_release_notes: true }


### PR DESCRIPTION
This commit addresses several distinct issues that were causing workflow failures:

1.  **Fixes PowerShell Path Quoting:** Encloses the `-WorkingDirectory` argument in double quotes in the `smoke-test` job of `build-electron-msi-gpt5.yml`. This resolves a critical error on x86 runners where paths with spaces and parentheses were being misinterpreted.

2.  **Corrects PowerShell Script Syntax:** Replaces a fragile, single-line script with a more robust multi-line version for calculating payload size in `build-core-universal.yml`, fixing a `Measure-Object` syntax error.

3.  **Improves YAML Syntax:** Refactors inline `with:` blocks to the standard multi-line format and quotes `uses:` paths in release workflows to improve readability and prevent potential parsing errors.