### PR TITLE
fix(ci): Use single quotes in universal workflow PowerShell scripts

### DIFF
--- a/.github/workflows/build-core-universal.yml
+++ b/.github/workflows/build-core-universal.yml
@@ -5,34 +5,43 @@ on:
     inputs:
       # --- VERSIONING ---
       node_version:
+        description: 'Node.js version to use'
         type: string
         default: '20'
       python_version:
+        description: 'Python version to use'
         type: string
         default: '3.11'
       wix_version:
+        description: 'WiX Toolset version'
         type: string
         default: '4.0.5'
 
       # --- FEATURE TOGGLES ---
       enable_dietician:
+        description: 'Run pre-package size analysis'
         type: boolean
         default: false
       enable_canary:
+        description: 'Run Windows Defender malware scan'
         type: boolean
         default: false
       enable_paparazzi:
+        description: 'Run Playwright visual verification'
         type: boolean
         default: false
       enable_forensics:
+        description: 'Run deep asset verification pre-flight'
         type: boolean
         default: false
 
       # --- CONFIG ---
       service_port:
+        description: 'Localhost port for the backend service'
         type: string
         default: '8102'
       skip_tests:
+        description: 'Skip heavy unit tests'
         type: boolean
         default: false
 
@@ -42,10 +51,19 @@ on:
       TVG_API_KEY:
         required: false
 
+# -------------------------------------------------------------------------
+# 2. GLOBAL PERMISSIONS & ENV
+# -------------------------------------------------------------------------
+permissions:
+  contents: read
+
 env:
   DOTNET_VERSION: '8.0.x'
   FORTUNA_ENV: smoke-test
 
+# -------------------------------------------------------------------------
+# 3. JOBS DEFINITION
+# -------------------------------------------------------------------------
 jobs:
   # =========================================================
   # 1. PREFLIGHT DIAGNOSTICS
@@ -53,6 +71,7 @@ jobs:
   preflight:
     name: 🔍 Preflight Diagnostics
     runs-on: windows-latest
+    timeout-minutes: 10
     outputs:
       semver: ${{ steps.ver.outputs.semver }}
       build_timestamp: ${{ steps.env.outputs.build_timestamp }}
@@ -72,7 +91,7 @@ jobs:
         id: env
         shell: pwsh
         run: |
-          Write-Host "::group::🖥️ Runner Environment"
+          Write-Host '::group::🖥️ Runner Environment'
 
           $diag = @{
             runner = @{
@@ -92,18 +111,18 @@ jobs:
             }
           }
 
-          Write-Host "┌─────────────────────────────────────────────────────────────┐"
-          Write-Host "│                    RUNNER INFO                              │"
-          Write-Host "├─────────────────────────────────────────────────────────────┤"
+          Write-Host '┌─────────────────────────────────────────────────────────────┐'
+          Write-Host '│                    RUNNER INFO                              │'
+          Write-Host '├─────────────────────────────────────────────────────────────┤'
           Write-Host "│ OS:        $($diag.runner.os.PadRight(47)) │"
           Write-Host "│ Arch:      $($diag.runner.arch.PadRight(47)) │"
           Write-Host "│ Name:      $($diag.runner.name.PadRight(47)) │"
-          Write-Host "└─────────────────────────────────────────────────────────────┘"
+          Write-Host '└─────────────────────────────────────────────────────────────┘'
 
           # System Resources
           Write-Host "`n┌─────────────────────────────────────────────────────────────┐"
-          Write-Host "│                  SYSTEM RESOURCES                           │"
-          Write-Host "├─────────────────────────────────────────────────────────────┤"
+          Write-Host '│                  SYSTEM RESOURCES                           │'
+          Write-Host '├─────────────────────────────────────────────────────────────┤'
 
           $disk = Get-PSDrive C
           $diskFreeGB = [math]::Round($disk.Free/1GB, 2)
@@ -120,35 +139,37 @@ jobs:
           $cpuInfo = Get-CimInstance Win32_Processor | Select-Object -First 1
 
           Write-Host "│ CPU:       $($cpuInfo.Name.Substring(0, [Math]::Min(47, $cpuInfo.Name.Length)).PadRight(47)) │"
-          Write-Host "│ Cores:     $($(\"$($cpuInfo.NumberOfCores) cores / $($cpuInfo.NumberOfLogicalProcessors) threads\").PadRight(47)) │"
-          Write-Host "│ RAM:       $($(\"$ramFreeGB GB free / $ramTotalGB GB total ($ramPct% used)\").PadRight(47)) │"
-          Write-Host "│ Disk (C:): $($(\"$diskFreeGB GB free / $diskTotalGB GB total ($diskPct% used)\").PadRight(47)) │"
-          Write-Host "└─────────────────────────────────────────────────────────────┘"
+          Write-Host "│ Cores:     $($("$($cpuInfo.NumberOfCores) cores / $($cpuInfo.NumberOfLogicalProcessors) threads").PadRight(47)) │"
+          Write-Host "│ RAM:       $($("$ramFreeGB GB free / $ramTotalGB GB total ($ramPct% used)").PadRight(47)) │"
+          Write-Host "│ Disk (C:): $($("$diskFreeGB GB free / $diskTotalGB GB total ($diskPct% used)").PadRight(47)) │"
+          Write-Host '└─────────────────────────────────────────────────────────────┘'
 
           # Resource warnings
           if ($diskFreeGB -lt 10) {
-            Write-Host "::warning::Low disk space: Only $diskFreeGB GB free"
+            Write-Host '::warning::Low disk space: Only $diskFreeGB GB free'
           }
           if ($ramFreeGB -lt 2) {
-            Write-Host "::warning::Low memory: Only $ramFreeGB GB free"
+            Write-Host '::warning::Low memory: Only $ramFreeGB GB free'
           }
 
           # Outputs
-          $timestamp = Get-Date -Format \"yyyy-MM-ddTHH:mm:ssZ\"
+          $timestamp = Get-Date -Format 'yyyy-MM-ddTHH:mm:ssZ'
           $shortSha = $env:GITHUB_SHA.Substring(0,7)
-          $isTag = if ($env:GITHUB_REF -like \"refs/tags/*\") { \"true\" } else { \"false\" }
-          $branch = switch -Regex ($env:GITHUB_REF) {
-            \"^refs/heads/\" { $env:GITHUB_REF -replace \"refs/heads/\",\"\" }
-            \"^refs/tags/\"  { $env:GITHUB_REF -replace \"refs/tags/\",\"\" }
-            default        { $env:GITHUB_REF }
-          }
 
-          \"build_timestamp=$timestamp\" >> $env:GITHUB_OUTPUT
-          \"short_sha=$shortSha\" >> $env:GITHUB_OUTPUT
-          \"is_tag=$isTag\" >> $env:GITHUB_OUTPUT
-          \"branch=$branch\" >> $env:GITHUB_OUTPUT
+          # FIX: Use single quotes to prevent JSON escaping issues
+          $isTag = 'false'
+          if ($env:GITHUB_REF -like 'refs/tags/*') { $isTag = 'true' }
 
-          Write-Host "::endgroup::"
+          $branch = $env:GITHUB_REF
+          if ($env:GITHUB_REF -match '^refs/heads/') { $branch = $env:GITHUB_REF -replace 'refs/heads/','' }
+          if ($env:GITHUB_REF -match '^refs/tags/') { $branch = $env:GITHUB_REF -replace 'refs/tags/','' }
+
+          "build_timestamp=$timestamp" >> $env:GITHUB_OUTPUT
+          "short_sha=$shortSha" >> $env:GITHUB_OUTPUT
+          "is_tag=$isTag" >> $env:GITHUB_OUTPUT
+          "branch=$branch" >> $env:GITHUB_OUTPUT
+
+          Write-Host '::endgroup::'
 
       # -------------------------------------------------------
       # INPUT VALIDATION
@@ -157,94 +178,94 @@ jobs:
         id: inputs
         shell: pwsh
         run: |
-          Write-Host "::group::✅ Input Validation"
+          Write-Host '::group::✅ Input Validation'
 
           $errors = [System.Collections.ArrayList]@()
           $warnings = [System.Collections.ArrayList]@()
 
-          Write-Host "┌─────────────────────────────────────────────────────────────┐"
-          Write-Host "│                   INPUT PARAMETERS                          │"
-          Write-Host "├─────────────────────────────────────────────────────────────┤"
+          Write-Host '┌─────────────────────────────────────────────────────────────┐'
+          Write-Host '│                   INPUT PARAMETERS                          │'
+          Write-Host '├─────────────────────────────────────────────────────────────┤'
 
           # Node version
-          $nodeVer = \"${{ inputs.node_version }}\"
+          $nodeVer = "${{ inputs.node_version }}"
           $nodeValid = $nodeVer -match '^\\d+(\\.\\d+)?(\\.\\d+)?$'
-          $nodeIcon = if ($nodeValid) { \"✅\" } else { \"❌\" }
+          $nodeIcon = if ($nodeValid) { '✅' } else { '❌' }
           Write-Host "│ $nodeIcon Node Version:    $($nodeVer.PadRight(43)) │"
-          if (-not $nodeValid) { [void]$errors.Add(\"Invalid node_version: $nodeVer\") }
+          if (-not $nodeValid) { [void]$errors.Add("Invalid node_version: $nodeVer") }
 
           # Python version
-          $pyVer = \"${{ inputs.python_version }}\"
+          $pyVer = "${{ inputs.python_version }}"
           $pyValid = $pyVer -match '^\\d+\\.\\d+(\\.\\d+)?$'
-          $pyIcon = if ($pyValid) { \"✅\" } else { \"❌\" }
+          $pyIcon = if ($pyValid) { '✅' } else { '❌' }
           Write-Host "│ $pyIcon Python Version:  $($pyVer.PadRight(43)) │"
-          if (-not $pyValid) { [void]$errors.Add(\"Invalid python_version: $pyVer\") }
+          if (-not $pyValid) { [void]$errors.Add("Invalid python_version: $pyVer") }
 
           # WiX version
-          $wixVer = \"${{ inputs.wix_version }}\"
+          $wixVer = "${{ inputs.wix_version }}"
           $wixValid = $wixVer -match '^\\d+\\.\\d+\\.\\d+$'
-          $wixIcon = if ($wixValid) { \"✅\" } else { \"❌\" }
+          $wixIcon = if ($wixValid) { '✅' } else { '❌' }
           Write-Host "│ $wixIcon WiX Version:     $($wixVer.PadRight(43)) │"
-          if (-not $wixValid) { [void]$errors.Add(\"Invalid wix_version: $wixVer\") }
+          if (-not $wixValid) { [void]$errors.Add("Invalid wix_version: $wixVer") }
 
           # Port validation
-          $port = \"${{ inputs.service_port }}\"
+          $port = "${{ inputs.service_port }}"
           $portNum = 0
           $portValid = [int]::TryParse($port, [ref]$portNum) -and $portNum -ge 1 -and $portNum -le 65535
-          $portIcon = if ($portValid) { \"✅\" } else { \"❌\" }
+          $portIcon = if ($portValid) { '✅' } else { '❌' }
           Write-Host "│ $portIcon Service Port:   $($port.PadRight(43)) │"
           if (-not $portValid) {
-            [void]$errors.Add(\"Invalid service_port: $port (must be 1-65535)\")
+            [void]$errors.Add("Invalid service_port: $port (must be 1-65535)")
           } elseif ($portNum -lt 1024) {
-            [void]$warnings.Add(\"Port $port is privileged (<1024)\")
+            [void]$warnings.Add("Port $port is privileged (<1024)")
           } elseif ($portNum -lt 49152) {
             # Check for common conflicts
-            $commonPorts = @{ 8080=\"HTTP-Alt\"; 3000=\"Dev Server\"; 5000=\"Flask\"; 8000=\"Django\" }
+            $commonPorts = @{ 8080='HTTP-Alt'; 3000='Dev Server'; 5000='Flask'; 8000='Django' }
             if ($commonPorts.ContainsKey($portNum)) {
-              [void]$warnings.Add(\"Port $port commonly used by $($commonPorts[$portNum])\")
+              [void]$warnings.Add("Port $port commonly used by $($commonPorts[$portNum])")
             }
           }
 
-          Write-Host "├─────────────────────────────────────────────────────────────┤"
-          Write-Host "│                   FEATURE TOGGLES                           │"
-          Write-Host "├─────────────────────────────────────────────────────────────┤"
+          Write-Host '├─────────────────────────────────────────────────────────────┤'
+          Write-Host '│                   FEATURE TOGGLES                           │'
+          Write-Host '├─────────────────────────────────────────────────────────────┤'
 
           $features = @(
-            @{ name = \"Dietician\"; value = \"${{ inputs.enable_dietician }}\" },
-            @{ name = \"Canary\"; value = \"${{ inputs.enable_canary }}\" },
-            @{ name = \"Paparazzi\"; value = \"${{ inputs.enable_paparazzi }}\" },
-            @{ name = \"Forensics\"; value = \"${{ inputs.enable_forensics }}\" },
-            @{ name = \"Skip Tests\"; value = \"${{ inputs.skip_tests }}\" }
+            @{ name = 'Dietician'; value = "${{ inputs.enable_dietician }}" },
+            @{ name = 'Canary'; value = "${{ inputs.enable_canary }}" },
+            @{ name = 'Paparazzi'; value = "${{ inputs.enable_paparazzi }}" },
+            @{ name = 'Forensics'; value = "${{ inputs.enable_forensics }}" },
+            @{ name = 'Skip Tests'; value = "${{ inputs.skip_tests }}" }
           )
 
           foreach ($f in $features) {
-            $icon = if ($f.value -eq 'true') { \"🟢\" } else { \"⚪\" }
-            $status = if ($f.value -eq 'true') { \"ENABLED\" } else { \"disabled\" }
+            $icon = if ($f.value -eq 'true') { '🟢' } else { '⚪' }
+            $status = if ($f.value -eq 'true') { 'ENABLED' } else { 'disabled' }
             Write-Host "│ $icon $($f.name.PadRight(14)): $($status.PadRight(41)) │"
           }
 
-          Write-Host "└─────────────────────────────────────────────────────────────┘"
+          Write-Host '└─────────────────────────────────────────────────────────────┘'
 
           # Report warnings and errors
           if ($warnings.Count -gt 0) {
-            Write-Host \"`n⚠️ WARNINGS ($($warnings.Count)):\"
+            Write-Host "`n⚠️ WARNINGS ($($warnings.Count)):"
             foreach ($w in $warnings) {
-              Write-Host \"  • $w\"
-              Write-Host \"::warning::$w\"
+              Write-Host "  • $w"
+              Write-Host "::warning::$w"
             }
           }
 
           if ($errors.Count -gt 0) {
-            Write-Host \"`n❌ ERRORS ($($errors.Count)):\" -ForegroundColor Red
+            Write-Host "`n❌ ERRORS ($($errors.Count)):" -ForegroundColor Red
             foreach ($e in $errors) {
-              Write-Host \"  • $e\" -ForegroundColor Red
-              Write-Host \"::error::$e\"
+              Write-Host "  • $e" -ForegroundColor Red
+              Write-Host "::error::$e"
             }
-            throw \"Input validation failed with $($errors.Count) error(s)\"
+            throw "Input validation failed with $($errors.Count) error(s)"
           }
 
-          Write-Host \"`n✅ All inputs validated successfully\"
-          Write-Host \"::endgroup::\"
+          Write-Host "`n✅ All inputs validated successfully"
+          Write-Host '::endgroup::'
 
       # -------------------------------------------------------
       # TOOL CHAIN VERIFICATION
@@ -252,21 +273,21 @@ jobs:
       - name: 🔧 Tool Chain Verification
         shell: pwsh
         run: |
-          Write-Host \"::group::🔧 Tool Chain Verification\"
+          Write-Host '::group::🔧 Tool Chain Verification'
 
-          Write-Host \"┌─────────────────────────────────────────────────────────────┐\"
-          Write-Host \"│                   INSTALLED TOOLS                           │\"
-          Write-Host \"├──────────────────┬──────────────────────────────────────────┤\"
-          Write-Host \"│ Tool             │ Version / Status                         │\"
-          Write-Host \"├──────────────────┼──────────────────────────────────────────┤\"
+          Write-Host '┌─────────────────────────────────────────────────────────────┐'
+          Write-Host '│                   INSTALLED TOOLS                           │'
+          Write-Host '├──────────────────┬──────────────────────────────────────────┤'
+          Write-Host '│ Tool             │ Version / Status                         │'
+          Write-Host '├──────────────────┼──────────────────────────────────────────┤'
 
           $tools = @(
-            @{ name = \"git\"; cmd = \"git --version\"; parse = { $args[0] -replace 'git version ','' } },
-            @{ name = \"dotnet\"; cmd = \"dotnet --version\"; parse = { $args[0] } },
-            @{ name = \"msiexec\"; cmd = \"msiexec /?\"; parse = { \"Available (Windows Installer)\" } },
-            @{ name = \"sc.exe\"; cmd = \"sc.exe query type= service\"; parse = { \"Available (Service Control)\" } },
-            @{ name = \"PowerShell\"; cmd = '$PSVersionTable.PSVersion.ToString()'; parse = { $args[0] } },
-            @{ name = \"Windows SDK\"; cmd = 'if (Test-Path \"C:\\Program Files (x86)\\Windows Kits\\10\") { \"Installed\" } else { \"Not Found\" }'; parse = { $args[0] } }
+            @{ name = 'git'; cmd = 'git --version'; parse = { $args[0] -replace 'git version ','' } },
+            @{ name = 'dotnet'; cmd = 'dotnet --version'; parse = { $args[0] } },
+            @{ name = 'msiexec'; cmd = 'msiexec /?'; parse = { 'Available (Windows Installer)' } },
+            @{ name = 'sc.exe'; cmd = 'sc.exe query type= service'; parse = { 'Available (Service Control)' } },
+            @{ name = 'PowerShell'; cmd = '$PSVersionTable.PSVersion.ToString()'; parse = { $args[0] } },
+            @{ name = 'Windows SDK'; cmd = 'if (Test-Path "C:\\Program Files (x86)\\Windows Kits\\10") { "Installed" } else { "Not Found" }'; parse = { $args[0] } }
           )
 
           $toolStatus = @{}
@@ -274,30 +295,30 @@ jobs:
             try {
               $result = Invoke-Expression $tool.cmd 2>&1 | Select-Object -First 1
               $version = & $tool.parse $result
-              $icon = \"✅\"
+              $icon = '✅'
               $toolStatus[$tool.name] = $true
             } catch {
-              $version = \"NOT AVAILABLE\"
-              $icon = \"❌\"
+              $version = 'NOT AVAILABLE'
+              $icon = '❌'
               $toolStatus[$tool.name] = $false
             }
-            Write-Host \"│ $icon $($tool.name.PadRight(14)) │ $($version.ToString().PadRight(40)) │\"
+            Write-Host "│ $icon $($tool.name.PadRight(14)) │ $($version.ToString().PadRight(40)) │"
           }
 
-          Write-Host \"└──────────────────┴──────────────────────────────────────────┘\"
+          Write-Host '└──────────────────┴──────────────────────────────────────────┘'
 
           # .NET SDKs detail
-          Write-Host \"`n📦 .NET SDKs Installed:\"
-          dotnet --list-sdks 2>$null | ForEach-Object { Write-Host \"   $_\" }
+          Write-Host "`n📦 .NET SDKs Installed:"
+          dotnet --list-sdks 2>$null | ForEach-Object { Write-Host "   $_" }
 
           # Check for critical tool failures
-          $criticalTools = @(\"git\", \"dotnet\", \"msiexec\")
+          $criticalTools = @('git', 'dotnet', 'msiexec')
           $missingCritical = $criticalTools | Where-Object { -not $toolStatus[$_] }
           if ($missingCritical) {
-            throw \"Critical tools missing: $($missingCritical -join ', ')\"
+            throw "Critical tools missing: $($missingCritical -join ', ')"
           }
 
-          Write-Host \"::endgroup::\"
+          Write-Host '::endgroup::'
 
       # -------------------------------------------------------
       # GIT STATE & VERSIONING
@@ -306,72 +327,72 @@ jobs:
         id: ver
         shell: pwsh
         run: |
-          Write-Host \"::group::🏷️ Git State & Versioning\"
+          Write-Host '::group::🏷️ Git State & Versioning'
 
           # Ensure we have all tags
           git fetch --prune --unshallow --tags 2>$null
 
-          Write-Host \"┌─────────────────────────────────────────────────────────────┐\"
-          Write-Host \"│                    GIT STATE                                │\"
-          Write-Host \"├─────────────────────────────────────────────────────────────┤\"
+          Write-Host '┌─────────────────────────────────────────────────────────────┐'
+          Write-Host '│                    GIT STATE                                │'
+          Write-Host '├─────────────────────────────────────────────────────────────┤'
 
           $branch = git rev-parse --abbrev-ref HEAD 2>$null
           $commit = git rev-parse HEAD 2>$null
           $shortSha = git rev-parse --short HEAD 2>$null
           $commitCount = git rev-list --count HEAD 2>$null
-          $lastCommitMsg = git log -1 --pretty=format:\"%s\" 2>$null
-          $lastCommitAuthor = git log -1 --pretty=format:\"%an\" 2>$null
-          $lastCommitDate = git log -1 --pretty=format:\"%ci\" 2>$null
+          $lastCommitMsg = git log -1 --pretty=format:"%s" 2>$null
+          $lastCommitAuthor = git log -1 --pretty=format:"%an" 2>$null
+          $lastCommitDate = git log -1 --pretty=format:"%ci" 2>$null
 
-          Write-Host \"│ Branch:      $($branch.PadRight(45)) │\"
-          Write-Host \"│ Commit:      $($shortSha.PadRight(45)) │\"
-          Write-Host \"│ Full SHA:    $($commit.Substring(0,40).PadRight(45)) │\"
-          Write-Host \"│ Total:       $($(\"$commitCount commits\").PadRight(45)) │\"
-          Write-Host \"├─────────────────────────────────────────────────────────────┤\"
-          Write-Host \"│ Last Commit: $($lastCommitMsg.Substring(0, [Math]::Min(45, $lastCommitMsg.Length)).PadRight(45)) │\"
-          Write-Host \"│ Author:      $($lastCommitAuthor.PadRight(45)) │\"
-          Write-Host \"│ Date:        $($lastCommitDate.PadRight(45)) │\"
-          Write-Host \"└─────────────────────────────────────────────────────────────┘\"
+          Write-Host "│ Branch:      $($branch.PadRight(45)) │"
+          Write-Host "│ Commit:      $($shortSha.PadRight(45)) │"
+          Write-Host "│ Full SHA:    $($commit.Substring(0,40).PadRight(45)) │"
+          Write-Host "│ Total:       $("$commitCount commits").PadRight(45) │"
+          Write-Host '├─────────────────────────────────────────────────────────────┤'
+          Write-Host "│ Last Commit: $($lastCommitMsg.Substring(0, [Math]::Min(45, $lastCommitMsg.Length)).PadRight(45)) │"
+          Write-Host "│ Author:      $($lastCommitAuthor.PadRight(45)) │"
+          Write-Host "│ Date:        $($lastCommitDate.PadRight(45)) │"
+          Write-Host '└─────────────────────────────────────────────────────────────┘'
 
           # Tag analysis
-          Write-Host \"`n┌─────────────────────────────────────────────────────────────┐\"
-          Write-Host \"│                   TAG ANALYSIS                              │\"
-          Write-Host \"├─────────────────────────────────────────────────────────────┤\"
+          Write-Host "`n┌─────────────────────────────────────────────────────────────┐"
+          Write-Host '│                   TAG ANALYSIS                              │'
+          Write-Host '├─────────────────────────────────────────────────────────────┤'
 
           $allTags = git tag --list 2>$null
-          $tagCount = if ($allTags) { ($allTags -split \"`n\" | Where-Object { $_ }).Count } else { 0 }
+          $tagCount = if ($allTags) { ($allTags -split "`n" | Where-Object { $_ }).Count } else { 0 }
 
-          Write-Host \"│ Total Tags: $($tagCount.ToString().PadRight(46)) │\"
+          Write-Host "│ Total Tags: $($tagCount.ToString().PadRight(46)) │"
 
           if ($tagCount -gt 0) {
-            Write-Host \"├─────────────────────────────────────────────────────────────┤\"
-            Write-Host \"│ Recent Tags (newest first):                                 │\"
+            Write-Host '├─────────────────────────────────────────────────────────────┤'
+            Write-Host '│ Recent Tags (newest first):                                 │'
             $recentTags = git tag --list --sort=-version:refname 2>$null | Select-Object -First 5
             foreach ($t in $recentTags) {
-              Write-Host \"│   • $($t.PadRight(53)) │\"
+              Write-Host "│   • $($t.PadRight(53)) │"
             }
           }
-          Write-Host \"└─────────────────────────────────────────────────────────────┘\"
+          Write-Host '└─────────────────────────────────────────────────────────────┘'
 
           # Version detection
-          Write-Host \"`n🔢 VERSION DETECTION:\"
+          Write-Host "`n🔢 VERSION DETECTION:"
           $tag = git describe --tags --abbrev=0 2>$null
           $descFull = git describe --tags --always 2>$null
           $commitsAhead = 0
 
           if ([string]::IsNullOrEmpty($tag)) {
-            Write-Host \"   ⚠️ No tags found in repository\"
-            Write-Host \"   📦 Using fallback version: v0.0.0\"
-            Write-Host \"::warning::No git tags found. Using default version v0.0.0\"
-            $tag = \"v0.0.0\"
+            Write-Host "   ⚠️ No tags found in repository"
+            Write-Host "   📦 Using fallback version: v0.0.0"
+            Write-Host '::warning::No git tags found. Using default version v0.0.0'
+            $tag = "v0.0.0"
           } else {
-            Write-Host \"   Latest Tag: $tag\"
-            Write-Host \"   Full Describe: $descFull\"
+            Write-Host "   Latest Tag: $tag"
+            Write-Host "   Full Describe: $descFull"
 
             # Check commits ahead of tag
-            $commitsAhead = git rev-list \"$tag..HEAD\" --count 2>$null
+            $commitsAhead = git rev-list "$tag..HEAD" --count 2>$null
             if ($commitsAhead -gt 0) {
-              Write-Host \"   ⚠️ $commitsAhead commit(s) ahead of latest tag\"
+              Write-Host "   ⚠️ $commitsAhead commit(s) ahead of latest tag"
             }
           }
 
@@ -379,36 +400,36 @@ jobs:
 
           # Validate semver
           if ($semver -match '^\\d+\\.\\d+\\.\\d+(-[a-zA-Z0-9.-]+)?(\\+[a-zA-Z0-9.-]+)?$') {
-            Write-Host \"   ✅ Valid SemVer format\"
+            Write-Host "   ✅ Valid SemVer format"
           } else {
-            Write-Host \"   ⚠️ Non-standard version format: $semver\"
-            Write-Host \"::warning::Version '$semver' does not follow standard SemVer\"
+            Write-Host "   ⚠️ Non-standard version format: $semver"
+            Write-Host "::warning::Version '$semver' does not follow standard SemVer"
           }
 
-          Write-Host \"\"
-          Write-Host \"   ╔═══════════════════════════════════════╗\"
-          Write-Host \"   ║  📦 BUILD VERSION: $($semver.PadRight(18)) ║\"
-          Write-Host \"   ╚═══════════════════════════════════════╝\"
+          Write-Host ""
+          Write-Host "   ╔═══════════════════════════════════════╗"
+          Write-Host "   ║  📦 BUILD VERSION: $($semver.PadRight(18)) ║"
+          Write-Host "   ╚═══════════════════════════════════════╝"
 
-          \"semver=$semver\" >> $env:GITHUB_OUTPUT
+          "semver=$semver" >> $env:GITHUB_OUTPUT
 
           # Dirty state check
-          Write-Host \"`n🧹 WORKING DIRECTORY STATUS:\"
+          Write-Host "`n🧹 WORKING DIRECTORY STATUS:"
           $status = git status --porcelain 2>$null
           if ($status) {
-            $changedFiles = ($status -split \"`n\" | Where-Object { $_ }).Count
-            Write-Host \"   ⚠️ $changedFiles uncommitted change(s) detected:\"
-            $status -split \"`n\" | Select-Object -First 5 | ForEach-Object {
-              Write-Host \"      $_\"
+            $changedFiles = ($status -split "`n" | Where-Object { $_ }).Count
+            Write-Host "   ⚠️ $changedFiles uncommitted change(s) detected:"
+            $status -split "`n" | Select-Object -First 5 | ForEach-Object {
+              Write-Host "      $_"
             }
             if ($changedFiles -gt 5) {
-              Write-Host \"      ... and $($changedFiles - 5) more\"
+              Write-Host "      ... and $($changedFiles - 5) more"
             }
           } else {
-            Write-Host \"   ✅ Working directory is clean\"
+            Write-Host "   ✅ Working directory is clean"
           }
 
-          Write-Host \"::endgroup::\"
+          Write-Host '::endgroup::'
 
       - name: ✨ Runner Stabilization
         shell: cmd
@@ -425,81 +446,81 @@ jobs:
         id: assets
         shell: pwsh
         run: |
-          Write-Host \"::group::📂 Core Asset Verification\"
+          Write-Host '::group::📂 Core Asset Verification'
 
           $criticalAssets = @(
-            @{ path = \"electron/package.json\"; desc = \"Electron package manifest\" },
-            @{ path = \"electron/package-lock.json\"; desc = \"Electron dependency lock\" },
-            @{ path = \"web_service/backend/requirements.txt\"; desc = \"Python dependencies\" },
-            @{ path = \"web_service/backend/service_entry.py\"; desc = \"Service entry point\" },
-            @{ path = \"build_wix/Product_WithService.wxs\"; desc = \"WiX installer definition\" }
+            @{ path = "electron/package.json"; desc = "Electron package manifest" },
+            @{ path = "electron/package-lock.json"; desc = "Electron dependency lock" },
+            @{ path = "web_service/backend/requirements.txt"; desc = "Python dependencies" },
+            @{ path = "web_service/backend/service_entry.py"; desc = "Service entry point" },
+            @{ path = "build_wix/Product_WithService.wxs"; desc = "WiX installer definition" }
           )
 
           $optionalAssets = @(
-            @{ path = \".github/workflows\"; desc = \"GitHub Actions workflows\" },
-            @{ path = \"README.md\"; desc = \"Project documentation\" },
-            @{ path = \"LICENSE\"; desc = \"License file\" },
-            @{ path = \".gitignore\"; desc = \"Git ignore rules\" },
-            @{ path = \"tests\"; desc = \"Test suite\" }
+            @{ path = ".github/workflows"; desc = "GitHub Actions workflows" },
+            @{ path = "README.md"; desc = "Project documentation" },
+            @{ path = "LICENSE"; desc = "License file" },
+            @{ path = ".gitignore"; desc = "Git ignore rules" },
+            @{ path = "tests"; desc = "Test suite" }
           )
 
           $missing = @()
 
-          Write-Host \"┌─────────────────────────────────────────────────────────────┐\"
-          Write-Host \"│                CRITICAL ASSETS                              │\"
-          Write-Host \"├─────────────────────────────────────────────────────────────┤\"
+          Write-Host '┌─────────────────────────────────────────────────────────────┐'
+          Write-Host '│                CRITICAL ASSETS                              │'
+          Write-Host '├─────────────────────────────────────────────────────────────┤'
 
           foreach ($asset in $criticalAssets) {
             if (Test-Path $asset.path) {
               $item = Get-Item $asset.path
               if ($item.PSIsContainer) {
-                $size = \"directory\"
+                $size = "directory"
                 $files = (Get-ChildItem $asset.path -Recurse -File | Measure-Object).Count
-                $size = \"$files files\"
+                $size = "$files files"
               } else {
                 $bytes = $item.Length
                 $size = switch ($bytes) {
-                  { $_ -lt 1KB } { \"$bytes B\" }
-                  { $_ -lt 1MB } { \"{0:N1} KB\" -f ($_ / 1KB) }
-                  default { \"{0:N1} MB\" -f ($_ / 1MB) }
+                  { $_ -lt 1KB } { "$bytes B" }
+                  { $_ -lt 1MB } { "{0:N1} KB" -f ($_ / 1KB) }
+                  default { "{0:N1} MB" -f ($_ / 1MB) }
                 }
               }
-              Write-Host \"│ ✅ $($asset.path.PadRight(35)) ($size)\"
+              Write-Host "│ ✅ $($asset.path.PadRight(35)) ($size)"
             } else {
-              Write-Host \"│ ❌ $($asset.path.PadRight(35)) MISSING!\" -ForegroundColor Red
+              Write-Host "│ ❌ $($asset.path.PadRight(35)) MISSING!" -ForegroundColor Red
               $missing += $asset
             }
           }
 
-          Write-Host \"├─────────────────────────────────────────────────────────────┤\"
-          Write-Host \"│                OPTIONAL ASSETS                              │\"
-          Write-Host \"├─────────────────────────────────────────────────────────────┤\"
+          Write-Host '├─────────────────────────────────────────────────────────────┤'
+          Write-Host '│                OPTIONAL ASSETS                              │'
+          Write-Host '├─────────────────────────────────────────────────────────────┤'
 
           foreach ($asset in $optionalAssets) {
             if (Test-Path $asset.path) {
-              Write-Host \"│ ✅ $($asset.path.PadRight(35)) present\"
+              Write-Host "│ ✅ $($asset.path.PadRight(35)) present"
             } else {
-              Write-Host \"│ ⚪ $($asset.path.PadRight(35)) not found\" -ForegroundColor Gray
+              Write-Host "│ ⚪ $($asset.path.PadRight(35)) not found" -ForegroundColor Gray
             }
           }
 
-          Write-Host \"└─────────────────────────────────────────────────────────────┘\"
+          Write-Host '└─────────────────────────────────────────────────────────────┘'
 
           if ($missing.Count -gt 0) {
-            Write-Host \"\"
-            Write-Host \"╔═══════════════════════════════════════════════════════════════╗\" -ForegroundColor Red
-            Write-Host \"║  ❌ FATAL: Missing $($missing.Count) critical asset(s)!                        ║\" -ForegroundColor Red
-            Write-Host \"╠═══════════════════════════════════════════════════════════════╣\" -ForegroundColor Red
+            Write-Host ""
+            Write-Host "╔═══════════════════════════════════════════════════════════════╗" -ForegroundColor Red
+            Write-Host "║  ❌ FATAL: Missing $($missing.Count) critical asset(s)!                        ║" -ForegroundColor Red
+            Write-Host "╠═══════════════════════════════════════════════════════════════╣" -ForegroundColor Red
             foreach ($m in $missing) {
-              Write-Host \"║  • $($m.path.PadRight(30)) - $($m.desc.PadRight(20)) ║\" -ForegroundColor Red
-              Write-Host \"::error file=$($m.path)::Missing critical asset: $($m.desc)\"
+              Write-Host "║  • $($m.path.PadRight(30)) - $($m.desc.PadRight(20)) ║" -ForegroundColor Red
+              Write-Host "::error file=$($m.path)::Missing critical asset: $($m.desc)"
             }
-            Write-Host \"╚═══════════════════════════════════════════════════════════════╝\" -ForegroundColor Red
-            throw \"Missing critical assets: $($missing.path -join ', ')\"
+            Write-Host "╚═══════════════════════════════════════════════════════════════╝" -ForegroundColor Red
+            throw "Missing critical assets: $($missing.path -join ', ')"
           }
 
-          Write-Host \"`n✅ All critical assets verified\"
-          Write-Host \"::endgroup::\"
+          Write-Host "`n✅ All critical assets verified"
+          Write-Host '::endgroup::'
 
       # -------------------------------------------------------
       # EXTENDED FORENSICS (Optional - Deep Analysis)
@@ -508,138 +529,138 @@ jobs:
         if: ${{ inputs.enable_forensics == true }}
         shell: pwsh
         run: |
-          Write-Host \"::group::🔬 Extended Forensics Analysis\"
+          Write-Host '::group::🔬 Extended Forensics Analysis'
 
           # ======= ELECTRON PACKAGE ANALYSIS =======
-          Write-Host \"┌─────────────────────────────────────────────────────────────┐\"
-          Write-Host \"│            ELECTRON PACKAGE ANALYSIS                        │\"
-          Write-Host \"└─────────────────────────────────────────────────────────────┘\"
+          Write-Host '┌─────────────────────────────────────────────────────────────┐'
+          Write-Host '│            ELECTRON PACKAGE ANALYSIS                        │'
+          Write-Host '└─────────────────────────────────────────────────────────────┘'
 
-          $pkg = Get-Content \"electron/package.json\" -Raw | ConvertFrom-Json
+          $pkg = Get-Content "electron/package.json" -Raw | ConvertFrom-Json
 
-          Write-Host \"  Name:    $($pkg.name)\"
-          Write-Host \"  Version: $($pkg.version)\"
-          Write-Host \"  Main:    $($pkg.main)\"
+          Write-Host "  Name:    $($pkg.name)"
+          Write-Host "  Version: $($pkg.version)"
+          Write-Host "  Main:    $($pkg.main)"
 
-          Write-Host \"`n  📜 Available Scripts:\"
+          Write-Host "`n  📜 Available Scripts:"
           if ($pkg.scripts) {
             $pkg.scripts.PSObject.Properties | ForEach-Object {
-              $icon = if ($_.Name -eq 'build') { \"⭐\" } else { \"  \" }
-              Write-Host \"     $icon $($_.Name): $($_.Value)\"
+              $icon = if ($_.Name -eq 'build') { "⭐" } else { "  " }
+              Write-Host "     $icon $($_.Name): $($_.Value)"
             }
 
             if (-not $pkg.scripts.build) {
-              Write-Host \"     ⚠️ WARNING: No 'build' script defined!\" -ForegroundColor Yellow
-              Write-Host \"::warning file=electron/package.json::No 'build' script defined in package.json\"
+              Write-Host "     ⚠️ WARNING: No 'build' script defined!" -ForegroundColor Yellow
+              Write-Host "::warning file=electron/package.json::No 'build' script defined in package.json"
             }
           }
 
-          Write-Host \"`n  📦 Dependencies:\"
+          Write-Host "`n  📦 Dependencies:"
           if ($pkg.dependencies) {
             $depCount = ($pkg.dependencies.PSObject.Properties | Measure-Object).Count
-            Write-Host \"     Production: $depCount packages\"
+            Write-Host "     Production: $depCount packages"
             $pkg.dependencies.PSObject.Properties | Select-Object -First 10 | ForEach-Object {
-              Write-Host \"       • $($_.Name)@$($_.Value)\"
+              Write-Host "       • $($_.Name)@$($_.Value)"
             }
           }
           if ($pkg.devDependencies) {
             $devCount = ($pkg.devDependencies.PSObject.Properties | Measure-Object).Count
-            Write-Host \"     Development: $devCount packages\"
+            Write-Host "     Development: $devCount packages"
           }
 
           # ======= PYTHON REQUIREMENTS ANALYSIS =======
-          Write-Host \"`n┌─────────────────────────────────────────────────────────────┐\"
-          Write-Host \"│            PYTHON REQUIREMENTS ANALYSIS                     │\"
-          Write-Host \"└─────────────────────────────────────────────────────────────┘\"
+          Write-Host "`n┌─────────────────────────────────────────────────────────────┐"
+          Write-Host '│            PYTHON REQUIREMENTS ANALYSIS                     │'
+          Write-Host '└─────────────────────────────────────────────────────────────┘'
 
-          $reqs = Get-Content \"web_service/backend/requirements.txt\"
+          $reqs = Get-Content "web_service/backend/requirements.txt"
           $packages = $reqs | Where-Object { $_ -notmatch '^\\s*(#|$)' }
           $pkgCount = ($packages | Measure-Object).Count
 
-          Write-Host \"  Total packages: $pkgCount\"
-          Write-Host \"`n  📦 Dependencies:\"
+          Write-Host "  Total packages: $pkgCount"
+          Write-Host "`n  📦 Dependencies:"
 
           # Categorize packages
           $pinnedExact = $packages | Where-Object { $_ -match '==' }
           $pinnedMin = $packages | Where-Object { $_ -match '>=' }
           $unpinned = $packages | Where-Object { $_ -notmatch '[<>=]' }
 
-          Write-Host \"     Pinned (exact): $($pinnedExact.Count)\"
-          Write-Host \"     Pinned (min):   $($pinnedMin.Count)\"
-          Write-Host \"     Unpinned:       $($unpinned.Count)\"
+          Write-Host "     Pinned (exact): $($pinnedExact.Count)"
+          Write-Host "     Pinned (min):   $($pinnedMin.Count)"
+          Write-Host "     Unpinned:       $($unpinned.Count)"
 
           if ($unpinned.Count -gt 0) {
-            Write-Host \"`n     ⚠️ Unpinned packages (potential reproducibility issues):\"
-            $unpinned | Select-Object -First 5 | ForEach-Object { Write-Host \"        • $_\" }
+            Write-Host "`n     ⚠️ Unpinned packages (potential reproducibility issues):"
+            $unpinned | Select-Object -First 5 | ForEach-Object { Write-Host "        • $_" }
           }
 
           # Check for known problematic packages on Windows
-          $winProblematic = @(\"pywin32\", \"win32\", \"numpy\", \"pandas\", \"scipy\")
+          $winProblematic = @("pywin32", "win32", "numpy", "pandas", "scipy")
           $foundProblematic = $packages | Where-Object {
             $pkg = $_
             $winProblematic | Where-Object { $pkg -match $_ }
           }
           if ($foundProblematic) {
-            Write-Host \"`n     📋 Windows-sensitive packages detected:\"
-            $foundProblematic | ForEach-Object { Write-Host \"        • $_\" }
+            Write-Host "`n     📋 Windows-sensitive packages detected:"
+            $foundProblematic | ForEach-Object { Write-Host "        • $_" }
           }
 
           # ======= WIX CONFIGURATION ANALYSIS =======
-          Write-Host \"`n┌─────────────────────────────────────────────────────────────┐\"
-          Write-Host \"│              WIX CONFIGURATION ANALYSIS                     │\"
-          Write-Host \"└─────────────────────────────────────────────────────────────┘\"
+          Write-Host "`n┌─────────────────────────────────────────────────────────────┐"
+          Write-Host '│              WIX CONFIGURATION ANALYSIS                     │'
+          Write-Host '└─────────────────────────────────────────────────────────────┘'
 
-          $wxsPath = \"build_wix/Product_WithService.wxs\"
+          $wxsPath = "build_wix/Product_WithService.wxs"
           $wxs = Get-Content $wxsPath -Raw
 
           $patterns = @{
-            \"UpgradeCode\" = 'UpgradeCode=\"([^\"]+)\"'
-            \"Product Name\" = 'Name=\"([^\"]+)\"'
-            \"Manufacturer\" = 'Manufacturer=\"([^\"]+)\"'
-            \"Version Variable\" = 'Version=\"\\$\\(var\\.([^)]+)\\)\"'
+            "UpgradeCode" = 'UpgradeCode="([^\"]+)"'
+            "Product Name" = 'Name="([^\"]+)"'
+            "Manufacturer" = 'Manufacturer="([^\"]+)"'
+            "Version Variable" = 'Version="\\$\\(var\\.([^)]+)\\)"'
           }
 
           foreach ($item in $patterns.Keys) {
             if ($wxs -match $patterns[$item]) {
-              Write-Host \"  $item`: $($Matches[1])\"
+              Write-Host "  $item`: $($Matches[1])"
             }
           }
 
           # Check for service configuration
           if ($wxs -match 'ServiceInstall') {
-            Write-Host \"  ✅ Windows Service installation configured\"
+            Write-Host "  ✅ Windows Service installation configured"
           } else {
-            Write-Host \"  ⚠️ No ServiceInstall element found\" -ForegroundColor Yellow
+            Write-Host "  ⚠️ No ServiceInstall element found" -ForegroundColor Yellow
           }
 
           # ======= DIRECTORY STRUCTURE =======
-          Write-Host \"`n┌─────────────────────────────────────────────────────────────┐\"
-          Write-Host \"│              PROJECT STRUCTURE                              │\"
-          Write-Host \"└─────────────────────────────────────────────────────────────┘\"
+          Write-Host "`n┌─────────────────────────────────────────────────────────────┐"
+          Write-Host '│              PROJECT STRUCTURE                              │'
+          Write-Host '└─────────────────────────────────────────────────────────────┘'
 
           function Show-Tree {
             param([string]$Path, [int]$Indent = 0, [int]$MaxDepth = 2)
             if ($Indent -ge $MaxDepth) { return }
 
             Get-ChildItem $Path -ErrorAction SilentlyContinue | ForEach-Object {
-              $prefix = \"  \" * $Indent
+              $prefix = "  " * $Indent
               if ($_.PSIsContainer) {
-                Write-Host \"$prefix📁 $($_.Name)/\"
+                Write-Host "$prefix📁 $($_.Name)/"
                 Show-Tree $_.FullName ($Indent + 1) $MaxDepth
               } else {
                 $size = switch ($_.Length) {
-                  { $_ -lt 1KB } { \"$($_.Length)B\" }
-                  { $_ -lt 1MB } { \"{0:N0}KB\" -f ($_ / 1KB) }
-                  default { \"{0:N1}MB\" -f ($_ / 1MB) }
+                  { $_ -lt 1KB } { "$($_.Length)B" }
+                  { $_ -lt 1MB } { "{0:N0}KB" -f ($_ / 1KB) }
+                  default { "{0:N1}MB" -f ($_ / 1MB) }
                 }
-                Write-Host \"$prefix📄 $($_.Name) ($size)\"
+                Write-Host "$prefix📄 $($_.Name) ($size)"
               }
             }
           }
 
-          Show-Tree \".\" 0 2
+          Show-Tree "." 0 2
 
-          Write-Host \"::endgroup::\"
+          Write-Host '::endgroup::'
 
       # -------------------------------------------------------
       # SECRET & CREDENTIAL CHECK
@@ -650,38 +671,38 @@ jobs:
           HAS_API_KEY: ${{ secrets.API_KEY != '' }}
           HAS_TVG_API_KEY: ${{ secrets.TVG_API_KEY != '' }}
         run: |
-          Write-Host \"::group::🔐 Secret Configuration\"
+          Write-Host '::group::🔐 Secret Configuration'
 
-          Write-Host \"┌─────────────────────────────────────────────────────────────┐\"
-          Write-Host \"│               SECRET AVAILABILITY                           │\"
-          Write-Host \"├──────────────────┬────────────────────────────────────────────┤\"
-          Write-Host \"│ Secret           │ Status                                     │\"
-          Write-Host \"├──────────────────┼────────────────────────────────────────────┤\"
+          Write-Host '┌─────────────────────────────────────────────────────────────┐'
+          Write-Host '│               SECRET AVAILABILITY                           │'
+          Write-Host '├──────────────────┬────────────────────────────────────────────┤'
+          Write-Host '│ Secret           │ Status                                     │'
+          Write-Host '├──────────────────┼────────────────────────────────────────────┤'
 
           $secrets = @(
-            @{ name = \"API_KEY\"; configured = $env:HAS_API_KEY -eq 'true'; required = $false },
-            @{ name = \"TVG_API_KEY\"; configured = $env:HAS_TVG_API_KEY -eq 'true'; required = $false }
+            @{ name = "API_KEY"; configured = $env:HAS_API_KEY -eq 'true'; required = $false },
+            @{ name = "TVG_API_KEY"; configured = $env:HAS_TVG_API_KEY -eq 'true'; required = $false }
           )
 
           foreach ($s in $secrets) {
             $status = if ($s.configured) {
-              \"✅ Configured\"
+              "✅ Configured"
             } elseif ($s.required) {
-              \"❌ MISSING (Required!)\"
+              "❌ MISSING (Required!)"
             } else {
-              \"⚪ Not configured (Optional)\"
+              "⚪ Not configured (Optional)"
             }
-            Write-Host \"│ $($s.name.PadRight(16)) │ $($status.PadRight(42)) │\"
+            Write-Host "│ $($s.name.PadRight(16)) │ $($status.PadRight(42)) │"
           }
 
-          Write-Host \"└──────────────────┴────────────────────────────────────────────┘\"
+          Write-Host '└──────────────────┴────────────────────────────────────────────┘'
 
           $missingRequired = $secrets | Where-Object { $_.required -and -not $_.configured }
           if ($missingRequired) {
-            throw \"Missing required secrets: $($missingRequired.name -join ', ')\"
+            throw "Missing required secrets: $($missingRequired.name -join ', ')"
           }
 
-          Write-Host \"::endgroup::\"
+          Write-Host '::endgroup::'
 
       # -------------------------------------------------------
       # NETWORK DIAGNOSTICS
@@ -689,19 +710,19 @@ jobs:
       - name: 🌐 Network Diagnostics
         shell: pwsh
         run: |
-          Write-Host \"::group::🌐 Network Diagnostics\"
+          Write-Host '::group::🌐 Network Diagnostics'
 
-          Write-Host \"┌─────────────────────────────────────────────────────────────┐\"
-          Write-Host \"│              ENDPOINT CONNECTIVITY                          │\"
-          Write-Host \"├──────────────────┬──────────────────────────────────────────┤\"
-          Write-Host \"│ Endpoint         │ Status                                   │\"
-          Write-Host \"├──────────────────┼──────────────────────────────────────────┤\"
+          Write-Host '┌─────────────────────────────────────────────────────────────┐'
+          Write-Host '│              ENDPOINT CONNECTIVITY                          │'
+          Write-Host '├──────────────────┬──────────────────────────────────────────┤'
+          Write-Host '│ Endpoint         │ Status                                   │'
+          Write-Host '├──────────────────┼──────────────────────────────────────────┤'
 
           $endpoints = @(
-            @{ name = \"GitHub API\"; url = \"https://api.github.com\"; critical = $true },
-            @{ name = \"npm Registry\"; url = \"https://registry.npmjs.org\"; critical = $true },
-            @{ name = \"PyPI\"; url = \"https://pypi.org/simple/\"; critical = $true },
-            @{ name = \"NuGet\"; url = \"https://api.nuget.org/v3/index.json\"; critical = $true }
+            @{ name = "GitHub API"; url = "https://api.github.com"; critical = $true },
+            @{ name = "npm Registry"; url = "https://registry.npmjs.org"; critical = $true },
+            @{ name = "PyPI"; url = "https://pypi.org/simple/"; critical = $true },
+            @{ name = "NuGet"; url = "https://api.nuget.org/v3/index.json"; critical = $true }
           )
 
           $failures = @()
@@ -711,49 +732,50 @@ jobs:
               $start = Get-Date
               $null = Invoke-WebRequest -Uri $ep.url -Method Head -TimeoutSec 10 -UseBasicParsing
               $latency = [math]::Round(((Get-Date) - $start).TotalMilliseconds)
-              $status = \"✅ OK (${latency}ms)\"
+              $status = "✅ OK (${latency}ms)"
             } catch {
-              $status = \"❌ FAILED\"
+              $status = "❌ FAILED"
               if ($ep.critical) { $failures += $ep.name }
             }
-            Write-Host \"│ $($ep.name.PadRight(16)) │ $($status.PadRight(40)) │\"
+            Write-Host "│ $($ep.name.PadRight(16)) │ $($status.PadRight(40)) │"
           }
 
-          Write-Host \"└──────────────────┴──────────────────────────────────────────┘\"
+          Write-Host '└──────────────────┴──────────────────────────────────────────┘'
 
           # Local port check
-          Write-Host \"`n┌─────────────────────────────────────────────────────────────┐\"
-          Write-Host \"│              LOCAL PORT STATUS                              │\"
-          Write-Host \"└─────────────────────────────────────────────────────────────┘\"
+          Write-Host "`n┌─────────────────────────────────────────────────────────────┐"
+          Write-Host '│              LOCAL PORT STATUS                              │'
+          Write-Host '└─────────────────────────────────────────────────────────────┘'
 
-          $port = ${{ inputs.service_port }}
+          # FIX: Quoted the input to prevent type coercion errors
+          $port = "${{ inputs.service_port }}"
           $connections = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
 
           if ($connections) {
-            Write-Host \"  ⚠️ Port $port is currently IN USE:\" -ForegroundColor Yellow
+            Write-Host "  ⚠️ Port $port is currently IN USE:" -ForegroundColor Yellow
             $connections | ForEach-Object {
               $proc = Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue
-              Write-Host \"     PID: $($_.OwningProcess) | Process: $($proc.ProcessName) | State: $($_.State)\"
+              Write-Host "     PID: $($_.OwningProcess) | Process: $($proc.ProcessName) | State: $($_.State)"
             }
-            Write-Host \"::warning::Port $port is already in use on the runner\"
+            Write-Host "::warning::Port $port is already in use on the runner"
           } else {
-            Write-Host \"  ✅ Port $port is available\"
+            Write-Host "  ✅ Port $port is available"
           }
 
           # DNS resolution check
-          Write-Host \"`n  🔍 DNS Resolution:\"
+          Write-Host "`n  🔍 DNS Resolution:"
           try {
-            $dns = Resolve-DnsName \"github.com\" -Type A -DnsOnly -ErrorAction Stop
-            Write-Host \"     ✅ github.com resolves to $($dns.IPAddress -join ', ')\"
+            $dns = Resolve-DnsName "github.com" -Type A -DnsOnly -ErrorAction Stop
+            Write-Host "     ✅ github.com resolves to $($dns.IPAddress -join ', ')"
           } catch {
-            Write-Host \"     ❌ DNS resolution failed\"
+            Write-Host "     ❌ DNS resolution failed"
           }
 
           if ($failures.Count -gt 0) {
-            Write-Host \"::warning::Failed to reach: $($failures -join ', ')\"
+            Write-Host "::warning::Failed to reach: $($failures -join ', ')"
           }
 
-          Write-Host \"::endgroup::\"
+          Write-Host '::endgroup::'
 
       # -------------------------------------------------------
       # PREFLIGHT SUMMARY
@@ -762,33 +784,66 @@ jobs:
         id: summary
         shell: pwsh
         run: |
-          Write-Host \"\"
-          Write-Host \"╔═════════════════════════════════════════════════════════════════╗\" -ForegroundColor Green
-          Write-Host \"║                                                                 ║\" -ForegroundColor Green
-          Write-Host \"║          ✅  PREFLIGHT DIAGNOSTICS COMPLETE                     ║\" -ForegroundColor Green
-          Write-Host \"║                                                                 ║\" -ForegroundColor Green
-          Write-Host \"╠═════════════════════════════════════════════════════════════════╣\" -ForegroundColor Green
-          Write-Host \"║                                                                 ║\" -ForegroundColor Cyan
-          Write-Host \"║  📦 VERSION:     $($(\"${{ steps.ver.outputs.semver }}\").PadRight(44)) ║\" -ForegroundColor Cyan
-          Write-Host \"║  🔖 COMMIT:      $($(\"${{ steps.env.outputs.short_sha }}\").PadRight(44)) ║\" -ForegroundColor Cyan
-          Write-Host \"║  🌿 BRANCH:      $($(\"${{ steps.env.outputs.branch }}\").PadRight(44)) ║\" -ForegroundColor Cyan
-          Write-Host \"║  🏷️ IS TAG:      $($(\"${{ steps.env.outputs.is_tag }}\").PadRight(44)) ║\" -ForegroundColor Cyan
-          Write-Host \"║                                                                 ║\" -ForegroundColor Cyan
-          Write-Host \"╠═════════════════════════════════════════════════════════════════╣\" -ForegroundColor Green
-          Write-Host \"║  TOOLCHAIN                                                      ║\" -ForegroundColor Yellow
-          Write-Host \"║  ├─ Node:   $($(\"${{ inputs.node_version }}\").PadRight(49)) ║\" -ForegroundColor White
-          Write-Host \"║  ├─ Python: $($(\"${{ inputs.python_version }}\").PadRight(49)) ║\" -ForegroundColor White
-          Write-Host \"║  └─ WiX:    $($(\"${{ inputs.wix_version }}\").PadRight(49)) ║\" -ForegroundColor White
-          Write-Host \"║                                                                 ║\" -ForegroundColor Cyan
-          Write-Host \"║  CONFIGURATION                                                  ║\" -ForegroundColor Yellow
-          Write-Host \"║  └─ Service Port: $($(\"${{ inputs.service_port }}\").PadRight(43)) ║\" -ForegroundColor White
-          Write-Host \"║                                                                 ║\" -ForegroundColor Cyan
-          Write-Host \"╚═════════════════════════════════════════════════════════════════╝\" -ForegroundColor Green
-          Write-Host \"\"
-          Write-Host \"🚀 Ready to proceed with build pipeline!\" -ForegroundColor Green
-          Write-Host \"\"
+          Write-Host ""
+          Write-Host "╔═════════════════════════════════════════════════════════════════╗" -ForegroundColor Green
+          Write-Host "║                                                                 ║" -ForegroundColor Green
+          Write-Host "║          ✅  PREFLIGHT DIAGNOSTICS COMPLETE                     ║" -ForegroundColor Green
+          Write-Host "║                                                                 ║" -ForegroundColor Green
+          Write-Host "╠═════════════════════════════════════════════════════════════════╣" -ForegroundColor Green
+          Write-Host "║                                                                 ║" -ForegroundColor Cyan
+          Write-Host "║  📦 VERSION:     $($("${{ steps.ver.outputs.semver }}").PadRight(44)) ║" -ForegroundColor Cyan
+          Write-Host "║  🔖 COMMIT:      $($("${{ steps.env.outputs.short_sha }}").PadRight(44)) ║" -ForegroundColor Cyan
+          Write-Host "║  🌿 BRANCH:      $($("${{ steps.env.outputs.branch }}").PadRight(44)) ║" -ForegroundColor Cyan
+          Write-Host "║  🏷️ IS TAG:      $($("${{ steps.env.outputs.is_tag }}").PadRight(44)) ║" -ForegroundColor Cyan
+          Write-Host "║                                                                 ║" -ForegroundColor Cyan
+          Write-Host "╠═════════════════════════════════════════════════════════════════╣" -ForegroundColor Green
+          Write-Host "║  TOOLCHAIN                                                      ║" -ForegroundColor Yellow
+          Write-Host "║  ├─ Node:   $($("${{ inputs.node_version }}").PadRight(49)) ║" -ForegroundColor White
+          Write-Host "║  ├─ Python: $($("${{ inputs.python_version }}").PadRight(49)) ║" -ForegroundColor White
+          Write-Host "║  └─ WiX:    $($("${{ inputs.wix_version }}").PadRight(49)) ║" -ForegroundColor White
+          Write-Host "║                                                                 ║" -ForegroundColor Cyan
+          Write-Host "║  CONFIGURATION                                                  ║" -ForegroundColor Yellow
+          Write-Host "║  └─ Service Port: $($("${{ inputs.service_port }}").PadRight(43)) ║" -ForegroundColor White
+          Write-Host "║                                                                 ║" -ForegroundColor Cyan
+          Write-Host "╚═════════════════════════════════════════════════════════════════╝" -ForegroundColor Green
+          Write-Host ""
+          Write-Host "🚀 Ready to proceed with build pipeline!" -ForegroundColor Green
+          Write-Host ""
 
-          \"passed=true\" >> $env:GITHUB_OUTPUT
+          # --- GitHub Job Summary ---
+          $summary = @"
+          ## 🔍 Preflight Diagnostics Complete
+
+          | Property | Value |
+          |----------|-------|
+          | 📦 **Version** | `${{ steps.ver.outputs.semver }}` |
+          | 🔖 **Commit** | `${{ steps.env.outputs.short_sha }}` |
+          | 🌿 **Branch** | `${{ steps.env.outputs.branch }}` |
+          | 🏷️ **Is Tag** | `${{ steps.env.outputs.is_tag }}` |
+          | ⏰ **Timestamp** | `${{ steps.env.outputs.build_timestamp }}` |
+
+          ### 🛠️ Toolchain
+          | Tool | Version |
+          |------|---------|
+          | Node.js | `${{ inputs.node_version }}` |
+          | Python | `${{ inputs.python_version }}` |
+          | WiX | `${{ inputs.wix_version }}` |
+
+          ### ⚙️ Feature Toggles
+          | Feature | Status |
+          |---------|--------|
+          | 🥗 Dietician | $(if ('${{ inputs.enable_dietician }}' -eq 'true') { '🟢 Enabled' } else { '⚪ Disabled' }) |
+          | 🦜 Canary | $(if ('${{ inputs.enable_canary }}' -eq 'true') { '🟢 Enabled' } else { '⚪ Disabled' }) |
+          | 📸 Paparazzi | $(if ('${{ inputs.enable_paparazzi }}' -eq 'true') { '🟢 Enabled' } else { '⚪ Disabled' }) |
+          | 🔬 Forensics | $(if ('${{ inputs.enable_forensics }}' -eq 'true') { '🟢 Enabled' } else { '⚪ Disabled' }) |
+
+          ---
+          ✅ **Ready to proceed with build pipeline**
+          "@
+
+          $summary >> $env:GITHUB_STEP_SUMMARY
+
+          "passed=true" >> $env:GITHUB_OUTPUT
 
   # =========================================================
   # 2. BUILD FRONTEND
@@ -797,6 +852,7 @@ jobs:
     name: ⚛️ Frontend
     needs: preflight
     runs-on: windows-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -810,7 +866,7 @@ jobs:
         working-directory: electron
         run: |
           $pkg = Get-Content package.json | ConvertFrom-Json
-          if (-not $pkg.scripts.build) { throw \"❌ package.json in electron/ is missing 'build' script!\" }
+          if (-not $pkg.scripts.build) { throw "❌ package.json in electron/ is missing 'build' script!" }
 
       - name: 🏗️ Build Frontend
         working-directory: electron
@@ -829,6 +885,7 @@ jobs:
     name: 🐍 Backend (${{ matrix.arch }})
     needs: [preflight, build-frontend]
     runs-on: windows-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         arch: [x64, x86]
@@ -864,8 +921,8 @@ jobs:
         run: |
           pyinstaller --noconfirm --onedir --clean --name fortuna-backend `
             --hidden-import=win32timezone --hidden-import=win32serviceutil `
-            --add-data \"web_service/backend;backend\" `
-            --add-data \"electron/out;ui\" `
+            --add-data "web_service/backend;backend" `
+            --add-data "electron/out;ui" `
             web_service/backend/service_entry.py
 
       - uses: actions/upload-artifact@v4
@@ -880,6 +937,7 @@ jobs:
     name: 📦 MSI (${{ matrix.arch }})
     needs: build-backend
     runs-on: windows-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         arch: [x64, x86]
@@ -900,26 +958,26 @@ jobs:
         if: ${{ inputs.enable_dietician }}
         shell: pwsh
         run: |
-          Write-Host \"Payload: $((Get-ChildItem staging -Recurse | Measure-Object -Sum Length).Sum / 1MB) MB\"
+          Write-Host "Payload: $((Get-ChildItem staging -Recurse | Measure-Object -Sum Length).Sum / 1MB) MB"
 
       - name: 🔧 Setup WiX
         run: |
           dotnet tool install --global wix --version ${{ inputs.wix_version }}
-          echo \"$env:USERPROFILE\\.dotnet\\tools\" >> $env:GITHUB_PATH
+          echo "$env:USERPROFILE\\.dotnet\\tools" >> $env:GITHUB_PATH
 
       - name: 🏗️ Build MSI
         run: |
-          wix build build_wix/Product_WithService.wxs -arch ${{ matrix.arch }} -o Fortuna-${{ matrix.arch }}.msi -d Version=\"${{ needs.preflight.outputs.semver }}\" -d SourceDir=\"staging\"
+          wix build build_wix/Product_WithService.wxs -arch ${{ matrix.arch }} -o Fortuna-${{ matrix.arch }}.msi -d Version="${{ needs.preflight.outputs.semver }}" -d SourceDir="staging"
 
       - name: 🦜 The Canary
         if: ${{ inputs.enable_canary }}
         shell: pwsh
         run: |
           try {
-            if (Test-Path \"C:\\Program Files\\Windows Defender\\MpCmdRun.exe\") {
-               & \"C:\\Program Files\\Windows Defender\\MpCmdRun.exe\" -Scan -ScanType 3 -File \"$pwd\\Fortuna-${{ matrix.arch }}.msi\"
+            if (Test-Path "C:\\Program Files\\Windows Defender\\MpCmdRun.exe") {
+               & "C:\\Program Files\\Windows Defender\\MpCmdRun.exe" -Scan -ScanType 3 -File "$pwd\\Fortuna-${{ matrix.arch }}.msi"
             }
-          } catch { Write-Warning \"Canary scan failed or skipped: $_\" }
+          } catch { Write-Warning "Canary scan failed or skipped: $_" }
 
       - uses: actions/upload-artifact@v4
         with:
@@ -933,10 +991,12 @@ jobs:
     name: 🚬 Smoke (${{ matrix.arch }})
     needs: package-msi
     runs-on: windows-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         arch: [x64, x86]
     steps:
+      # NO CHECKOUT HERE - Pure Artifacts
       - uses: actions/download-artifact@v4
         with:
           name: msi-${{ matrix.arch }}
@@ -944,20 +1004,20 @@ jobs:
       - name: 🧹 Clean & Install
         shell: pwsh
         run: |
-          sc.exe delete \"FortunaWebService\" *>$null; Start-Sleep 2
-          Start-Process msiexec.exe -ArgumentList \"/i Fortuna-${{ matrix.arch }}.msi /quiet /norestart\" -Wait
+          sc.exe delete "FortunaWebService" *>$null; Start-Sleep 2
+          Start-Process msiexec.exe -ArgumentList "/i Fortuna-${{ matrix.arch }}.msi /quiet /norestart" -Wait
 
       - name: 🩺 Health Check
         shell: pwsh
         run: |
           Start-Sleep 10
-          for($i=0;$i -lt 5;$i++) { try { if ((Invoke-RestMethod \"http://127.0.0.1:${{ inputs.service_port }}/health\").status -eq \"ok\") { return } } catch { Start-Sleep 5 } }
-          throw \"Dead Service\"
+          for($i=0;$i -lt 5;$i++) { try { if ((Invoke-RestMethod "http://127.0.0.1:${{ inputs.service_port }}/health").status -eq "ok") { return } } catch { Start-Sleep 5 } }
+          throw "Dead Service"
 
       - name: 🧹 Cleanup
         if: always()
         run: |
-          sc.exe delete \"FortunaWebService\" *>$null
+          sc.exe delete "FortunaWebService" *>$null
 
   # =========================================================
   # 6. UI PROOF (Heavy/Optional)
@@ -967,6 +1027,7 @@ jobs:
     needs: smoke-test
     if: ${{ inputs.enable_paparazzi }}
     runs-on: windows-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         arch: [x64, x86]
@@ -978,13 +1039,13 @@ jobs:
       - name: 💿 Re-Install for UI
         shell: pwsh
         run: |
-          Start-Process msiexec.exe -ArgumentList \"/i Fortuna-${{ matrix.arch }}.msi /quiet /norestart\" -Wait
+          Start-Process msiexec.exe -ArgumentList "/i Fortuna-${{ matrix.arch }}.msi /quiet /norestart" -Wait
 
       - name: 📸 Run Playwright
         shell: pwsh
         run: |
           npm install playwright; npx playwright install chromium --with-deps
-          node -e \"const { chromium } = require('playwright'); (async () => { const b = await chromium.launch(); const p = await b.newPage(); await p.goto('http://127.0.0.1:${{ inputs.service_port }}/docs'); await p.screenshot({path: 'proof.png'}); await b.close(); })();\"
+          node -e "const { chromium } = require('playwright'); (async () => { const b = await chromium.launch(); const p = await b.newPage(); await p.goto('http://127.0.0.1:${{ inputs.service_port }}/docs'); await p.screenshot({path: 'proof.png'}); await b.close(); })();"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -994,4 +1055,4 @@ jobs:
       - name: 🧹 Cleanup
         if: always()
         run: |
-          sc.exe delete \"FortunaWebService\" *>$null
+          sc.exe delete "FortunaWebService" *>$null


### PR DESCRIPTION
Switches from double quotes to single quotes for string literals in the PowerShell `run` blocks within the `preflight` job of the `build-core-universal.yml` workflow.

This prevents potential `ParserError` issues caused by character escaping conflicts when the workflow is processed, particularly with JSON-like structures or special characters that might be misinterpreted by PowerShell when inside double-quoted strings.