### PR TITLE
fix(ci): Add verbose logging to versioning step

### DIFF
--- a/.github/workflows/build-core-universal.yml
+++ b/.github/workflows/build-core-universal.yml
@@ -60,12 +60,32 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: 🏷️ Versioning
+      - name: 🏷️ Versioning - DETAILED LOGGING
         id: ver
         shell: pwsh
         run: |
-          $tag = git describe --tags --abbrev=0 2>$null; if (-not $tag) { $tag = "v0.0.0" }
-          "semver=$($tag -replace '^v','')" >> $env:GITHUB_OUTPUT
+          # Enable strict mode to immediately catch errors
+          Set-StrictMode -Version Latest
+
+          # 1. Attempt to get the latest tag, redirecting non-fatal errors to null
+          Write-Host "--- Attempting to find latest tag... ---"
+          $tag = git describe --tags --abbrev=0 2>$null
+
+          # 2. Check the result of the tag search
+          if ([string]::IsNullOrEmpty($tag)) {
+            Write-Host "INFO: No tag found. Defaulting to v0.0.0."
+            $tag = "v0.0.0"
+          } else {
+            Write-Host "SUCCESS: Found tag: $tag"
+          }
+
+          # 3. Process and set the semver output
+          $semver = $tag -replace '^v',''
+          Write-Host "Processed SemVer output: $semver"
+
+          # 4. Set the GitHub output variable
+          "semver=$semver" >> $env:GITHUB_OUTPUT
+          Write-Host "--- Versioning step complete. ---"
 
       - name: 🔎 Forensic Asset Verification
         if: ${{ inputs.enable_forensics }}


### PR DESCRIPTION
Replaced the condensed 'Versioning' step in the 'build-core-universal.yml' reusable workflow with a verbose, multi-line PowerShell script.

This change is intended to diagnose a recurring crash where the 'git describe' command fails with exit code 1. The new script includes:
- Strict mode for error handling.
- Step-by-step logging for each action (tag lookup, fallback, processing, and output setting).
- A safe fallback to 'v0.0.0' when no tags are found.

This improves the debuggability of the preflight job without changing the core versioning logic.