### PR TITLE
fix(ci): Add verbose logging and correct conditionals in core workflow

### DIFF
--- a/.github/workflows/build-core-universal.yml
+++ b/.github/workflows/build-core-universal.yml
@@ -60,15 +60,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: 🏷️ Versioning
+      - name: 🏷️ Versioning - DETAILED LOGGING
         id: ver
         shell: pwsh
         run: |
-          $tag = git describe --tags --abbrev=0 2>$null; if (-not $tag) { $tag = "v0.0.0" }
-          "semver=$($tag -replace '^v','')" >> $env:GITHUB_OUTPUT
+          # Enable strict mode to immediately catch errors
+          Set-StrictMode -Version Latest
+
+          # 1. Attempt to get the latest tag, redirecting non-fatal errors to null
+          Write-Host "--- Attempting to find latest tag... ---"
+          $tag = git describe --tags --abbrev=0 2>$null
+
+          # 2. Check the result of the tag search
+          if ([string]::IsNullOrEmpty($tag)) {
+            Write-Host "INFO: No tag found. Defaulting to v0.0.0."
+            $tag = "v0.0.0"
+          } else {
+            Write-Host "SUCCESS: Found tag: $tag"
+          }
+
+          # 3. Process and set the semver output
+          $semver = $tag -replace '^v',''
+          Write-Host "Processed SemVer output: $semver"
+
+          # 4. Set the GitHub output variable
+          "semver=$semver" >> $env:GITHUB_OUTPUT
+          Write-Host "--- Versioning step complete. ---"
 
       - name: 🔎 Forensic Asset Verification
-        if: ${{ inputs.enable_forensics }}
+        if: ${{ inputs.enable_forensics == 'true' }}
         shell: pwsh
         run: |
           # Checking paths based on Supreme Combo structure
@@ -187,7 +207,7 @@ jobs:
           echo net start FortunaWebService >> staging\backend\restart_service.bat
 
       - name: ⚖️ The Dietician
-        if: ${{ inputs.enable_dietician }}
+        if: ${{ inputs.enable_dietician == 'true' }}
         shell: pwsh
         run: |
           # 🎯 CRITICAL FIX: Indentation corrected here.
@@ -205,7 +225,7 @@ jobs:
           wix build build_wix/Product_WithService.wxs -arch ${{ matrix.arch }} -o Fortuna-${{ matrix.arch }}.msi -d Version="${{ needs.preflight.outputs.semver }}" -d SourceDir="staging"
 
       - name: 🦜 The Canary
-        if: ${{ inputs.enable_canary }}
+        if: ${{ inputs.enable_canary == 'true' }}
         shell: pwsh
         run: |
           # 🟢 Corrected: Multi-line script indentation fixed
@@ -261,7 +281,7 @@ jobs:
   ui-proof:
     name: 📸 Paparazzi (${{ matrix.arch }})
     needs: smoke-test
-    if: ${{ inputs.enable_paparazzi }}
+    if: ${{ inputs.enable_paparazzi == 'true' }}
     runs-on: windows-latest
     strategy:
       matrix:


### PR DESCRIPTION
This commit applies two critical fixes to the `.github/workflows/build-core-universal.yml` reusable workflow to improve debugging and prevent crashes.

1.  **Verbose Logging for Versioning:** The 'Versioning' step has been expanded from a condensed one-liner into a multi-line PowerShell script. This adds detailed logging for each stage of the versioning process (tag lookup, fallback, processing) to help diagnose a recurring `git describe` failure.

2.  **Corrected Feature Toggle Conditionals:** The `if` conditions for all feature toggles (`enable_forensics`, `enable_dietician`, `enable_canary`, `enable_paparazzi`) have been updated to explicitly compare against the string `'true'`. This prevents a suspected type coercion error in GitHub Actions where string inputs were being evaluated incorrectly as booleans, causing the workflow to crash after the versioning step.