### PR TITLE
fix(workflows): Correct line breaks in restored YAML files

### DIFF
--- a/.github/workflows/build-electron-hybrid.yml
+++ b/.github/workflows/build-electron-hybrid.yml
@@ -38,10 +38,8 @@ jobs:
           pip install -r web_service/backend/requirements-dev.txt
           pytest web_service/backend/tests
   # ============================================================================
-======
   # JOB 1: BUILD CORE (The "HatTrick" Engine)
   # ============================================================================
-======
   build-core:
     name: '⚙️ Build Core Components (${{ matrix.arch }})'
     runs-on: windows-latest
@@ -59,11 +57,9 @@ jobs:
         id: meta
         shell: pwsh
         run: |
-          $ver = if ("${{ github.ref }}" -match 'refs/tags/v(.*)') { $Matches[1]
- } else { "0.0.${{ github.run_number }}" }
+          $ver = if ("${{ github.ref }}" -match 'refs/tags/v(.*)') { $Matches[1] } else { "0.0.${{ github.run_number }}" }
           "semver=$ver" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          "build_id=${{ github.run_id }}" | Out-File $env:GITHUB_OUTPUT -Encodin
-g utf8 -Append
+          "build_id=${{ github.run_id }}" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
       # --- FRONTEND (Standard) ---
       - uses: actions/setup-node@v4
         with:
@@ -75,9 +71,7 @@ g utf8 -Append
         uses: actions/cache@v4
         with:
           path: ${{ env.FRONTEND_DIR }}/out
-          key: ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json', '
-${{ env.FRONTEND_DIR }}/**/*.js', '${{ env.FRONTEND_DIR }}/**/*.ts', '${{ env.FR
-ONTEND_DIR }}/**/*.tsx', '${{ env.FRONTEND_DIR }}/**/*.css') }}
+          key: ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json', '${{ env.FRONTEND_DIR }}/**/*.js', '${{ env.FRONTEND_DIR }}/**/*.ts', '${{ env.FRONTEND_DIR }}/**/*.tsx', '${{ env.FRONTEND_DIR }}/**/*.css') }}
           restore-keys: |
             ${{ runner.os }}-frontend-
       - name: 🎨 Build Frontend
@@ -94,15 +88,12 @@ ONTEND_DIR }}/**/*.tsx', '${{ env.FRONTEND_DIR }}/**/*.css') }}
           Set-StrictMode -Version Latest
           $outDir = Resolve-Path "out"
           $manifestPath = "frontend-manifest.tsv"
-          "RelativePath`tSizeBytes`tSHA256" | Out-File $manifestPath -Encoding u
-tf8
+          "RelativePath`tSizeBytes`tSHA256" | Out-File $manifestPath -Encoding utf8
           $files = Get-ChildItem -Path $outDir -Recurse -File
           foreach ($f in $files) {
             $rel = $f.FullName.Substring($outDir.Path.Length).TrimStart('\','/')
-            $hash = (Get-FileHash $f.FullName -Algorithm SHA256).Hash.Substring(
-0,16)
-            "$rel`t$($f.Length)`t$hash" | Out-File $manifestPath -Encoding utf8
--Append
+            $hash = (Get-FileHash $f.FullName -Algorithm SHA256).Hash.Substring(0,16)
+            "$rel`t$($f.Length)`t$hash" | Out-File $manifestPath -Encoding utf8 -Append
           }
           Write-Host "✅ Generated frontend artifact manifest."
       # --- BACKEND (The "HatTrick" Upgrade) ---
@@ -117,16 +108,14 @@ tf8
         run: |
           $constraintDir = "temp-constraints"
           New-Item -ItemType Directory -Path $constraintDir -Force | Out-Null
-          $constraintFile = Join-Path $constraintDir "constraint-${{ matrix.arch
- }}.txt"
+          $constraintFile = Join-Path $constraintDir "constraint-${{ matrix.arch }}.txt"
           if ('${{ matrix.arch }}' -eq 'x86') {
             "numpy==1.23.5`npandas==1.5.3" | Set-Content $constraintFile
           } else { New-Item $constraintFile -ItemType File -Force }
           "file=$constraintFile" | Out-File $env:GITHUB_OUTPUT -Append
       - name: 🐍 Install Python Dependencies
         run: |
-          pip install -r ${{ env.BACKEND_DIR }}/requirements-dev.txt -c ${{ step
-s.constraints.outputs.file }}
+          pip install -r ${{ env.BACKEND_DIR }}/requirements-dev.txt -c ${{ steps.constraints.outputs.file }}
           pip install pyinstaller==6.6.0
       - name: 📦 Build Python Backend
         shell: pwsh
@@ -151,10 +140,8 @@ s.constraints.outputs.file }}
           retention-days: 1
 
   # ============================================================================
-======
   # JOB 2: PACKAGE ELECTRON (The "Ironclad" Chassis)
   # ============================================================================
-======
   package-electron:
     name: '⚡ Package Electron MSI (${{ matrix.arch }})'
     runs-on: windows-latest
@@ -182,8 +169,7 @@ s.constraints.outputs.file }}
       - name: 📥 Download Backend Artifact
         uses: actions/download-artifact@v4
         with:
-          name: python-service-${{ matrix.arch }}-${{ needs.build-core.outputs.b
-uild_id }}
+          name: python-service-${{ matrix.arch }}-${{ needs.build-core.outputs.build_id }}
           path: python-service-bin
       - name: 📥 Download Frontend Artifact
         uses: actions/download-artifact@v4
@@ -193,8 +179,7 @@ uild_id }}
       - name: 🚚 Stage Artifacts for Electron
         shell: pwsh
         run: |
-          Move-Item -Path "python-service-bin" -Destination "${{ env.ELECTRON_DI
-R }}/resources/backend" -Force
+          Move-Item -Path "python-service-bin" -Destination "${{ env.ELECTRON_DIR }}/resources/backend" -Force
           Write-Host "✅ Staged backend artifacts for Electron."
       - name: '⚖️ The Dietician (Size Analysis)'
         shell: pwsh
@@ -202,63 +187,49 @@ R }}/resources/backend" -Force
           $target = "." # Analyze entire workspace staged for build
           $limitMB = 300
           Write-Host "--- 📊 Size Breakdown ---"
-          $files = Get-ChildItem -Path $target -Recurse -File -ErrorAction Silen
-tlyContinue
+          $files = Get-ChildItem -Path $target -Recurse -File -ErrorAction SilentlyContinue
           if (!$files) { Write-Warning "No files found to weigh."; exit 0 }
           $totalBytes = ($files | Measure-Object -Property Length -Sum).Sum
           $totalMB = [math]::Round($totalBytes / 1MB, 2)
           Write-Host "Total Payload Size: $totalMB MB"
           if ($totalMB -gt $limitMB) {
-              Write-Warning "⚠️ BLOAT ALERT: Build exceeds $limitMB MB limit! Ch
-eck the heaviest files below."
+              Write-Warning "⚠️ BLOAT ALERT: Build exceeds $limitMB MB limit! Check the heaviest files below."
           } else {
-              Write-Host "✅ Size within limits (< $limitMB MB)." -ForegroundColo
-r Green
+              Write-Host "✅ Size within limits (< $limitMB MB)." -ForegroundColor Green
           }
           Write-Host "`n--- 🐘 Top 10 Heaviest Files ---"
-          $files | Sort-Object Length -Descending | Select-Object -First 10 @{N=
-'File';E={$_.FullName.Replace($pwd,'')}}, @{N='Size(MB)';E={"{0:N2}" -f ($_.Leng
-th/1MB)}} | Format-Table -AutoSize
+          $files | Sort-Object Length -Descending | Select-Object -First 10 @{N='File';E={$_.FullName.Replace($pwd,'')}}, @{N='Size(MB)';E={"{0:N2}" -f ($_.Length/1MB)}} | Format-Table -AutoSize
       - name: '🧐 Forensically Guarantee Icon Paths'
         shell: pwsh
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
-          Install-Module -Name powershell-yaml -Force -Scope CurrentUser -ErrorA
-ction Stop
+          Install-Module -Name powershell-yaml -Force -Scope CurrentUser -ErrorAction Stop
           Import-Module powershell-yaml
           $configPath = '${{ env.ELECTRON_DIR }}/electron-builder-config.yml'
           $iconPath = "${{ env.ELECTRON_DIR }}/assets/icon.ico"
           if (-not (Test-Path -LiteralPath $iconPath)) {
-            Write-Error "CRITICAL: The primary icon file is missing at '$iconPat
-h'."
+            Write-Error "CRITICAL: The primary icon file is missing at '$iconPath'."
             exit 1
           }
           $absoluteIconPath = (Resolve-Path -LiteralPath $iconPath).Path
           $config = Get-Content $configPath | ConvertFrom-Yaml
           $config.win.icon = $absoluteIconPath.Replace('\\', '/')
-          try { $config.msi.PSObject.Properties.Remove('installerIcon') } catch
-{}
-          try { $config.msi.PSObject.Properties.Remove('uninstallerIcon') } catc
-h {}
+          try { $config.msi.PSObject.Properties.Remove('installerIcon') } catch {}
+          try { $config.msi.PSObject.Properties.Remove('uninstallerIcon') } catch {}
           $tempConfigPath = '${{ env.ELECTRON_DIR }}/temp-builder-config.yml'
           $config | ConvertTo-Yaml | Set-Content -Path $tempConfigPath
-          Write-Host "✅ Successfully created temporary config '$tempConfigPath'
-with corrected icon paths."
+          Write-Host "✅ Successfully created temporary config '$tempConfigPath' with corrected icon paths."
       - name: 📄 Ensure WiX License Exists for electron-builder
         shell: pwsh
         run: |
           # electron-builder uses build_wix/license.rtf by convention
           $wixDir = 'build_wix'
-          if (-not (Test-Path $wixDir)) { New-Item -ItemType Directory -Path $wi
-xDir | Out-Null }
+          if (-not (Test-Path $wixDir)) { New-Item -ItemType Directory -Path $wixDir | Out-Null }
           $licensePath = Join-Path $wixDir 'license.rtf'
           if (-not (Test-Path $licensePath)) {
-            Write-Host '⚠️ License file missing. Generating placeholder for elec
-tron-builder...'
-            $rtfContent = '{\rtf1\ansi\deff0{\fonttbl{\f0 Arial;}}\f0\fs24 END U
-SER LICENSE AGREEMENT\par\par This is a placeholder license for Fortuna Faucet.
-Please replace with actual terms.}'
+            Write-Host '⚠️ License file missing. Generating placeholder for electron-builder...'
+            $rtfContent = '{\rtf1\ansi\deff0{\fonttbl{\f0 Arial;}}\f0\fs24 END USER LICENSE AGREEMENT\par\par This is a placeholder license for Fortuna Faucet. Please replace with actual terms.}'
             Set-Content -Path $licensePath -Value $rtfContent -Encoding Ascii
             Write-Host '✅ Placeholder license.rtf created.'
           } else {
@@ -271,19 +242,14 @@ Please replace with actual terms.}'
         run: |
           npm ci --prefer-offline
           $ver = "${{ needs.build-core.outputs.semver }}"
-          $arch_flag = if ('${{ matrix.arch }}' -eq 'x86') { '--ia32' } else { '
---x64' }
-          npm run dist -- --win msi $arch_flag --config temp-builder-config.yml
---publish never --config.artifactName="Fortuna-Electron-${ver}-${{ matrix.arch }
-}.msi"
+          $arch_flag = if ('${{ matrix.arch }}' -eq 'x86') { '--ia32' } else { '--x64' }
+          npm run dist -- --win msi $arch_flag --config temp-builder-config.yml --publish never --config.artifactName="Fortuna-Electron-${ver}-${{ matrix.arch }}.msi"
       - name: 🔬 Forensic Packaging Analysis
         shell: pwsh
         run: |
-          $unpackedDir = if ('${{ matrix.arch }}' -eq 'x86') { 'win-ia32-unpacke
-d' } else { 'win-unpacked' }
+          $unpackedDir = if ('${{ matrix.arch }}' -eq 'x86') { 'win-ia32-unpacked' } else { 'win-unpacked' }
           Write-Host "=== HYBRID STAGING LAYOUT (${{ matrix.arch }}) ==="
-          Get-ChildItem -Path "${{ env.ELECTRON_DIR }}/dist/$unpackedDir" -Recur
-se | Select-Object FullName, Length
+          Get-ChildItem -Path "${{ env.ELECTRON_DIR }}/dist/$unpackedDir" -Recurse | Select-Object FullName, Length
       - name: Rename & Hash MSI
         id: name_msi
         shell: pwsh
@@ -291,14 +257,12 @@ se | Select-Object FullName, Length
           $ver = "${{ needs.build-core.outputs.semver }}"
           $sha = "${{ needs.build-core.outputs.short_sha }}"
           $releaseDir = "${{ env.ELECTRON_DIR }}/dist"
-          $msiFound = Get-ChildItem -Path $releaseDir -Filter "*.msi" | Select-O
-bject -First 1
+          $msiFound = Get-ChildItem -Path $releaseDir -Filter "*.msi" | Select-Object -First 1
           if (-not $msiFound) {
             Write-Error "❌ FATAL: No MSI file found in $releaseDir."
             exit 1
           }
-          $targetName = "Fortuna-Electron-Hybrid-${{ matrix.arch }}-${ver}-${sha
-}.msi"
+          $targetName = "Fortuna-Electron-Hybrid-${{ matrix.arch }}-${ver}-${sha}.msi"
           $newPath = Join-Path $releaseDir $targetName
           Move-Item -Path $msiFound.FullName -Destination $newPath -Force
           "msi_name=$targetName" | Out-File $env:GITHUB_OUTPUT -Append
@@ -310,10 +274,8 @@ bject -First 1
           retention-days: 1
 
   # ============================================================================
-======
   # JOB 3: SMOKE TEST (The "Robust" Verification)
   # ============================================================================
-======
   smoke-test:
     name: '🔬 Smoke Test (${{ matrix.arch }})'
     runs-on: windows-latest
@@ -331,11 +293,9 @@ bject -First 1
       - name: 🤫 Install MSI & Verify
         shell: pwsh
         run: |
-          $msi = Get-ChildItem "installer" -Filter "*.msi" -Recurse | Select -Fi
-rst 1
+          $msi = Get-ChildItem "installer" -Filter "*.msi" -Recurse | Select -First 1
           if (!$msi) { throw "No MSI found" }
-          $proc = Start-Process msiexec.exe -ArgumentList "/i `"$($msi.FullName)
-`" /qn /L*v install.log" -Wait -PassThru
+          $proc = Start-Process msiexec.exe -ArgumentList "/i `"$($msi.FullName)`" /qn /L*v install.log" -Wait -PassThru
           if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
             Get-Content install.log -Tail 50
             throw "Install failed with code $($proc.ExitCode)"
@@ -344,60 +304,44 @@ rst 1
         shell: pwsh
         run: |
           $progFiles = ${env:ProgramFiles}
-          if ('${{ matrix.arch }}' -eq 'x86') { $progFiles = ${env:ProgramFiles(
-x86)} }
+          if ('${{ matrix.arch }}' -eq 'x86') { $progFiles = ${env:ProgramFiles(x86)} }
           $installRoot = Join-Path $progFiles "Fortuna Faucet"
           if (! (Test-Path $installRoot)) {
             Write-Error "Installation directory not found at $installRoot."
             exit 1
           }
-          New-Item -Path "$installRoot\data" -ItemType Directory -Force | Out-Nu
-ll
-          New-Item -Path "$installRoot\json" -ItemType Directory -Force | Out-Nu
-ll
-          New-Item -Path "$installRoot\logs" -ItemType Directory -Force | Out-Nu
-ll
+          New-Item -Path "$installRoot\data" -ItemType Directory -Force | Out-Null
+          New-Item -Path "$installRoot\json" -ItemType Directory -Force | Out-Null
+          New-Item -Path "$installRoot\logs" -ItemType Directory -Force | Out-Null
       - name: '🔬 Complete Smoke Test (3-Layer Defense)'
         shell: pwsh
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
           $progFiles = ${env:ProgramFiles}
-          if ('${{ matrix.arch }}' -eq 'x86') { $progFiles = ${env:ProgramFiles(
-x86)} }
+          if ('${{ matrix.arch }}' -eq 'x86') { $progFiles = ${env:ProgramFiles(x86)} }
           $installRoot = Join-Path $progFiles "Fortuna Faucet"
           # --- LAYER 1: FILE VERIFICATION ---
-          $mainExe = Get-ChildItem -Path $installRoot -Filter "*.exe" -Recurse |
- Where-Object { $_.Name -notmatch 'uninstall' } | Select -First 1
-          $backendExe = Get-ChildItem -Path $installRoot -Filter "fortuna-backen
-d.exe" -Recurse | Select -First 1
-          if (-not $mainExe) { Write-Error "❌ LAYER 1 FAILED: Main 'Fortuna Fauc
-et.exe' not found."; exit 1 }
-          if (-not $backendExe) { Write-Error "❌ LAYER 1 FAILED: Backend 'fortun
-a-backend.exe' not found."; exit 1 }
+          $mainExe = Get-ChildItem -Path $installRoot -Filter "*.exe" -Recurse | Where-Object { $_.Name -notmatch 'uninstall' } | Select -First 1
+          $backendExe = Get-ChildItem -Path $installRoot -Filter "fortuna-backend.exe" -Recurse | Select -First 1
+          if (-not $mainExe) { Write-Error "❌ LAYER 1 FAILED: Main 'Fortuna Faucet.exe' not found."; exit 1 }
+          if (-not $backendExe) { Write-Error "❌ LAYER 1 FAILED: Backend 'fortuna-backend.exe' not found."; exit 1 }
           # --- LAYER 2: PROCESS VERIFICATION ---
-          $proc = Start-Process -FilePath $mainExe.FullName -ArgumentList "--no-
-sandbox" -PassThru
+          $proc = Start-Process -FilePath $mainExe.FullName -ArgumentList "--no-sandbox" -PassThru
           Start-Sleep -Seconds 10
-          $parentProcess = Get-Process -Name "Fortuna Faucet" -ErrorAction Silen
-tlyContinue
-          $childProcess = Get-Process -Name "fortuna-backend" -ErrorAction Silen
-tlyContinue
-          if (-not $parentProcess) { Write-Error "❌ LAYER 2 FAILED: Main 'Fortun
-a Faucet' process is not running."; exit 1 }
-          if (-not $childProcess) { Write-Error "❌ LAYER 2 FAILED: Child 'fortun
-a-backend' process is not running."; exit 1 }
+          $parentProcess = Get-Process -Name "Fortuna Faucet" -ErrorAction SilentlyContinue
+          $childProcess = Get-Process -Name "fortuna-backend" -ErrorAction SilentlyContinue
+          if (-not $parentProcess) { Write-Error "❌ LAYER 2 FAILED: Main 'Fortuna Faucet' process is not running."; exit 1 }
+          if (-not $childProcess) { Write-Error "❌ LAYER 2 FAILED: Child 'fortuna-backend' process is not running."; exit 1 }
           # --- LAYER 3: NETWORK VERIFICATION ---
           $maxAttempts = 10
           $healthUrl = "http://localhost:${{ env.FORTUNA_PORT }}/health"
           for ($i = 1; $i -le $maxAttempts; $i++) {
             try {
-              $response = Invoke-WebRequest -Uri $healthUrl -Method Get -UseBasi
-cParsing -ErrorAction Stop
+              $response = Invoke-WebRequest -Uri $healthUrl -Method Get -UseBasicParsing -ErrorAction Stop
               if ($response.StatusCode -eq 200) {
                 Write-Host "✅✅✅ SMOKE TEST PASSED ✅✅✅"
-                Stop-Process -Name "Fortuna Faucet", "fortuna-backend" -Force -E
-rrorAction SilentlyContinue
+                Stop-Process -Name "Fortuna Faucet", "fortuna-backend" -Force -ErrorAction SilentlyContinue
                 exit 0
               }
             } catch { Start-Sleep -Seconds 5 }
@@ -406,14 +350,11 @@ rrorAction SilentlyContinue
           exit 1
       - name: Cleanup
         if: always()
-        run: Stop-Process -Name "Fortuna Faucet", "fortuna-backend" -Force -Erro
-rAction SilentlyContinue
+        run: Stop-Process -Name "Fortuna Faucet", "fortuna-backend" -Force -ErrorAction SilentlyContinue
 
   # ============================================================================
-======
   # JOB 4: RELEASE (The "Triple-Tap" Staging)
   # ============================================================================
-======
   release:
     name: '📦 Release'
     runs-on: windows-latest

--- a/.github/workflows/build-msi-hat-trick-fusion.yml
+++ b/.github/workflows/build-msi-hat-trick-fusion.yml
@@ -44,9 +44,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: web_platform/frontend/out
-          key: ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json', '
-web_platform/frontend/**/*.js', 'web_platform/frontend/**/*.ts', 'web_platform/f
-rontend/**/*.tsx', 'web_platform/frontend/**/*.css') }}
+          key: ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json', 'web_platform/frontend/**/*.js', 'web_platform/frontend/**/*.ts', 'web_platform/frontend/**/*.tsx', 'web_platform/frontend/**/*.css') }}
           restore-keys: |
             ${{ runner.os }}-frontend-
       - name: Install and Build
@@ -62,15 +60,12 @@ rontend/**/*.tsx', 'web_platform/frontend/**/*.css') }}
           Set-StrictMode -Version Latest
           $outDir = Resolve-Path "out"
           $manifestPath = "frontend-manifest.tsv"
-          "RelativePath`tSizeBytes`tSHA256" | Out-File $manifestPath -Encoding u
-tf8
+          "RelativePath`tSizeBytes`tSHA256" | Out-File $manifestPath -Encoding utf8
           $files = Get-ChildItem -Path $outDir -Recurse -File
           foreach ($f in $files) {
             $rel = $f.FullName.Substring($outDir.Path.Length).TrimStart('\','/')
-            $hash = (Get-FileHash $f.FullName -Algorithm SHA256).Hash.Substring(
-0,16)
-            "$rel`t$($f.Length)`t$hash" | Out-File $manifestPath -Encoding utf8
--Append
+            $hash = (Get-FileHash $f.FullName -Algorithm SHA256).Hash.Substring(0,16)
+            "$rel`t$($f.Length)`t$hash" | Out-File $manifestPath -Encoding utf8 -Append
           }
           Write-Host "✅ Generated frontend artifact manifest."
       - name: Upload Frontend
@@ -102,17 +97,12 @@ tf8
       - id: meta
         shell: pwsh
         run: |
-          $ver = if ("${{ github.ref }}" -match 'refs/tags/v(.*)') { $Matches[1]
- } else { "0.0.${{ github.run_number }}" }
-          "semver=$ver" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -
-Append
+          $ver = if ("${{ github.ref }}" -match 'refs/tags/v(.*)') { $Matches[1] } else { "0.0.${{ github.run_number }}" }
+          "semver=$ver" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           $shortSha = "${{ github.sha }}".Substring(0,7)
-          "short_sha=$shortSha" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Ap
-pend
-          "backend_dir=web_service/backend" | Out-File -FilePath $env:GITHUB_OUT
-PUT -Encoding utf8 -Append
-          "module_path=web_service.backend" | Out-File -FilePath $env:GITHUB_ENV
- -Encoding utf8 -Append
+          "short_sha=$shortSha" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "backend_dir=web_service/backend" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "module_path=web_service.backend" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -124,8 +114,7 @@ PUT -Encoding utf8 -Append
         run: |
           $constraintDir = "temp-constraints"
           New-Item -ItemType Directory -Path $constraintDir -Force | Out-Null
-          $constraintFile = Join-Path $constraintDir "constraint-${{ matrix.arch
- }}.txt"
+          $constraintFile = Join-Path $constraintDir "constraint-${{ matrix.arch }}.txt"
           if ('${{ matrix.arch }}' -eq 'x86') {
             # 🚀 GPT-5 SAFE MODE
             "numpy==1.23.5`r`npandas==1.5.3" | Set-Content $constraintFile
@@ -134,14 +123,11 @@ PUT -Encoding utf8 -Append
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r web_service/backend/requirements.txt -c ${{ steps.const
-raints.outputs.file }}
+          pip install -r web_service/backend/requirements.txt -c ${{ steps.constraints.outputs.file }}
           pip install pyinstaller==6.6.0 pywin32
       - name: Build Backend (PyInstaller)
         run: |
-          pyinstaller --noconfirm --onedir --clean --name fortuna-backend --hidd
-en-import=win32timezone --hidden-import=win32serviceutil --add-data "web_service
-/backend;backend" web_service/backend/service_entry.py
+          pyinstaller --noconfirm --onedir --clean --name fortuna-backend --hidden-import=win32timezone --hidden-import=win32serviceutil --add-data "web_service/backend;backend" web_service/backend/service_entry.py
       - name: Upload Backend
         uses: actions/upload-artifact@v4
         with:
@@ -169,32 +155,24 @@ en-import=win32timezone --hidden-import=win32serviceutil --add-data "web_service
           $target = "staging"
           $limitMB = 300
           Write-Host "--- 📊 Size Breakdown ---"
-          $files = Get-ChildItem -Path $target -Recurse -File -ErrorAction Silen
-tlyContinue
+          $files = Get-ChildItem -Path $target -Recurse -File -ErrorAction SilentlyContinue
           if (!$files) { Write-Warning "No files found to weigh."; exit 0 }
           $totalBytes = ($files | Measure-Object -Property Length -Sum).Sum
           $totalMB = [math]::Round($totalBytes / 1MB, 2)
           Write-Host "Total Payload Size: $totalMB MB"
           if ($totalMB -gt $limitMB) {
-              Write-Warning "⚠️ BLOAT ALERT: Build exceeds $limitMB MB limit! Ch
-eck the heaviest files below."
+              Write-Warning "⚠️ BLOAT ALERT: Build exceeds $limitMB MB limit! Check the heaviest files below."
           } else {
-              Write-Host "✅ Size within limits (< $limitMB MB)." -ForegroundColo
-r Green
+              Write-Host "✅ Size within limits (< $limitMB MB)." -ForegroundColor Green
           }
           Write-Host "`n--- 🐘 Top 10 Heaviest Files ---"
-          $files | Sort-Object Length -Descending | Select-Object -First 10 @{N=
-'File';E={$_.FullName.Replace($pwd,'')}}, @{N='Size(MB)';E={"{0:N2}" -f ($_.Leng
-th/1MB)}} | Format-Table -AutoSize
+          $files | Sort-Object Length -Descending | Select-Object -First 10 @{N='File';E={$_.FullName.Replace($pwd,'')}}, @{N='Size(MB)';E={"{0:N2}" -f ($_.Length/1MB)}} | Format-Table -AutoSize
 
       - name: Create Restart Service Batch Script
         shell: pwsh
         run: |
-          $scriptContent = "@echo off`r`necho Requesting Admin privileges to res
-tart FortunaWebService...`r`nnet stop FortunaWebService`r`nnet start FortunaWebS
-ervice`r`necho Service Restarted.`r`npause"
-          Set-Content -Path "staging/backend/restart_service.bat" -Value $script
-Content -Encoding Ascii
+          $scriptContent = "@echo off`r`necho Requesting Admin privileges to restart FortunaWebService...`r`nnet stop FortunaWebService`r`nnet start FortunaWebService`r`necho Service Restarted.`r`npause"
+          Set-Content -Path "staging/backend/restart_service.bat" -Value $scriptContent -Encoding Ascii
           Write-Host "✅ Created restart_service.bat script."
 
       - uses: actions/setup-dotnet@v4
@@ -204,18 +182,12 @@ Content -Encoding Ascii
       - name: 📄 Ensure WiX License Exists
         shell: pwsh
         run: |
-          if (-not (Test-Path build_wix)) { New-Item -ItemType Directory -Path b
-uild_wix | Out-Null }
+          if (-not (Test-Path build_wix)) { New-Item -ItemType Directory -Path build_wix | Out-Null }
           $licensePath = 'build_wix/license.rtf'
           if (-not (Test-Path $licensePath)) {
             Write-Host '⚠️ License file missing. Generating placeholder...'
-            # FIX: Use Base64 decoding to avoid RTF escape sequence issues in Po
-werShell/YAML
-            $rtfContent = [System.Text.Encoding]::ASCII.GetString([System.Conver
-t]::FromBase64String("e1xydGYxXGFuc2lcZGVmZjB7XGZvbnR0Ymx7XGYwIEFyaWFsO319XGYwXG
-ZzMjQgRU5EIFVTRVIgTElDRU5TRSBBR1JFRU1FTlRccGFyXHBhciBUaGlzIGlzIGEgcGxhY2Vob2xkZX
-IgbGljZW5zZSBmb3IgRm9ydHVuYSBGYXVjZXQuIFBsZWFzZSByZXBsYWNlIHdpdGggYWN0dWFsIHRlcm
-1zLn0="))
+            # FIX: Use Base64 decoding to avoid RTF escape sequence issues in PowerShell/YAML
+            $rtfContent = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String("e1xydGYxXGFuc2lcZGVmZjB7XGZvbnR0Ymx7XGYwIEFyaWFsO319XGYwXGZzMjQgRU5EIFVTRVIgTElDRU5TRSBBR1JFRU1FTlRccGFyXHBhciBUaGlzIGlzIGEgcGxhY2Vob2xkZXIgbGljZW5zZSBmb3IgRm9ydHVuYSBGYXVjZXQuIFBsZWFzZSByZXBsYWNlIHdpdGggYWN0dWFsIHRlcm1zLn0="))
             Set-Content -Path $licensePath -Value $rtfContent -Encoding Ascii
             Write-Host '✅ Placeholder license.rtf created.'
           } else {
@@ -225,23 +197,18 @@ IgbGljZW5zZSBmb3IgRm9ydHVuYSBGYXVjZXQuIFBsZWFzZSByZXBsYWNlIHdpdGggYWN0dWFsIHRlcm
         shell: pwsh
         run: |
           Set-StrictMode -Version Latest
-          if (-not (Test-Path build_wix)) { New-Item -ItemType Directory -Path b
-uild_wix | Out-Null }
-          Copy-Item build_wix/Product_WithService.wxs build_wix/Product.wxs -For
-ce
+          if (-not (Test-Path build_wix)) { New-Item -ItemType Directory -Path build_wix | Out-Null }
+          Copy-Item build_wix/Product_WithService.wxs build_wix/Product.wxs -Force
           $wxsPath = 'build_wix/Product.wxs'
           $wxsContent = [xml](Get-Content $wxsPath -Raw)
-          $serviceControl = $wxsContent.SelectSingleNode("//*[local-name()='Serv
-iceControl']")
+          $serviceControl = $wxsContent.SelectSingleNode("//*[local-name()='ServiceControl']")
           if ($serviceControl -and $serviceControl.HasAttribute("Start")) {
               $serviceControl.RemoveAttribute("Start")
               $wxsContent.Save($wxsPath)
-              Write-Host "✅ Dynamically removed 'Start=install' attribute from W
-iX template."
+              Write-Host "✅ Dynamically removed 'Start=install' attribute from WiX template."
           }
           if (Test-Path staging/backend/fortuna-backend.exe) {
-            Move-Item staging/backend/fortuna-backend.exe staging/backend/fortun
-a-webservice.exe -Force
+            Move-Item staging/backend/fortuna-backend.exe staging/backend/fortuna-webservice.exe -Force
           }
           $proj = @(
             '<Project Sdk="WixToolset.Sdk/${{ env.WIX_VERSION }}">',
@@ -249,37 +216,29 @@ a-webservice.exe -Force
             '    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>',
             '    <OutputType>Package</OutputType>',
             '    <Platforms>x64;x86</Platforms>',
-            '    <DefineConstants>Version=$(Version);SourceDir=$(SourceDir);Serv
-icePort=$(ServicePort)</DefineConstants>',
+            '    <DefineConstants>Version=$(Version);SourceDir=$(SourceDir);ServicePort=$(ServicePort)</DefineConstants>',
             '  </PropertyGroup>',
             '  <ItemGroup>',
-            '    <PackageReference Include="WixToolset.UI.wixext" Version="${{ e
-nv.WIX_VERSION }}" />',
-            '    <PackageReference Include="WixToolset.Firewall.wixext" Version=
-"${{ env.WIX_VERSION }}" />',
-            '    <PackageReference Include="WixToolset.Util.wixext" Version="${{
- env.WIX_VERSION }}" />',
+            '    <PackageReference Include="WixToolset.UI.wixext" Version="${{ env.WIX_VERSION }}" />',
+            '    <PackageReference Include="WixToolset.Firewall.wixext" Version="${{ env.WIX_VERSION }}" />',
+            '    <PackageReference Include="WixToolset.Util.wixext" Version="${{ env.WIX_VERSION }}" />',
             '  </ItemGroup>',
             '  <ItemGroup>',
             '    <Compile Include="Product.wxs" />',
             '  </ItemGroup>',
             '</Project>'
           )
-          Set-Content build_wix/Fortuna.wixproj ($proj -join "`r`n") -Encoding u
-tf8
+          Set-Content build_wix/Fortuna.wixproj ($proj -join "`r`n") -Encoding utf8
       - name: Build MSI
         working-directory: build_wix
         run: |
-          dotnet build Fortuna.wixproj -c Release -p:Platform=${{ matrix.arch }}
- -p:Version="${{ needs.build-backend.outputs.semver }}" -p:SourceDir="../staging
-/backend" -p:ServicePort="${{ env.SERVICE_PORT }}"
+          dotnet build Fortuna.wixproj -c Release -p:Platform=${{ matrix.arch }} -p:Version="${{ needs.build-backend.outputs.semver }}" -p:SourceDir="../staging/backend" -p:ServicePort="${{ env.SERVICE_PORT }}"
       - name: Rename & Hash MSI
         run: |
           $ver = "${{ needs.build-backend.outputs.semver }}"
           $sha = "${{ needs.build-backend.outputs.short_sha }}"
           $releaseDir = "build_wix/bin/${{ matrix.arch }}/Release"
-          $msiFound = Get-ChildItem -Path $releaseDir -Filter "*.msi" | Select-O
-bject -First 1
+          $msiFound = Get-ChildItem -Path $releaseDir -Filter "*.msi" | Select-Object -First 1
           if (-not $msiFound) { throw "MSI not found in $releaseDir" }
           $targetName = "HatTrickFusion-${{ matrix.arch }}-${ver}-${sha}.msi"
           $newPath = Join-Path $releaseDir $targetName
@@ -308,15 +267,13 @@ bject -First 1
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
-          $msiPath = (Get-ChildItem -Path "msi-installer" -Filter "*.msi" -Recur
-se | Select-Object -First 1).FullName
+          $msiPath = (Get-ChildItem -Path "msi-installer" -Filter "*.msi" -Recurse | Select-Object -First 1).FullName
           if (-not $msiPath) { throw "MSI not found!" }
           Write-Host "Found MSI at $msiPath"
 
           # 1. PRE-INSTALL CLEANUP
           Write-Host "Attempting pre-emptive service removal..."
-          $service = Get-Service -Name "FortunaWebService" -ErrorAction Silently
-Continue
+          $service = Get-Service -Name "FortunaWebService" -ErrorAction SilentlyContinue
           if ($service) {
             sc.exe delete "FortunaWebService"
             Start-Sleep -Seconds 5
@@ -326,8 +283,7 @@ Continue
           $logFile = "msi-install.log"
           $msiArgs = "/i `"$msiPath`" /qn /L*v `"$logFile`""
           Write-Host "Running: msiexec.exe $msiArgs"
-          $proc = Start-Process msiexec.exe -ArgumentList $msiArgs -Wait -PassTh
-ru
+          $proc = Start-Process msiexec.exe -ArgumentList $msiArgs -Wait -PassThru
           if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
             Get-Content $logFile -Tail 50
             throw "MSI installation failed with exit code $($proc.ExitCode)."
@@ -336,17 +292,12 @@ ru
 
           # 3. VERIFY & RUN
           $progFiles = ${env:ProgramFiles}
-          if ('${{ matrix.arch }}' -eq 'x86') { $progFiles = ${env:ProgramFiles(
-x86)} }
+          if ('${{ matrix.arch }}' -eq 'x86') { $progFiles = ${env:ProgramFiles(x86)} }
           $installDir = Join-Path $progFiles "Fortuna Faucet Service"
-          if (-not (Test-Path $installDir)) { throw "Installation directory not
-found!" }
-          New-Item -ItemType Directory -Path (Join-Path $installDir "data") -For
-ce | Out-Null
-          New-Item -ItemType Directory -Path (Join-Path $installDir "json") -For
-ce | Out-Null
-          New-Item -ItemType Directory -Path (Join-Path $installDir "logs") -For
-ce | Out-Null
+          if (-not (Test-Path $installDir)) { throw "Installation directory not found!" }
+          New-Item -ItemType Directory -Path (Join-Path $installDir "data") -Force | Out-Null
+          New-Item -ItemType Directory -Path (Join-Path $installDir "json") -Force | Out-Null
+          New-Item -ItemType Directory -Path (Join-Path $installDir "logs") -Force | Out-Null
           Start-Service -Name "FortunaWebService"
           Start-Sleep -Seconds 10
 
@@ -355,15 +306,13 @@ ce | Out-Null
           $delay = 5
           For ($i=0; $i -lt $maxRetries; $i++) {
             try {
-              $response = Invoke-WebRequest -Uri "http://localhost:${{ env.SERVI
-CE_PORT }}/health" -UseBasicParsing
+              $response = Invoke-WebRequest -Uri "http://localhost:${{ env.SERVICE_PORT }}/health" -UseBasicParsing
               if ($response.StatusCode -eq 200) {
                 Write-Host "✅ Health check PASSED."
                 Stop-Service -Name "FortunaWebService"
                 exit 0
               }
-            } catch { Write-Host "Attempt $($i+1) failed. Retrying in $delay sec
-onds..." }
+            } catch { Write-Host "Attempt $($i+1) failed. Retrying in $delay seconds..." }
             Start-Sleep -Seconds $delay
           }
           throw "Health check failed after $maxRetries attempts."

--- a/.github/workflows/build-msi-hattrickfusion-ultimate.yml
+++ b/.github/workflows/build-msi-hattrickfusion-ultimate.yml
@@ -44,9 +44,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: web_platform/frontend/out
-          key: ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json', '
-web_platform/frontend/**/*.js', 'web_platform/frontend/**/*.ts', 'web_platform/f
-rontend/**/*.tsx', 'web_platform/frontend/**/*.css') }}
+          key: ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json', 'web_platform/frontend/**/*.js', 'web_platform/frontend/**/*.ts', 'web_platform/frontend/**/*.tsx', 'web_platform/frontend/**/*.css') }}
           restore-keys: |
             ${{ runner.os }}-frontend-
       - name: Install and Build
@@ -62,15 +60,12 @@ rontend/**/*.tsx', 'web_platform/frontend/**/*.css') }}
           Set-StrictMode -Version Latest
           $outDir = Resolve-Path "out"
           $manifestPath = "frontend-manifest.tsv"
-          "RelativePath`tSizeBytes`tSHA256" | Out-File $manifestPath -Encoding u
-tf8
+          "RelativePath`tSizeBytes`tSHA256" | Out-File $manifestPath -Encoding utf8
           $files = Get-ChildItem -Path $outDir -Recurse -File
           foreach ($f in $files) {
             $rel = $f.FullName.Substring($outDir.Path.Length).TrimStart('\','/')
-            $hash = (Get-FileHash $f.FullName -Algorithm SHA256).Hash.Substring(
-0,16)
-            "$rel`t$($f.Length)`t$hash" | Out-File $manifestPath -Encoding utf8
--Append
+            $hash = (Get-FileHash $f.FullName -Algorithm SHA256).Hash.Substring(0,16)
+            "$rel`t$($f.Length)`t$hash" | Out-File $manifestPath -Encoding utf8 -Append
           }
           Write-Host "✅ Generated frontend artifact manifest."
       - name: Upload Frontend
@@ -122,17 +117,12 @@ tf8
       - id: meta
         shell: pwsh
         run: |
-          $ver = if ("${{ github.ref }}" -match 'refs/tags/v(.*)') { $Matches[1]
- } else { "0.0.${{ github.run_number }}" }
-          "semver=$ver" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -
-Append
+          $ver = if ("${{ github.ref }}" -match 'refs/tags/v(.*)') { $Matches[1] } else { "0.0.${{ github.run_number }}" }
+          "semver=$ver" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           $shortSha = "${{ github.sha }}".Substring(0,7)
-          "short_sha=$shortSha" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Ap
-pend
-          "backend_dir=web_service/backend" | Out-File -FilePath $env:GITHUB_OUT
-PUT -Encoding utf8 -Append
-          "module_path=web_service.backend" | Out-File -FilePath $env:GITHUB_ENV
- -Encoding utf8 -Append
+          "short_sha=$shortSha" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "backend_dir=web_service/backend" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "module_path=web_service.backend" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -144,8 +134,7 @@ PUT -Encoding utf8 -Append
         run: |
           $constraintDir = "temp-constraints"
           New-Item -ItemType Directory -Path $constraintDir -Force | Out-Null
-          $constraintFile = Join-Path $constraintDir "constraint-${{ matrix.arch
- }}.txt"
+          $constraintFile = Join-Path $constraintDir "constraint-${{ matrix.arch }}.txt"
           if ('${{ matrix.arch }}' -eq 'x86') {
             # 🚀 GPT-5 SAFE MODE
             "numpy==1.23.5`r`npandas==1.5.3" | Set-Content $constraintFile
@@ -154,15 +143,11 @@ PUT -Encoding utf8 -Append
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r web_service/backend/requirements.txt -c ${{ steps.const
-raints.outputs.file }}
+          pip install -r web_service/backend/requirements.txt -c ${{ steps.constraints.outputs.file }}
           pip install pyinstaller==6.6.0 pywin32
       - name: Build Backend (PyInstaller)
         run: |
-          pyinstaller --noconfirm --onedir --clean --name fortuna-backend --hidd
-en-import=win32timezone --hidden-import=win32serviceutil --add-data "web_service
-/backend;backend" --add-data "web_platform/frontend/out;ui" web_service/backend/
-service_entry.py
+          pyinstaller --noconfirm --onedir --clean --name fortuna-backend --hidden-import=win32timezone --hidden-import=win32serviceutil --add-data "web_service/backend;backend" --add-data "web_platform/frontend/out;ui" web_service/backend/service_entry.py
       - name: Upload Backend
         uses: actions/upload-artifact@v4
         with:
@@ -190,11 +175,9 @@ service_entry.py
       - name: '⚖️ The Dietician (Size Analysis)'
         shell: pwsh
         run: |
-          $stagingDir = "staging" # Adjust if your staging folder is named diffe
-rently
+          $stagingDir = "staging" # Adjust if your staging folder is named differently
           if (Test-Path $stagingDir) {
-            $size = (Get-ChildItem $stagingDir -Recurse | Measure-Object -Proper
-ty Length -Sum).Sum / 1MB
+            $size = (Get-ChildItem $stagingDir -Recurse | Measure-Object -Property Length -Sum).Sum / 1MB
             $sizeRounded = [math]::Round($size, 2)
             Write-Host "📊 Total Payload Size: $sizeRounded MB"
 
@@ -207,11 +190,8 @@ ty Length -Sum).Sum / 1MB
       - name: Create Restart Service Batch Script
         shell: pwsh
         run: |
-          $scriptContent = "@echo off`r`necho Requesting Admin privileges to res
-tart FortunaWebService...`r`nnet stop FortunaWebService`r`nnet start FortunaWebS
-ervice`r`necho Service Restarted.`r`npause"
-          Set-Content -Path "staging/backend/restart_service.bat" -Value $script
-Content -Encoding Ascii
+          $scriptContent = "@echo off`r`necho Requesting Admin privileges to restart FortunaWebService...`r`nnet stop FortunaWebService`r`nnet start FortunaWebService`r`necho Service Restarted.`r`npause"
+          Set-Content -Path "staging/backend/restart_service.bat" -Value $scriptContent -Encoding Ascii
           Write-Host "✅ Created restart_service.bat script."
       - uses: actions/setup-dotnet@v4
         with:
@@ -219,16 +199,11 @@ Content -Encoding Ascii
       - name: 📄 Ensure WiX License Exists
         shell: pwsh
         run: |
-          if (-not (Test-Path build_wix)) { New-Item -ItemType Directory -Path b
-uild_wix | Out-Null }
+          if (-not (Test-Path build_wix)) { New-Item -ItemType Directory -Path build_wix | Out-Null }
           $licensePath = 'build_wix/license.rtf'
           if (-not (Test-Path $licensePath)) {
             Write-Host '⚠️ License file missing. Generating placeholder...'
-            $rtfContent = [System.Text.Encoding]::ASCII.GetString([System.Conver
-t]::FromBase64String("e1xydGYxXGFuc2lcZGVmZjB7XGZvbnR0Ymx7XGYwIEFyaWFsO319XGYwXG
-ZzMjQgRU5EIFVTRVIgTElDRU5TRSBBR1JFRU1FTlRccGFyXHBhciBUaGlzIGlzIGEgcGxhY2Vob2xkZX
-IgbGljZW5zZSBmb3IgRm9ydHVuYSBGYXVjZXQuIFBsZWFzZSByZXBsYWNlIHdpdGggYWN0dWFsIHRlcm
-1zLn0="))
+            $rtfContent = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String("e1xydGYxXGFuc2lcZGVmZjB7XGZvbnR0Ymx7XGYwIEFyaWFsO319XGYwXGZzMjQgRU5EIFVTRVIgTElDRU5TRSBBR1JFRU1FTlRccGFyXHBhciBUaGlzIGlzIGEgcGxhY2Vob2xkZXIgbGljZW5zZSBmb3IgRm9ydHVuYSBGYXVjZXQuIFBsZWFzZSByZXBsYWNlIHdpdGggYWN0dWFsIHRlcm1zLn0="))
             Set-Content -Path $licensePath -Value $rtfContent -Encoding Ascii
             Write-Host '✅ Placeholder license.rtf created.'
           } else {
@@ -238,23 +213,18 @@ IgbGljZW5zZSBmb3IgRm9ydHVuYSBGYXVjZXQuIFBsZWFzZSByZXBsYWNlIHdpdGggYWN0dWFsIHRlcm
         shell: pwsh
         run: |
           Set-StrictMode -Version Latest
-          if (-not (Test-Path build_wix)) { New-Item -ItemType Directory -Path b
-uild_wix | Out-Null }
-          Copy-Item build_wix/Product_WithService.wxs build_wix/Product.wxs -For
-ce
+          if (-not (Test-Path build_wix)) { New-Item -ItemType Directory -Path build_wix | Out-Null }
+          Copy-Item build_wix/Product_WithService.wxs build_wix/Product.wxs -Force
           $wxsPath = 'build_wix/Product.wxs'
           $wxsContent = [xml](Get-Content $wxsPath -Raw)
-          $serviceControl = $wxsContent.SelectSingleNode("//*[local-name()='Serv
-iceControl']")
+          $serviceControl = $wxsContent.SelectSingleNode("//*[local-name()='ServiceControl']")
           if ($serviceControl -and $serviceControl.HasAttribute("Start")) {
               $serviceControl.RemoveAttribute("Start")
               $wxsContent.Save($wxsPath)
-              Write-Host "✅ Dynamically removed 'Start=install' attribute from W
-iX template."
+              Write-Host "✅ Dynamically removed 'Start=install' attribute from WiX template."
           }
           if (Test-Path staging/backend/fortuna-backend.exe) {
-            Move-Item staging/backend/fortuna-backend.exe staging/backend/fortun
-a-webservice.exe -Force
+            Move-Item staging/backend/fortuna-backend.exe staging/backend/fortuna-webservice.exe -Force
           }
           $proj = @(
             '<Project Sdk="WixToolset.Sdk/${{ env.WIX_VERSION }}">',
@@ -262,37 +232,29 @@ a-webservice.exe -Force
             '    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>',
             '    <OutputType>Package</OutputType>',
             '    <Platforms>x64;x86</Platforms>',
-            '    <DefineConstants>Version=$(Version);SourceDir=$(SourceDir);Serv
-icePort=$(ServicePort);Platform=$(Platform)</DefineConstants>',
+            '    <DefineConstants>Version=$(Version);SourceDir=$(SourceDir);ServicePort=$(ServicePort);Platform=$(Platform)</DefineConstants>',
             '  </PropertyGroup>',
             '  <ItemGroup>',
-            '    <PackageReference Include="WixToolset.UI.wixext" Version="${{ e
-nv.WIX_VERSION }}" />',
-            '    <PackageReference Include="WixToolset.Firewall.wixext" Version=
-"${{ env.WIX_VERSION }}" />',
-            '    <PackageReference Include="WixToolset.Util.wixext" Version="${{
- env.WIX_VERSION }}" />',
+            '    <PackageReference Include="WixToolset.UI.wixext" Version="${{ env.WIX_VERSION }}" />',
+            '    <PackageReference Include="WixToolset.Firewall.wixext" Version="${{ env.WIX_VERSION }}" />',
+            '    <PackageReference Include="WixToolset.Util.wixext" Version="${{ env.WIX_VERSION }}" />',
             '  </ItemGroup>',
             '  <ItemGroup>',
             '    <Compile Include="Product.wxs" />',
             '  </ItemGroup>',
             '</Project>'
           )
-          Set-Content build_wix/Fortuna.wixproj ($proj -join "`r`n") -Encoding u
-tf8
+          Set-Content build_wix/Fortuna.wixproj ($proj -join "`r`n") -Encoding utf8
       - name: Build MSI
         working-directory: build_wix
         run: |
-          dotnet build Fortuna.wixproj -c Release -p:Platform=${{ matrix.arch }}
- -p:Version="${{ needs.build-backend.outputs.semver }}" -p:SourceDir="../staging
-/backend" -p:ServicePort="${{ env.SERVICE_PORT }}"
+          dotnet build Fortuna.wixproj -c Release -p:Platform=${{ matrix.arch }} -p:Version="${{ needs.build-backend.outputs.semver }}" -p:SourceDir="../staging/backend" -p:ServicePort="${{ env.SERVICE_PORT }}"
       - name: Rename & Hash MSI
         run: |
           $ver = "${{ needs.build-backend.outputs.semver }}"
           $sha = "${{ needs.build-backend.outputs.short_sha }}"
           $releaseDir = "build_wix/bin/${{ matrix.arch }}/Release"
-          $msiFound = Get-ChildItem -Path $releaseDir -Filter "*.msi" | Select-O
-bject -First 1
+          $msiFound = Get-ChildItem -Path $releaseDir -Filter "*.msi" | Select-Object -First 1
           if (-not $msiFound) { throw "MSI not found in $releaseDir" }
           $targetName = "HatTrickFusion-${{ matrix.arch }}-${ver}-${sha}.msi"
           $newPath = Join-Path $releaseDir $targetName
@@ -321,14 +283,12 @@ bject -First 1
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
-          $msiPath = (Get-ChildItem -Path "msi-installer" -Filter "*.msi" -Recur
-se | Select-Object -First 1).FullName
+          $msiPath = (Get-ChildItem -Path "msi-installer" -Filter "*.msi" -Recurse | Select-Object -First 1).FullName
           if (-not $msiPath) { throw "MSI not found!" }
           Write-Host "Found MSI at $msiPath"
           # 1. PRE-INSTALL CLEANUP
           Write-Host "Attempting pre-emptive service removal..."
-          $service = Get-Service -Name "FortunaWebService" -ErrorAction Silently
-Continue
+          $service = Get-Service -Name "FortunaWebService" -ErrorAction SilentlyContinue
           if ($service) {
             sc.exe delete "FortunaWebService"
             Start-Sleep -Seconds 5
@@ -337,8 +297,7 @@ Continue
           $logFile = "msi-install.log"
           $msiArgs = "/i `"$msiPath`" /qn /L*v `"$logFile`""
           Write-Host "Running: msiexec.exe $msiArgs"
-          $proc = Start-Process msiexec.exe -ArgumentList $msiArgs -Wait -PassTh
-ru
+          $proc = Start-Process msiexec.exe -ArgumentList $msiArgs -Wait -PassThru
           if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
             Get-Content $logFile -Tail 50
             throw "MSI installation failed with exit code $($proc.ExitCode)."
@@ -346,17 +305,12 @@ ru
           Write-Host "✅ MSI Installation successful."
           # 3. VERIFY & RUN
           $progFiles = ${env:ProgramFiles}
-          if ('${{ matrix.arch }}' -eq 'x86') { $progFiles = ${env:ProgramFiles(
-x86)} }
+          if ('${{ matrix.arch }}' -eq 'x86') { $progFiles = ${env:ProgramFiles(x86)} }
           $installDir = Join-Path $progFiles "Fortuna Faucet Service"
-          if (-not (Test-Path $installDir)) { throw "Installation directory not
-found!" }
-          New-Item -ItemType Directory -Path (Join-Path $installDir "data") -For
-ce | Out-Null
-          New-Item -ItemType Directory -Path (Join-Path $installDir "json") -For
-ce | Out-Null
-          New-Item -ItemType Directory -Path (Join-Path $installDir "logs") -For
-ce | Out-Null
+          if (-not (Test-Path $installDir)) { throw "Installation directory not found!" }
+          New-Item -ItemType Directory -Path (Join-Path $installDir "data") -Force | Out-Null
+          New-Item -ItemType Directory -Path (Join-Path $installDir "json") -Force | Out-Null
+          New-Item -ItemType Directory -Path (Join-Path $installDir "logs") -Force | Out-Null
           Start-Service -Name "FortunaWebService"
           Start-Sleep -Seconds 10
           # 4. HEALTH CHECK
@@ -365,15 +319,13 @@ ce | Out-Null
           $success = $false
           For ($i=0; $i -lt $maxRetries; $i++) {
             try {
-              $response = Invoke-WebRequest -Uri "http://localhost:${{ env.SERVI
-CE_PORT }}/health" -UseBasicParsing
+              $response = Invoke-WebRequest -Uri "http://localhost:${{ env.SERVICE_PORT }}/health" -UseBasicParsing
               if ($response.StatusCode -eq 200) {
                 Write-Host "✅ Health check PASSED."
                 $success = $true
                 break
               }
-            } catch { Write-Host "Attempt $($i+1) failed. Retrying in $delay sec
-onds..." }
+            } catch { Write-Host "Attempt $($i+1) failed. Retrying in $delay seconds..." }
             Start-Sleep -Seconds $delay
           }
           if (-not $success) {
@@ -392,12 +344,7 @@ onds..." }
           # Ensure we hit the local service
           $url = "http://127.0.0.1:${{ env.SERVICE_PORT }}/docs"
 
-          $nodeScript = "const { chromium } = require('playwright'); (async () =
-> { const browser = await chromium.launch(); const page = await browser.newPage(
-); try { await page.goto('$url', { timeout: 10000 }); await page.screenshot({ pa
-th: 'proof-of-life.png', fullPage: true }); console.log('✅ Screenshot captured!'
-); } catch (e) { console.error('❌ Failed to capture screenshot:', e); process.ex
-it(1); } await browser.close(); })();"
+          $nodeScript = "const { chromium } = require('playwright'); (async () => { const browser = await chromium.launch(); const page = await browser.newPage(); try { await page.goto('$url', { timeout: 10000 }); await page.screenshot({ path: 'proof-of-life.png', fullPage: true }); console.log('✅ Screenshot captured!'); } catch (e) { console.error('❌ Failed to capture screenshot:', e); process.exit(1); } await browser.close(); })();"
           node -e $nodeScript
 
       - name: 📤 Upload Visual Proof

--- a/.github/workflows/build-msi-revived.yml
+++ b/.github/workflows/build-msi-revived.yml
@@ -91,18 +91,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           # 🚀 Apply Constraints
-          pip install -r ${{ env.BACKEND_DIR }}/requirements.txt -c ${{ steps.co
-nstraints.outputs.file }}
+          pip install -r ${{ env.BACKEND_DIR }}/requirements.txt -c ${{ steps.constraints.outputs.file }}
           pip install pyinstaller==6.6.0 pywin32
 
       - name: Build Backend (PyInstaller)
         run: |
           # CRITICAL: Target service_entry.py for Windows Service
           # CRITICAL: Add win32timezone to prevent Error 1053
-          pyinstaller --noconfirm --onedir --clean --name fortuna-backend --hidd
-en-import=win32timezone --hidden-import=win32serviceutil --add-data "web_service
-/backend;backend" --add-data "web_platform/frontend/out;ui" web_service/backend/
-service_entry.py
+          pyinstaller --noconfirm --onedir --clean --name fortuna-backend --hidden-import=win32timezone --hidden-import=win32serviceutil --add-data "web_service/backend;backend" --add-data "web_platform/frontend/out;ui" web_service/backend/service_entry.py
 
       - uses: actions/upload-artifact@v4
         with:
@@ -134,8 +130,7 @@ service_entry.py
       - name: '⚖️ The Dietician (Size Analysis)'
         shell: pwsh
         run: |
-          $size = (Get-ChildItem staging -Recurse | Measure-Object -Property Len
-gth -Sum).Sum / 1MB
+          $size = (Get-ChildItem staging -Recurse | Measure-Object -Property Length -Sum).Sum / 1MB
           Write-Host "Total Payload: $([math]::Round($size, 2)) MB"
 
       - uses: actions/setup-dotnet@v4
@@ -146,17 +141,13 @@ gth -Sum).Sum / 1MB
         working-directory: ${{ env.WIX_DIR }}
         run: |
           # 🚀 Pass Matrix Arch to WiX
-          dotnet build Fortuna.wixproj -c Release -p:Platform=${{ matrix.arch }}
- -p:Version="0.0.${{ github.run_number }}" -p:SourceDir="../staging/backend" -p:
-ServicePort="${{ env.FORTUNA_PORT }}"
+          dotnet build Fortuna.wixproj -c Release -p:Platform=${{ matrix.arch }} -p:Version="0.0.${{ github.run_number }}" -p:SourceDir="../staging/backend" -p:ServicePort="${{ env.FORTUNA_PORT }}"
 
       - name: Rename & Hash
         run: |
           $releaseDir = "${{ env.WIX_DIR }}/bin/${{ matrix.arch }}/Release"
-          $msi = Get-ChildItem -Path $releaseDir -Filter "*.msi" | Select -First
- 1
-          $target = "FortunaService-${{ matrix.arch }}-${{ github.run_number }}.
-msi"
+          $msi = Get-ChildItem -Path $releaseDir -Filter "*.msi" | Select -First 1
+          $target = "FortunaService-${{ matrix.arch }}-${{ github.run_number }}.msi"
           Move-Item $msi.FullName -Destination "$releaseDir/$target" -Force
           Write-Host "✅ MSI Ready: $target"
 
@@ -182,8 +173,7 @@ msi"
       - name: Install MSI
         run: |
           $msi = Get-ChildItem installer/*.msi | Select -First 1
-          Start-Process msiexec.exe -ArgumentList "/i `"$($msi.FullName)`" /qn /
-L*v install.log" -Wait
+          Start-Process msiexec.exe -ArgumentList "/i `"$($msi.FullName)`" /qn /L*v install.log" -Wait
 
       - name: Verify Service & Port
         shell: pwsh
@@ -191,20 +181,16 @@ L*v install.log" -Wait
           ARCH: ${{ matrix.arch }}
         run: |
           # 🚀 DYNAMIC PATH LOGIC
-          $progFiles = if ($env:ARCH -eq 'x86') { ${env:ProgramFiles(x86)} } els
-e { $env:ProgramFiles }
+          $progFiles = if ($env:ARCH -eq 'x86') { ${env:ProgramFiles(x86)} } else { $env:ProgramFiles }
           $installRoot = "$progFiles\FortunaWeb"
 
-          if (-not (Test-Path $installRoot)) { throw "❌ Install dir not found at
- $installRoot" }
+          if (-not (Test-Path $installRoot)) { throw "❌ Install dir not found at $installRoot" }
 
           Write-Host "Waiting for service..."
           Start-Sleep -Seconds 10
 
-          $response = Invoke-WebRequest -Uri "http://localhost:${{ env.FORTUNA_P
-ORT }}/health" -UseBasicParsing
-          if ($response.StatusCode -eq 200) { Write-Host "✅ Service Healthy" } e
-lse { throw "❌ Service Failed" }
+          $response = Invoke-WebRequest -Uri "http://localhost:${{ env.FORTUNA_PORT }}/health" -UseBasicParsing
+          if ($response.StatusCode -eq 200) { Write-Host "✅ Service Healthy" } else { throw "❌ Service Failed" }
 
       - name: '📸 Paparazzi (Visual Proof)'
         run: |
@@ -212,10 +198,7 @@ lse { throw "❌ Service Failed" }
           npx playwright install chromium --with-deps
           # FIX: Point to /docs
           $url = "http://127.0.0.1:${{ env.FORTUNA_PORT }}/docs"
-          node -e "const { chromium } = require('playwright'); (async () => { co
-nst browser = await chromium.launch(); const page = await browser.newPage(); awa
-it page.goto('$url'); await page.screenshot({ path: 'proof.png' }); await browse
-r.close(); })();"
+          node -e "const { chromium } = require('playwright'); (async () => { const browser = await chromium.launch(); const page = await browser.newPage(); await page.goto('$url'); await page.screenshot({ path: 'proof.png' }); await browser.close(); })();"
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/build-msi-supreme-combo.yml
+++ b/.github/workflows/build-msi-supreme-combo.yml
@@ -59,8 +59,7 @@ jobs:
       - name: 🔎 Forensic Asset Verification (GPT5)
         shell: pwsh
         run: |
-          $critical = @("web_platform/frontend/package.json", "web_service/backe
-nd/requirements.txt", "build_wix/Product_WithService.wxs")
+          $critical = @("web_platform/frontend/package.json", "web_service/backend/requirements.txt", "build_wix/Product_WithService.wxs")
           foreach ($file in $critical) {
             if (-not (Test-Path $file)) {
               Write-Error "❌ FATAL: Missing critical asset: $file"; exit 1
@@ -108,8 +107,7 @@ nd/requirements.txt", "build_wix/Product_WithService.wxs")
 
       - name: 📦 Install Dependencies
         run: |
-          pip install -r web_service/backend/requirements.txt -c ${{ steps.const
-raints.outputs.file }}
+          pip install -r web_service/backend/requirements.txt -c ${{ steps.constraints.outputs.file }}
           pip install pyinstaller
 
       - name: 🧪 Backend Quality Gate (Fail Fast)
@@ -187,19 +185,15 @@ raints.outputs.file }}
         shell: cmd
         run: |
           echo @echo off > staging\\backend\\restart_service.bat
-          echo net stop FortunaWebService >> staging\\backend\\restart_service.b
-at
-          echo net start FortunaWebService >> staging\\backend\\restart_service.
-bat
+          echo net stop FortunaWebService >> staging\\backend\\restart_service.bat
+          echo net start FortunaWebService >> staging\\backend\\restart_service.bat
 
       - name: ⚖️ The Dietician (Size Analysis)
         shell: pwsh
         run: |
-          $size = (Get-ChildItem staging -Recurse | Measure-Object -Property Len
-gth -Sum).Sum / 1MB
+          $size = (Get-ChildItem staging -Recurse | Measure-Object -Property Length -Sum).Sum / 1MB
           Write-Host "📊 Total Payload: $([math]::Round($size, 2)) MB"
-          if ($size -gt 300) { Write-Warning "⚠️ BLOAT ALERT: Payload exceeds 30
-0MB!" }
+          if ($size -gt 300) { Write-Warning "⚠️ BLOAT ALERT: Payload exceeds 300MB!" }
 
       - name: 🔧 Setup WiX
         run: dotnet tool install --global wix --version ${{ env.WIX_VERSION }}
@@ -221,8 +215,7 @@ gth -Sum).Sum / 1MB
           $msi = "Fortuna-${{ matrix.arch }}.msi"
           if (Test-Path "C:\\Program Files\\Windows Defender\\MpCmdRun.exe") {
             Write-Host "🛡️ Scanning $msi with Windows Defender..."
-            & "C:\\Program Files\\Windows Defender\\MpCmdRun.exe" -Scan -ScanTyp
-e 3 -File "$pwd\\$msi"
+            & "C:\\Program Files\\Windows Defender\\MpCmdRun.exe" -Scan -ScanType 3 -File "$pwd\\$msi"
             if ($LASTEXITCODE -ne 0) { throw "🦠 MALWARE DETECTED in MSI!" }
           }
 
@@ -259,21 +252,17 @@ e 3 -File "$pwd\\$msi"
         shell: pwsh
         run: |
           $msi = "Fortuna-${{ matrix.arch }}.msi"
-          Start-Process msiexec.exe -ArgumentList "/i $msi /quiet /norestart" -W
-ait
+          Start-Process msiexec.exe -ArgumentList "/i $msi /quiet /norestart" -Wait
           Start-Sleep 10 # Give service time to register
 
       - name: 🔍 Dynamic Path Verification (Revived)
         shell: pwsh
         run: |
-          $progFiles = if ('${{ matrix.arch }}' -eq 'x86') { ${env:ProgramFiles(
-x86)} } else { $env:ProgramFiles }
+          $progFiles = if ('${{ matrix.arch }}' -eq 'x86') { ${env:ProgramFiles(x86)} } else { $env:ProgramFiles }
           $installRoot = Join-Path $progFiles "Fortuna Faucet Service"
-          if (-not (Test-Path $installRoot)) { throw "❌ Install dir not found at
- $installRoot" }
+          if (-not (Test-Path $installRoot)) { throw "❌ Install dir not found at $installRoot" }
           Write-Host "✅ Found install at $installRoot"
-          New-Item -Path "$installRoot\data", "$installRoot\json", "$installRoot
-\logs" -ItemType Directory -Force | Out-Null
+          New-Item -Path "$installRoot\data", "$installRoot\json", "$installRoot\logs" -ItemType Directory -Force | Out-Null
           Start-Service "FortunaWebService"
           Start-Sleep 10
 
@@ -282,10 +271,8 @@ x86)} } else { $env:ProgramFiles }
         run: |
           for ($i=0; $i -lt 5; $i++) {
             try {
-              $resp = Invoke-RestMethod "http://127.0.0.1:${{ env.SERVICE_PORT }
-}/health" -ErrorAction Stop
-              if ($resp.status -eq "ok") { Write-Host "✅ Service Healthy"; retur
-n }
+              $resp = Invoke-RestMethod "http://127.0.0.1:${{ env.SERVICE_PORT }}/health" -ErrorAction Stop
+              if ($resp.status -eq "ok") { Write-Host "✅ Service Healthy"; return }
             } catch { Write-Host "⏳ Waiting for service..." }
             Start-Sleep 5
           }

--- a/.github/workflows/build-msi-unified.yml
+++ b/.github/workflows/build-msi-unified.yml
@@ -49,21 +49,17 @@ jobs:
         run: |
           $MAX_FAILURES = 30
           Write-Host "Running Test Suite (Threshold: $MAX_FAILURES failures)..."
-          cmd /c "pytest web_service/backend --junitxml=test-report.xml" || Writ
-e-Host "Pytest finished with issues."
+          cmd /c "pytest web_service/backend --junitxml=test-report.xml" || Write-Host "Pytest finished with issues."
 
           if (Test-Path "test-report.xml") {
               [xml]$xml = Get-Content "test-report.xml"
               $failures = 0; $errors = 0
-              if ($xml.testsuites) { $failures = [int]$xml.testsuites.failures;
-$errors = [int]$xml.testsuites.errors }
-              elseif ($xml.testsuite) { $failures = [int]$xml.testsuite.failures
-; $errors = [int]$xml.testsuite.errors }
+              if ($xml.testsuites) { $failures = [int]$xml.testsuites.failures; $errors = [int]$xml.testsuites.errors }
+              elseif ($xml.testsuite) { $failures = [int]$xml.testsuite.failures; $errors = [int]$xml.testsuite.errors }
 
               $total = $failures + $errors
               Write-Host "Total Issues: $total (Limit: $MAX_FAILURES)"
-              if ($total -gt $MAX_FAILURES) { Write-Error "❌ Too many failures."
-; exit 1 }
+              if ($total -gt $MAX_FAILURES) { Write-Error "❌ Too many failures."; exit 1 }
               else { Write-Host "✅ Failure count acceptable."; exit 0 }
           } else {
               Write-Warning "No test report found. Skipping gate."
@@ -88,8 +84,7 @@ $errors = [int]$xml.testsuites.errors }
 
       - name: Set Build ID
         id: vars
-        run: echo "build_id=${{ github.run_id }}-${{ github.run_attempt }}" | Ou
-t-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        run: echo "build_id=${{ github.run_id }}-${{ github.run_attempt }}" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -103,9 +98,7 @@ t-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
         uses: actions/cache@v4
         with:
           path: ${{ env.FRONTEND_DIR }}/out
-          key: ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json', '
-${{ env.FRONTEND_DIR }}/**/*.js', '${{ env.FRONTEND_DIR }}/**/*.ts', '${{ env.FR
-ONTEND_DIR }}/**/*.tsx', '${{ env.FRONTEND_DIR }}/**/*.css') }}
+          key: ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json', '${{ env.FRONTEND_DIR }}/**/*.js', '${{ env.FRONTEND_DIR }}/**/*.ts', '${{ env.FRONTEND_DIR }}/**/*.tsx', '${{ env.FRONTEND_DIR }}/**/*.css') }}
           restore-keys: |
             ${{ runner.os }}-frontend-
 
@@ -150,8 +143,7 @@ ONTEND_DIR }}/**/*.tsx', '${{ env.FRONTEND_DIR }}/**/*.css') }}
           from pathlib import Path
 
           # Install deps with constraints
-          os.system("pip install -r " + os.environ['BACKEND_DIR'] + "/requiremen
-ts.txt -c " + os.environ['CONSTRAINTS_FILE'])
+          os.system("pip install -r " + os.environ['BACKEND_DIR'] + "/requirements.txt -c " + os.environ['CONSTRAINTS_FILE'])
           os.system("pip install pyinstaller==6.6.0 pywin32")
 
           bk_dir = os.environ['BACKEND_DIR'].replace('\\', '/')
@@ -161,18 +153,15 @@ ts.txt -c " + os.environ['CONSTRAINTS_FILE'])
 
           spec = f"""
           # -- mode: python ; coding: utf-8 --
-          from PyInstaller.utils.hooks import collect_data_files, collect_submod
-ules
+          from PyInstaller.utils.hooks import collect_data_files, collect_submodules
           block_cipher = None
           a = Analysis(
               ['{entry}'],
               pathex=[],
               binaries=[],
-              datas=collect_data_files('uvicorn') + collect_data_files('slowapi'
-) + [('{frontend_out}', 'ui')],
+              datas=collect_data_files('uvicorn') + collect_data_files('slowapi') + [('{frontend_out}', 'ui')],
               # FIX: Added win32timezone to prevent Error 1053
-              hiddenimports=collect_submodules('{mod_path}') + ['win32timezone']
-,
+              hiddenimports=collect_submodules('{mod_path}') + ['win32timezone'],
               hookspath=[],
               runtime_hooks=[],
               excludes=['tests', 'pytest'],
@@ -184,8 +173,7 @@ ules
           pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
           exe = EXE(
               pyz, a.scripts, [],
-              exclude_binaries=True, name='fortuna-backend', debug=False, bootlo
-ader_ignore_signals=False, strip=False, upx=True, console=False
+              exclude_binaries=True, name='fortuna-backend', debug=False, bootloader_ignore_signals=False, strip=False, upx=True, console=False
           )
           coll = COLLECT(
               exe, a.binaries, a.zipfiles, a.datas,
@@ -202,22 +190,18 @@ ader_ignore_signals=False, strip=False, upx=True, console=False
           Set-StrictMode -Version Latest
           $outDir = Resolve-Path "out"
           $manifestPath = "frontend-manifest.tsv"
-          "RelativePath`tSizeBytes`tSHA256" | Out-File $manifestPath -Encoding u
-tf8
+          "RelativePath`tSizeBytes`tSHA256" | Out-File $manifestPath -Encoding utf8
           $files = Get-ChildItem -Path $outDir -Recurse -File
           foreach ($f in $files) {
             $rel = $f.FullName.Substring($outDir.Path.Length).TrimStart('\','/')
-            $hash = (Get-FileHash $f.FullName -Algorithm SHA256).Hash.Substring(
-0,16)
-            "$rel`t$($f.Length)`t$hash" | Out-File $manifestPath -Encoding utf8
--Append
+            $hash = (Get-FileHash $f.FullName -Algorithm SHA256).Hash.Substring(0,16)
+            "$rel`t$($f.Length)`t$hash" | Out-File $manifestPath -Encoding utf8 -Append
           }
 
       - name: Upload Backend and Frontend Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts-${{ matrix.arch }}-${{ steps.vars.outputs.build_
-id }}
+          name: build-artifacts-${{ matrix.arch }}-${{ steps.vars.outputs.build_id }}
           path: |
             dist/fortuna-backend/
             ${{ env.FRONTEND_DIR }}/frontend-manifest.tsv
@@ -240,8 +224,7 @@ id }}
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: build-artifacts-${{ matrix.arch }}-${{ needs.build-executable.ou
-tputs.build_id }}
+          name: build-artifacts-${{ matrix.arch }}-${{ needs.build-executable.outputs.build_id }}
           path: staging
 
       - name: '⚖️ The Dietician (Size Analysis)'
@@ -250,37 +233,28 @@ tputs.build_id }}
           $target = "staging"
           $limitMB = 300
           Write-Host "--- 📊 Size Breakdown ---"
-          $files = Get-ChildItem -Path $target -Recurse -File -ErrorAction Silen
-tlyContinue
+          $files = Get-ChildItem -Path $target -Recurse -File -ErrorAction SilentlyContinue
           if (!$files) { Write-Warning "No files found to weigh."; exit 0 }
           $totalBytes = ($files | Measure-Object -Property Length -Sum).Sum
           $totalMB = [math]::Round($totalBytes / 1MB, 2)
           Write-Host "Total Payload Size: $totalMB MB"
           if ($totalMB -gt $limitMB) {
-              Write-Warning "⚠️ BLOAT ALERT: Build exceeds $limitMB MB limit! Ch
-eck the heaviest files below."
+              Write-Warning "⚠️ BLOAT ALERT: Build exceeds $limitMB MB limit! Check the heaviest files below."
           } else {
-              Write-Host "✅ Size within limits (< $limitMB MB)." -ForegroundColo
-r Green
+              Write-Host "✅ Size within limits (< $limitMB MB)." -ForegroundColor Green
           }
           Write-Host "`n--- 🐘 Top 10 Heaviest Files ---"
-          $files | Sort-Object Length -Descending | Select-Object -First 10 @{N=
-'File';E={$_.FullName.Replace($pwd,'')}}, @{N='Size(MB)';E={"{0:N2}" -f ($_.Leng
-th/1MB)}} | Format-Table -AutoSize
+          $files | Sort-Object Length -Descending | Select-Object -First 10 @{N='File';E={$_.FullName.Replace($pwd,'')}}, @{N='Size(MB)';E={"{0:N2}" -f ($_.Length/1MB)}} | Format-Table -AutoSize
 
       - name: Prepare Staging
         shell: pwsh
         run: |
           # Rename EXE for WiX
-          Rename-Item -Path staging/fortuna-backend.exe -NewName fortuna-webserv
-ice.exe -Force
+          Rename-Item -Path staging/fortuna-backend.exe -NewName fortuna-webservice.exe -Force
 
           # Create Restart Script (Required by WiX)
-          $scriptContent = "@echo off`r`necho Requesting Admin privileges...`r`n
-net stop FortunaWebService`r`nnet start FortunaWebService`r`necho Service Restar
-ted.`r`npause"
-          Set-Content -Path "staging/restart_service.bat" -Value $scriptContent
--Encoding Ascii
+          $scriptContent = "@echo off`r`necho Requesting Admin privileges...`r`nnet stop FortunaWebService`r`nnet start FortunaWebService`r`necho Service Restarted.`r`npause"
+          Set-Content -Path "staging/restart_service.bat" -Value $scriptContent -Encoding Ascii
           Write-Host "✅ Created restart_service.bat"
 
       - name: Setup .NET SDK
@@ -291,18 +265,15 @@ ted.`r`npause"
       - name: Prepare WiX Project
         shell: pwsh
         run: |
-          if (-not (Test-Path build_wix)) { New-Item -ItemType Directory -Path b
-uild_wix | Out-Null }
+          if (-not (Test-Path build_wix)) { New-Item -ItemType Directory -Path build_wix | Out-Null }
 
           # License
           if (-not (Test-Path 'build_wix/license.rtf')) {
-             Set-Content -Path 'build_wix/license.rtf' -Value '{\rtf1\ansi Place
-holder License}' -Encoding Ascii
+             Set-Content -Path 'build_wix/license.rtf' -Value '{\rtf1\ansi Placeholder License}' -Encoding Ascii
           }
 
           # Copy WXS
-          Copy-Item "${{ env.WIX_DIR }}/Product_WithService.wxs" "${{ env.WIX_DI
-R }}/Product.wxs" -Force
+          Copy-Item "${{ env.WIX_DIR }}/Product_WithService.wxs" "${{ env.WIX_DIR }}/Product.wxs" -Force
 
           # Generate Project
           $proj = @(
@@ -311,30 +282,23 @@ R }}/Product.wxs" -Force
             '    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>',
             '    <OutputType>Package</OutputType>',
             '    <Platforms>x64;x86</Platforms>',
-            '    <DefineConstants>Version=$(Version);SourceDir=$(SourceDir);Serv
-icePort=$(ServicePort);Platform=$(Platform)</DefineConstants>',
+            '    <DefineConstants>Version=$(Version);SourceDir=$(SourceDir);ServicePort=$(ServicePort);Platform=$(Platform)</DefineConstants>',
             '  </PropertyGroup>',
             '  <ItemGroup>',
-            '    <PackageReference Include="WixToolset.UI.wixext" Version="${{ e
-nv.WIX_VERSION }}" />',
-            '    <PackageReference Include="WixToolset.Firewall.wixext" Version=
-"${{ env.WIX_VERSION }}" />',
-            '    <PackageReference Include="WixToolset.Util.wixext" Version="${{
- env.WIX_VERSION }}" />',
+            '    <PackageReference Include="WixToolset.UI.wixext" Version="${{ env.WIX_VERSION }}" />',
+            '    <PackageReference Include="WixToolset.Firewall.wixext" Version="${{ env.WIX_VERSION }}" />',
+            '    <PackageReference Include="WixToolset.Util.wixext" Version="${{ env.WIX_VERSION }}" />',
             '  </ItemGroup>',
             '  <ItemGroup>',
             '    <Compile Include="Product.wxs" />',
             '  </ItemGroup>',
             '</Project>'
           )
-          Set-Content "${{ env.WIX_DIR }}/Fortuna.wixproj" -Value ($proj -join "
-`r`n") -Encoding utf8
+          Set-Content "${{ env.WIX_DIR }}/Fortuna.wixproj" -Value ($proj -join "`r`n") -Encoding utf8
 
       - name: Build MSI
         working-directory: ${{ env.WIX_DIR }}
-        run: dotnet build Fortuna.wixproj -c Release -p:Platform=${{ matrix.arch
- }} -p:Version="0.0.${{ github.run_number }}" -p:SourceDir="../staging" -p:Servi
-cePort="${{ env.SERVICE_PORT }}"
+        run: dotnet build Fortuna.wixproj -c Release -p:Platform=${{ matrix.arch }} -p:Version="0.0.${{ github.run_number }}" -p:SourceDir="../staging" -p:ServicePort="${{ env.SERVICE_PORT }}"
 
       - name: Rename & Hash MSI
         id: name_msi
@@ -343,8 +307,7 @@ cePort="${{ env.SERVICE_PORT }}"
           $ver = "0.0.${{ github.run_number }}"
           $sha = "${{ github.sha }}".Substring(0,7)
           $releaseDir = "${{ env.WIX_DIR }}/bin/${{ matrix.arch }}/Release"
-          $msiFound = Get-ChildItem -Path $releaseDir -Filter "*.msi" | Select-O
-bject -First 1
+          $msiFound = Get-ChildItem -Path $releaseDir -Filter "*.msi" | Select-Object -First 1
           if (-not $msiFound) {
             Write-Error "❌ FATAL: No MSI file found in $releaseDir."
             exit 1
@@ -359,8 +322,7 @@ bject -First 1
       - name: Upload MSI Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: msi-installer-${{ matrix.arch }}-${{ needs.build-executable.outp
-uts.build_id }}
+          name: msi-installer-${{ matrix.arch }}-${{ needs.build-executable.outputs.build_id }}
           path: ${{ env.WIX_DIR }}/bin/${{ matrix.arch }}/Release/*
           retention-days: 1
 
@@ -376,20 +338,16 @@ uts.build_id }}
       - name: Download MSI
         uses: actions/download-artifact@v4
         with:
-          name: msi-installer-${{ matrix.arch }}-${{ needs.package-msi.outputs.b
-uild_id }}
+          name: msi-installer-${{ matrix.arch }}-${{ needs.package-msi.outputs.build_id }}
           path: msi-installer
 
       - name: Install MSI
         shell: pwsh
         run: |
-          $msi = Get-ChildItem -Path "msi-installer" -Filter "*.msi" -Recurse |
-Select-Object -First 1
+          $msi = Get-ChildItem -Path "msi-installer" -Filter "*.msi" -Recurse | Select-Object -First 1
           if (-not $msi) { throw "No MSI found" }
-          $proc = Start-Process msiexec.exe -ArgumentList "/i `"$($msi.FullName)
-`" /qn /L*v msi-install.log" -Wait -PassThru
-          if ($proc.ExitCode -ne 0) { throw "Install failed: $($proc.ExitCode)"
-}
+          $proc = Start-Process msiexec.exe -ArgumentList "/i `"$($msi.FullName)`" /qn /L*v msi-install.log" -Wait -PassThru
+          if ($proc.ExitCode -ne 0) { throw "Install failed: $($proc.ExitCode)" }
 
       - name: '🔬 Complete Smoke Test (3-Layer Defense)'
         shell: pwsh
@@ -397,31 +355,25 @@ Select-Object -First 1
           Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
           $progFiles = ${env:ProgramFiles}
-          if ('${{ matrix.arch }}' -eq 'x86') { $progFiles = ${env:ProgramFiles(
-x86)} }
+          if ('${{ matrix.arch }}' -eq 'x86') { $progFiles = ${env:ProgramFiles(x86)} }
           $installRoot = Join-Path $progFiles "Fortuna Faucet Service"
           # --- LAYER 1: FILE VERIFICATION ---
-          if (-not (Test-Path $installRoot)) { Write-Error "❌ LAYER 1 FAILED: In
-stall directory not found."; exit 1 }
-          New-Item -Path "$installRoot\data", "$installRoot\json", "$installRoot
-\logs" -ItemType Directory -Force | Out-Null
+          if (-not (Test-Path $installRoot)) { Write-Error "❌ LAYER 1 FAILED: Install directory not found."; exit 1 }
+          New-Item -Path "$installRoot\data", "$installRoot\json", "$installRoot\logs" -ItemType Directory -Force | Out-Null
           # --- LAYER 2: PROCESS VERIFICATION ---
           Start-Service "Fortuna Faucet Service"
           Start-Sleep -Seconds 10
           $svc = Get-Service "Fortuna Faucet Service"
           if ($svc.Status -ne 'Running') {
-            Write-Error "❌ LAYER 2 FAILED: Service failed to start. Status: $($s
-vc.Status)"
+            Write-Error "❌ LAYER 2 FAILED: Service failed to start. Status: $($svc.Status)"
             exit 1
           }
           # --- LAYER 3: NETWORK VERIFICATION ---
           $maxAttempts = 10
           for ($i = 1; $i -le $maxAttempts; $i++) {
             try {
-              $response = Invoke-WebRequest -Uri "http://localhost:${{ env.SERVI
-CE_PORT }}/health" -Method Get -UseBasicParsing -ErrorAction Stop
-              if ($response.StatusCode -eq 200) { Write-Host "✅✅✅ SMOKE TEST PAS
-SED ✅✅✅"; exit 0 }
+              $response = Invoke-WebRequest -Uri "http://localhost:${{ env.SERVICE_PORT }}/health" -Method Get -UseBasicParsing -ErrorAction Stop
+              if ($response.StatusCode -eq 200) { Write-Host "✅✅✅ SMOKE TEST PASSED ✅✅✅"; exit 0 }
             } catch { Start-Sleep -Seconds 5 }
           }
           Write-Error "❌ LAYER 3 FAILED: Service Failed Health Check"
@@ -438,8 +390,7 @@ SED ✅✅✅"; exit 0 }
               try {
                 const browser = await chromium.launch();
                 const page = await browser.newPage();
-                await page.goto('http://127.0.0.1:${{ env.SERVICE_PORT }}/docs',
- { timeout: 15000 });
+                await page.goto('http://127.0.0.1:${{ env.SERVICE_PORT }}/docs', { timeout: 15000 });
                 await page.waitForSelector('.swagger-ui', { timeout: 5000 });
                 await page.screenshot({ path: 'proof.png', fullPage: true });
                 await browser.close();

--- a/.github/workflows/build-web-service-msi-jules.yml
+++ b/.github/workflows/build-web-service-msi-jules.yml
@@ -70,20 +70,16 @@ jobs:
           # Test web_service path
           $web_service_main = Test-Path (Join-Path $web_service_path "main.py")
           $web_service_api = Test-Path (Join-Path $web_service_path "api.py")
-          $web_service_init = Test-Path (Join-Path $web_service_path "__init__.p
-y")
+          $web_service_init = Test-Path (Join-Path $web_service_path "__init__.py")
           Write-Host "Checking '$web_service_path':"
           Write-Host "  main.py -> $web_service_main"
           Write-Host "  api.py -> $web_service_api"
           Write-Host "  __init__.py -> $web_service_init"
 
           # Test python_service path
-          $python_service_main = Test-Path (Join-Path $python_service_path "main
-.py")
-          $python_service_api = Test-Path (Join-Path $python_service_path "api.p
-y")
-          $python_service_init = Test-Path (Join-Path $python_service_path "__in
-it__.py")
+          $python_service_main = Test-Path (Join-Path $python_service_path "main.py")
+          $python_service_api = Test-Path (Join-Path $python_service_path "api.py")
+          $python_service_init = Test-Path (Join-Path $python_service_path "__init__.py")
           Write-Host "Checking '$python_service_path':"
           Write-Host "  main.py -> $python_service_main"
           Write-Host "  api.py -> $python_service_api"
@@ -93,19 +89,14 @@ it__.py")
             $backend_dir = $web_service_path
             $backend_module_path = "web_service.backend"
             $spec_file = "jules.spec"
-            Write-Host "✅ Verdict: Detected 'web_service/backend' as the target.
-" -ForegroundColor Green
-          } elseif ($python_service_main -and $python_service_api -and $python_s
-ervice_init) {
+            Write-Host "✅ Verdict: Detected 'web_service/backend' as the target." -ForegroundColor Green
+          } elseif ($python_service_main -and $python_service_api -and $python_service_init) {
             $backend_dir = $python_service_path
             $backend_module_path = "python_service"
             $spec_file = "fortuna-backend-webservice.spec"
-            Write-Host "✅ Verdict: Detected 'python_service' as the target." -Fo
-regroundColor Green
+            Write-Host "✅ Verdict: Detected 'python_service' as the target." -ForegroundColor Green
           } else {
-            Write-Host "❌ FATAL: Could not determine a valid backend directory.
-Neither 'web_service/backend' nor 'python_service' contains the required files (
-main.py, api.py, __init__.py)." -ForegroundColor Red
+            Write-Host "❌ FATAL: Could not determine a valid backend directory. Neither 'web_service/backend' nor 'python_service' contains the required files (main.py, api.py, __init__.py)." -ForegroundColor Red
             exit 1
           }
 
@@ -114,12 +105,9 @@ main.py, api.py, __init__.py)." -ForegroundColor Red
           Write-Host "backend_module_path: $backend_module_path"
           Write-Host "spec_file: $spec_file"
 
-          "backend_dir=$backend_dir" | Out-File $env:GITHUB_OUTPUT -Encoding utf
-8 -Append
-          "backend_module_path=$backend_module_path" | Out-File $env:GITHUB_OUTP
-UT -Encoding utf8 -Append
-          "spec_file=$spec_file" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -A
-ppend
+          "backend_dir=$backend_dir" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "backend_module_path=$backend_module_path" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "spec_file=$spec_file" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
   system-check:
     name: '⚙️ System Prerequisites'
     runs-on: windows-latest
@@ -135,13 +123,11 @@ ppend
             Write-Host "Checking for $($tool)..."
             Get-Command $tool -ErrorAction SilentlyContinue
             if (-not $?) {
-              Write-Host "❌ FATAL: Build tool '$tool' not found in PATH." -Foreg
-roundColor Red
+              Write-Host "❌ FATAL: Build tool '$tool' not found in PATH." -ForegroundColor Red
               exit 1
             }
           }
-          Write-Host "✅ All critical build tools are present." -ForegroundColor
-Green
+          Write-Host "✅ All critical build tools are present." -ForegroundColor Green
       - name: Check Disk Space
         id: system
         run: |
@@ -149,11 +135,9 @@ Green
           $disk = Get-Volume | Where-Object { $_.DriveLetter -eq 'C' }
           $freeGB = [math]::Round($disk.SizeRemaining / 1GB, 2)
           if ($freeGB -lt 10) {
-            Write-Host "⚠️ WARNING: Low disk space. Only $freeGB GB free (10+ GB
- recommended)." -ForegroundColor Yellow
+            Write-Host "⚠️ WARNING: Low disk space. Only $freeGB GB free (10+ GB recommended)." -ForegroundColor Yellow
           } else {
-            Write-Host "✅ Disk space check passed ($freeGB GB free)." -Foregroun
-dColor Green
+            Write-Host "✅ Disk space check passed ($freeGB GB free)." -ForegroundColor Green
           }
           "disk_gb=$freeGB" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
@@ -164,8 +148,7 @@ dColor Green
     timeout-minutes: 5
     outputs:
       frontend_lock_hash: ${{ steps.hashes.outputs.frontend_lock_hash }}
-      backend_requirements_hash: ${{ steps.hashes.outputs.backend_requirements_h
-ash }}
+      backend_requirements_hash: ${{ steps.hashes.outputs.backend_requirements_hash }}
       wix_definition_hash: ${{ steps.hashes.outputs.wix_definition_hash }}
       semver: ${{ steps.meta.outputs.semver }}
       short_sha: ${{ steps.meta.outputs.short_sha }}
@@ -187,8 +170,7 @@ ash }}
           }
           $shortSha = "${{ github.sha }}".Substring(0,7)
           "semver=$semver" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          "short_sha=$shortSha" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Ap
-pend
+          "short_sha=$shortSha" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
           Write-Host "🔖 Version: $semver ($shortSha)"
 
       - name: Validate Critical Files Exist
@@ -205,8 +187,7 @@ pend
           )
           foreach ($path in $paths) {
             if (-not (Test-Path $path)) {
-              Write-Host "❌ FATAL: Required path missing: $path" -ForegroundColo
-r Red
+              Write-Host "❌ FATAL: Required path missing: $path" -ForegroundColor Red
               exit 1
             }
           }
@@ -218,18 +199,12 @@ r Red
           BACKEND_DIR: ${{ needs.path-finder.outputs.backend_dir }}
         run: |
           Set-StrictMode -Version Latest
-          $frontend = (Get-FileHash "${{ env.FRONTEND_DIR }}/package-lock.json"
--Algorithm SHA256).Hash
-          $backend = (Get-FileHash (Join-Path $env:BACKEND_DIR "requirements.txt
-") -Algorithm SHA256).Hash
-          $wix = (Get-FileHash "${{ env.WIX_DIR }}/Product_WithService.wxs" -Alg
-orithm SHA256).Hash
-          "frontend_lock_hash=$frontend" | Out-File $env:GITHUB_OUTPUT -Encoding
- utf8 -Append
-          "backend_requirements_hash=$backend" | Out-File $env:GITHUB_OUTPUT -En
-coding utf8 -Append
-          "wix_definition_hash=$wix" | Out-File $env:GITHUB_OUTPUT -Encoding utf
-8 -Append
+          $frontend = (Get-FileHash "${{ env.FRONTEND_DIR }}/package-lock.json" -Algorithm SHA256).Hash
+          $backend = (Get-FileHash (Join-Path $env:BACKEND_DIR "requirements.txt") -Algorithm SHA256).Hash
+          $wix = (Get-FileHash "${{ env.WIX_DIR }}/Product_WithService.wxs" -Algorithm SHA256).Hash
+          "frontend_lock_hash=$frontend" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "backend_requirements_hash=$backend" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "wix_definition_hash=$wix" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Upload Integrity Snapshot
         uses: actions/upload-artifact@v4
@@ -262,8 +237,7 @@ coding utf8 -Append
         uses: actions/cache@v4
         with:
           path: ${{ env.FRONTEND_BUILD_DIR }}
-          key: ${{ runner.os }}-frontend-build-${{ hashFiles('${{ env.FRONTEND_D
-IR }}/**') }}
+          key: ${{ runner.os }}-frontend-build-${{ hashFiles('${{ env.FRONTEND_DIR }}/**') }}
 
       - name: Install Dependencies
         run: |
@@ -308,8 +282,7 @@ IR }}/**') }}
     timeout-minutes: 20
     needs: [path-finder, repo-preflight]
     env:
-      BACKEND_REQUIREMENTS_HASH: ${{ needs.repo-preflight.outputs.backend_requir
-ements_hash }}
+      BACKEND_REQUIREMENTS_HASH: ${{ needs.repo-preflight.outputs.backend_requirements_hash }}
       BACKEND_DIR: ${{ needs.path-finder.outputs.backend_dir }}
       BACKEND_SPEC: ${{ needs.path-finder.outputs.spec_file }}
     steps:
@@ -330,8 +303,7 @@ ements_hash }}
         uses: actions/cache@v4
         with:
           path: dist
-          key: ${{ runner.os }}-backend-build-${{ hashFiles(format('{0}/**', env
-.BACKEND_DIR), format('{0}', env.BACKEND_SPEC)) }}
+          key: ${{ runner.os }}-backend-build-${{ hashFiles(format('{0}/**', env.BACKEND_DIR), format('{0}', env.BACKEND_SPEC)) }}
 
       - name: Install Dependencies
         run: |
@@ -350,12 +322,10 @@ ements_hash }}
       - name: Run Pytest (if available)
         run: |
           Set-StrictMode -Version Latest
-          python -c 'import importlib.util, sys; sys.exit(0 if importlib.util.fi
-nd_spec("pytest") else 1)'
+          python -c 'import importlib.util, sys; sys.exit(0 if importlib.util.find_spec("pytest") else 1)'
           if ($LASTEXITCODE -eq 0) {
             Write-Host "🧪 pytest detected, running suite..."
-            python -m pytest "${{ env.BACKEND_DIR }}" --maxfail=1 --disable-warn
-ings
+            python -m pytest "${{ env.BACKEND_DIR }}" --maxfail=1 --disable-warnings
           } else {
             Write-Host "ℹ️ pytest not installed; skipping tests."
           }
@@ -412,8 +382,7 @@ ings
         uses: actions/cache@v4
         with:
           path: ${{ env.FRONTEND_BUILD_DIR }}
-          key: ${{ runner.os }}-frontend-build-${{ hashFiles('${{ env.FRONTEND_D
-IR }}/**') }}
+          key: ${{ runner.os }}-frontend-build-${{ hashFiles('${{ env.FRONTEND_DIR }}/**') }}
           restore-keys: |
             ${{ runner.os }}-frontend-build-
 
@@ -421,8 +390,7 @@ IR }}/**') }}
         uses: actions/cache@v4
         with:
           path: ~\AppData\Local\npm-cache
-          key: ${{ runner.os }}-npm-${{ env.NODE_VERSION }}-${{ env.FRONTEND_LOC
-K_HASH }}
+          key: ${{ runner.os }}-npm-${{ env.NODE_VERSION }}-${{ env.FRONTEND_LOCK_HASH }}
           restore-keys: |
             ${{ runner.os }}-npm-${{ env.NODE_VERSION }}-
 
@@ -444,11 +412,9 @@ K_HASH }}
       - name: Report Cache Status
         run: |
           if ('${{ steps.cache-frontend.outputs.cache-hit }}' -eq 'true') {
-            Write-Host "✅ Frontend build restored from cache." -ForegroundColor
-Green
+            Write-Host "✅ Frontend build restored from cache." -ForegroundColor Green
           } else {
-            Write-Host "ℹ️ No cache hit. A new build was performed." -Foreground
-Color Yellow
+            Write-Host "ℹ️ No cache hit. A new build was performed." -ForegroundColor Yellow
           }
 
       - name: Verify Build Output
@@ -456,8 +422,7 @@ Color Yellow
           Set-StrictMode -Version Latest
           $outDir = Resolve-Path "${{ env.FRONTEND_BUILD_DIR }}"
           if (-not (Test-Path $outDir)) {
-             Write-Host "❌ FATAL: Build directory not found" -ForegroundColor Re
-d
+             Write-Host "❌ FATAL: Build directory not found" -ForegroundColor Red
              exit 1
           }
           $files = Get-ChildItem -Path $outDir -Recurse -File
@@ -473,30 +438,23 @@ d
           Set-StrictMode -Version Latest
           $outDir = Resolve-Path "${{ env.FRONTEND_DIR }}/out"
           # Fallback for different env var names in different workflows
-          if (-not (Test-Path $outDir)) { $outDir = Resolve-Path "${{ env.FRONTE
-ND_BUILD_DIR }}" }
+          if (-not (Test-Path $outDir)) { $outDir = Resolve-Path "${{ env.FRONTEND_BUILD_DIR }}" }
 
-          if (-not (Test-Path $outDir)) { Write-Error "❌ Build failed: 'out' dir
- missing"; exit 1 }
+          if (-not (Test-Path $outDir)) { Write-Error "❌ Build failed: 'out' dir missing"; exit 1 }
 
           $manifestPath = "frontend-manifest.tsv"
-          "RelativePath`tSizeBytes`tSHA256" | Out-File $manifestPath -Encoding u
-tf8
+          "RelativePath`tSizeBytes`tSHA256" | Out-File $manifestPath -Encoding utf8
 
           $files = Get-ChildItem -Path $outDir -Recurse -File
-          if ($files.Count -eq 0) { Write-Error "❌ Build failed: 'out' dir empty
-"; exit 1 }
+          if ($files.Count -eq 0) { Write-Error "❌ Build failed: 'out' dir empty"; exit 1 }
 
           Write-Host "✅ Frontend built: $($files.Count) files."
 
           foreach ($f in $files) {
-            # FIX: Changed TrimStart('\\\\', '/') to TrimStart('\\', '/') to pre
-vent char conversion error
+            # FIX: Changed TrimStart('\\\\', '/') to TrimStart('\\', '/') to prevent char conversion error
             $rel = $f.FullName.Substring($outDir.Path.Length).TrimStart('\','/')
-            $hash = (Get-FileHash $f.FullName -Algorithm SHA256).Hash.Substring(
-0,16)
-            "$rel`t$($f.Length)`t$hash" | Out-File $manifestPath -Encoding utf8
--Append
+            $hash = (Get-FileHash $f.FullName -Algorithm SHA256).Hash.Substring(0,16)
+            "$rel`t$($f.Length)`t$hash" | Out-File $manifestPath -Encoding utf8 -Append
           }
 
       - name: Upload Frontend Artifact
@@ -522,8 +480,7 @@ vent char conversion error
       matrix:
         arch: [x64, x86]
     env:
-      BACKEND_REQUIREMENTS_HASH: ${{ needs.repo-preflight.outputs.backend_requir
-ements_hash }}
+      BACKEND_REQUIREMENTS_HASH: ${{ needs.repo-preflight.outputs.backend_requirements_hash }}
       BUILD_VERSION: ${{ needs.repo-preflight.outputs.semver }}
       BACKEND_DIR: ${{ needs.path-finder.outputs.backend_dir }}
       BACKEND_MODULE_PATH: ${{ needs.path-finder.outputs.backend_module_path }}
@@ -541,8 +498,7 @@ ements_hash }}
         uses: actions/cache@v4
         with:
           path: dist
-          key: ${{ runner.os }}-backend-build-${{ matrix.arch }}-${{ hashFiles(f
-ormat('{0}/**', env.BACKEND_DIR), format('{0}', env.BACKEND_SPEC)) }}
+          key: ${{ runner.os }}-backend-build-${{ matrix.arch }}-${{ hashFiles(format('{0}/**', env.BACKEND_DIR), format('{0}', env.BACKEND_SPEC)) }}
           restore-keys: |
             ${{ runner.os }}-backend-build-${{ matrix.arch }}-
       - name: Stage Frontend for PyInstaller
@@ -567,8 +523,7 @@ ormat('{0}/**', env.BACKEND_DIR), format('{0}', env.BACKEND_SPEC)) }}
         run: |
           $constraintDir = "temp-constraints"
           New-Item -ItemType Directory -Path $constraintDir -Force | Out-Null
-          $constraintFile = Join-Path $constraintDir "constraint-${{ matrix.arch
- }}.txt"
+          $constraintFile = Join-Path $constraintDir "constraint-${{ matrix.arch }}.txt"
           if ('${{ matrix.arch }}' -eq 'x86') {
             "numpy==1.23.5`npandas==1.5.3" | Set-Content $constraintFile
           } else { New-Item $constraintFile -ItemType File -Force }
@@ -580,16 +535,14 @@ ormat('{0}/**', env.BACKEND_DIR), format('{0}', env.BACKEND_SPEC)) }}
           $req_file = Join-Path $env:BACKEND_DIR "requirements.txt"
           pip install -r $req_file -c ${{ steps.constraints.outputs.file }}
           if (Test-Path (Join-Path $env:BACKEND_DIR "requirements-dev.txt")) {
-            pip install -r (Join-Path $env:BACKEND_DIR "requirements-dev.txt") -
-c ${{ steps.constraints.outputs.file }}
+            pip install -r (Join-Path $env:BACKEND_DIR "requirements-dev.txt") -c ${{ steps.constraints.outputs.file }}
           }
       - name: Create Dynamic webservice.spec for PyInstaller
         if: steps.cache-backend.outputs.cache-hit != 'true'
         shell: python
         env:
           BACKEND_DIR: ${{ needs.path-finder.outputs.backend_dir }}
-          BACKEND_MODULE_PATH: ${{ needs.path-finder.outputs.backend_module_path
- }}
+          BACKEND_MODULE_PATH: ${{ needs.path-finder.outputs.backend_module_path }}
           FRONTEND_OUT: ${{ env.FRONTEND_DIR }}/out
         run: |
           import os
@@ -601,17 +554,14 @@ c ${{ steps.constraints.outputs.file }}
           entry = f"{bk_dir}/service_entry.py"
           spec = f"""
           # -- mode: python ; coding: utf-8 --
-          from PyInstaller.utils.hooks import collect_data_files, collect_submod
-ules
+          from PyInstaller.utils.hooks import collect_data_files, collect_submodules
           block_cipher = None
           a = Analysis(
               ['{entry}'],
               pathex=[],
               binaries=[],
-              datas=collect_data_files('uvicorn') + collect_data_files('slowapi'
-) + [('{frontend_out}', 'ui')],
-              hiddenimports=collect_submodules('{mod_path}') + ['win32timezone']
-,
+              datas=collect_data_files('uvicorn') + collect_data_files('slowapi') + [('{frontend_out}', 'ui')],
+              hiddenimports=collect_submodules('{mod_path}') + ['win32timezone'],
               hookspath=[],
               runtime_hooks=[],
               excludes=['tests', 'pytest'],
@@ -623,8 +573,7 @@ ules
           pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
           exe = EXE(
               pyz, a.scripts, a.binaries, a.zipfiles, a.datas, [],
-              name='fortuna-backend', debug=False, bootloader_ignore_signals=Fal
-se, strip=False, upx=True, console=False
+              name='fortuna-backend', debug=False, bootloader_ignore_signals=False, strip=False, upx=True, console=False
           )
           """
           with open(spec_file, "w") as f: f.write(spec)
@@ -632,10 +581,8 @@ se, strip=False, upx=True, console=False
         if: steps.cache-backend.outputs.cache-hit != 'true'
         run: |
           Set-StrictMode -Version Latest
-          New-Item -ItemType Directory -Path (Join-Path $env:BACKEND_DIR "data")
- -Force | Out-Null
-          New-Item -ItemType Directory -Path (Join-Path $env:BACKEND_DIR "json")
- -Force | Out-Null
+          New-Item -ItemType Directory -Path (Join-Path $env:BACKEND_DIR "data") -Force | Out-Null
+          New-Item -ItemType Directory -Path (Join-Path $env:BACKEND_DIR "json") -Force | Out-Null
           Write-Host "✅ Created required backend directories for PyInstaller."
       - name: Build with PyInstaller
         if: steps.cache-backend.outputs.cache-hit != 'true'
@@ -643,17 +590,14 @@ se, strip=False, upx=True, console=False
           FORTUNA_VERSION: ${{ needs.repo-preflight.outputs.semver }}
         run: |
           Set-StrictMode -Version Latest
-          pyinstaller "${{ env.BACKEND_SPEC }}" --clean --log-level=WARN --nocon
-firm
+          pyinstaller "${{ env.BACKEND_SPEC }}" --clean --log-level=WARN --noconfirm
       - name: Verify Executable
         run: |
           Set-StrictMode -Version Latest
           $exePath = "dist/fortuna-backend.exe"
-          if (-not (Test-Path $exePath)) { throw "❌ FATAL: Executable not found"
- }
+          if (-not (Test-Path $exePath)) { throw "❌ FATAL: Executable not found" }
           $size = (Get-Item $exePath).Length / 1MB
-          if ($size -lt 10) { throw "❌ FATAL: Executable is suspiciously small:
-$($size) MB." }
+          if ($size -lt 10) { throw "❌ FATAL: Executable is suspiciously small: $($size) MB." }
           Write-Host "✅ Backend ready: $([math]::Round($size, 2)) MB"
       - name: Upload Backend Executable
         uses: actions/upload-artifact@v4
@@ -678,8 +622,7 @@ $($size) MB." }
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           backend-dir: ${{ needs.path-finder.outputs.backend_dir }}
-          backend-module-path: ${{ needs.path-finder.outputs.backend_module_path
- }}
+          backend-module-path: ${{ needs.path-finder.outputs.backend_module_path }}
   diagnose-runtime:
     name: '🔎 Diagnose PyInstaller Runtime'
     runs-on: windows-latest
@@ -714,16 +657,12 @@ $($size) MB." }
           if ($LASTEXITCODE -ne 0) { throw "Failed to analyze executable." }
           Write-Host "--- Archive Contents ---"
           $archiveContents | Out-Host
-          $expectedInitFile = ($env:BACKEND_MODULE_PATH.Replace('.', '/') + '/__
-init__.py')
-          $found = $archiveContents | ForEach-Object { $_.Replace('\', '/') } |
-Select-String -Pattern $expectedInitFile -SimpleMatch -Quiet
+          $expectedInitFile = ($env:BACKEND_MODULE_PATH.Replace('.', '/') + '/__init__.py')
+          $found = $archiveContents | ForEach-Object { $_.Replace('\', '/') } | Select-String -Pattern $expectedInitFile -SimpleMatch -Quiet
           if ($found) {
-            Write-Host "✅ SUCCESS: Key module file found." -ForegroundColor Gree
-n
+            Write-Host "✅ SUCCESS: Key module file found." -ForegroundColor Green
           } else {
-            Write-Error "❌ FAILURE: Key module file '$expectedInitFile' NOT foun
-d."
+            Write-Error "❌ FAILURE: Key module file '$expectedInitFile' NOT found."
             exit 1
           }
   smoke-test:
@@ -745,34 +684,26 @@ d."
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
-          $msiPath = (Get-ChildItem -Path "msi-installer" -Filter "*.msi" -Recur
-se | Select-Object -First 1).FullName
+          $msiPath = (Get-ChildItem -Path "msi-installer" -Filter "*.msi" -Recurse | Select-Object -First 1).FullName
           if (-not $msiPath) { throw "MSI not found!" }
           # 1. PRE-INSTALL CLEANUP
-          if (Get-Service -Name FortunaWebService -ErrorAction SilentlyContinue)
- {
+          if (Get-Service -Name FortunaWebService -ErrorAction SilentlyContinue) {
             sc.exe delete FortunaWebService 2>&1 | Out-Null
           }
           # 2. INSTALL
-          $proc = Start-Process msiexec.exe -ArgumentList "/i `"$msiPath`" /qn /
-L*v msi-install.log" -Wait -PassThru
+          $proc = Start-Process msiexec.exe -ArgumentList "/i `"$msiPath`" /qn /L*v msi-install.log" -Wait -PassThru
           if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
             Get-Content msi-install.log -Tail 50
             throw "MSI installation failed with exit code $($proc.ExitCode)."
           }
           # 3. VERIFY & RUN
           $progFiles = ${env:ProgramFiles}
-          if ('${{ matrix.arch }}' -eq 'x86') { $progFiles = ${env:ProgramFiles(
-x86)} }
+          if ('${{ matrix.arch }}' -eq 'x86') { $progFiles = ${env:ProgramFiles(x86)} }
           $installDir = Join-Path $progFiles "Fortuna Faucet Service"
-          if (-not (Test-Path $installDir)) { throw "Installation directory not
-found!" }
-          New-Item -ItemType Directory -Path (Join-Path $installDir "data") -For
-ce | Out-Null
-          New-Item -ItemType Directory -Path (Join-Path $installDir "json") -For
-ce | Out-Null
-          New-Item -ItemType Directory -Path (Join-Path $installDir "logs") -For
-ce | Out-Null
+          if (-not (Test-Path $installDir)) { throw "Installation directory not found!" }
+          New-Item -ItemType Directory -Path (Join-Path $installDir "data") -Force | Out-Null
+          New-Item -ItemType Directory -Path (Join-Path $installDir "json") -Force | Out-Null
+          New-Item -ItemType Directory -Path (Join-Path $installDir "logs") -Force | Out-Null
           Start-Service -Name "FortunaWebService"
           Start-Sleep -Seconds 10
           # 4. HEALTH CHECK
@@ -780,8 +711,7 @@ ce | Out-Null
           $delay = 5
           For ($i=0; $i -lt $maxRetries; $i++) {
             try {
-              $response = Invoke-WebRequest -Uri "http://localhost:${{ env.SERVI
-CE_PORT }}/health" -UseBasicParsing
+              $response = Invoke-WebRequest -Uri "http://localhost:${{ env.SERVICE_PORT }}/health" -UseBasicParsing
               if ($response.StatusCode -eq 200) {
                 Write-Host "✅ Health check PASSED."
                 Stop-Service -Name "FortunaWebService"
@@ -819,21 +749,15 @@ CE_PORT }}/health" -UseBasicParsing
           Set-StrictMode -Version Latest
           $staging = "${{ env.MSI_STAGING_DIR }}"
           New-Item -ItemType Directory -Path $staging -Force | Out-Null
-          Move-Item -Path "dist/fortuna-backend.exe" -Destination "$staging/fort
-una-webservice.exe" -Force
-          $msiName = "Fortuna-WebService-${{ matrix.arch }}-${{ env.BUILD_VERSIO
-N }}-${{ env.SHORT_SHA }}.msi".Replace('/', '-')
-          "msi_name=$msiName" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Appe
-nd
+          Move-Item -Path "dist/fortuna-backend.exe" -Destination "$staging/fortuna-webservice.exe" -Force
+          $msiName = "Fortuna-WebService-${{ matrix.arch }}-${{ env.BUILD_VERSION }}-${{ env.SHORT_SHA }}.msi".Replace('/', '-')
+          "msi_name=$msiName" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
           Write-Host "✅ Staged for MSI: $msiName"
       - name: Create Restart Service Batch Script
         shell: pwsh
         run: |
-          $scriptContent = "@echo off`r`necho Requesting Admin privileges to res
-tart FortunaWebService...`r`nnet stop FortunaWebService`r`nnet start FortunaWebS
-ervice`r`necho Service Restarted.`r`npause"
-          Set-Content -Path "${{ env.MSI_STAGING_DIR }}/restart_service.bat" -Va
-lue $scriptContent -Encoding Ascii
+          $scriptContent = "@echo off`r`necho Requesting Admin privileges to restart FortunaWebService...`r`nnet stop FortunaWebService`r`nnet start FortunaWebService`r`necho Service Restarted.`r`npause"
+          Set-Content -Path "${{ env.MSI_STAGING_DIR }}/restart_service.bat" -Value $scriptContent -Encoding Ascii
           Write-Host "✅ Created restart_service.bat script."
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
@@ -846,14 +770,11 @@ lue $scriptContent -Encoding Ascii
           key: ${{ runner.os }}-nuget-${{ env.WIX_HASH }}
       - name: 📄 Ensure WiX License Exists
         run: |
-          if (-not (Test-Path build_wix)) { New-Item -ItemType Directory -Path b
-uild_wix | Out-Null }
+          if (-not (Test-Path build_wix)) { New-Item -ItemType Directory -Path build_wix | Out-Null }
           $licensePath = 'build_wix/license.rtf'
           if (-not (Test-Path $licensePath)) {
             Write-Host '⚠️ License file missing. Generating placeholder...'
-            $rtfContent = '{\rtf1\ansi\deff0{\fonttbl{\f0 Arial;}}\f0\fs24 END U
-SER LICENSE AGREEMENT\par\par This is a placeholder license for Fortuna Faucet.
-Please replace with actual terms.}'
+            $rtfContent = '{\rtf1\ansi\deff0{\fonttbl{\f0 Arial;}}\f0\fs24 END USER LICENSE AGREEMENT\par\par This is a placeholder license for Fortuna Faucet. Please replace with actual terms.}'
             Set-Content -Path $licensePath -Value $rtfContent -Encoding Ascii
             Write-Host '✅ Placeholder license.rtf created.'
           } else {
@@ -862,32 +783,26 @@ Please replace with actual terms.}'
       - name: Prepare WiX Project
         run: |
           Set-StrictMode -Version Latest
-          Copy-Item "${{ env.WIX_DIR }}/Product_WithService.wxs" "${{ env.WIX_DI
-R }}/Product.wxs" -Force
+          Copy-Item "${{ env.WIX_DIR }}/Product_WithService.wxs" "${{ env.WIX_DIR }}/Product.wxs" -Force
           $proj = @(
             '<Project Sdk="WixToolset.Sdk/${{ env.WIX_VERSION }}">',
             '  <PropertyGroup>',
             '    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>',
             '    <OutputType>Package</OutputType>',
             '    <Platforms>x64;x86</Platforms>',
-            '    <DefineConstants>Version=$(Version);SourceDir=$(SourceDir);Serv
-icePort=$(ServicePort);Platform=$(Platform)</DefineConstants>',
+            '    <DefineConstants>Version=$(Version);SourceDir=$(SourceDir);ServicePort=$(ServicePort);Platform=$(Platform)</DefineConstants>',
             '  </PropertyGroup>',
             '  <ItemGroup>',
-            '    <PackageReference Include="WixToolset.UI.wixext" Version="${{ e
-nv.WIX_VERSION }}" />',
-            '    <PackageReference Include="WixToolset.Firewall.wixext" Version=
-"${{ env.WIX_VERSION }}" />',
-            '    <PackageReference Include="WixToolset.Util.wixext" Version="${{
- env.WIX_VERSION }}" />',
+            '    <PackageReference Include="WixToolset.UI.wixext" Version="${{ env.WIX_VERSION }}" />',
+            '    <PackageReference Include="WixToolset.Firewall.wixext" Version="${{ env.WIX_VERSION }}" />',
+            '    <PackageReference Include="WixToolset.Util.wixext" Version="${{ env.WIX_VERSION }}" />',
             '  </ItemGroup>',
             '  <ItemGroup>',
             '    <Compile Include="Product.wxs" />',
             '  </ItemGroup>',
             '</Project>'
           )
-          Set-Content "${{ env.WIX_DIR }}/Fortuna.wixproj" -Value ($proj -join "
-`r`n") -Encoding utf8
+          Set-Content "${{ env.WIX_DIR }}/Fortuna.wixproj" -Value ($proj -join "`r`n") -Encoding utf8
       - name: Build MSI
         working-directory: ${{ env.WIX_DIR }}
         run: |
@@ -971,8 +886,7 @@ nv.WIX_VERSION }}" />',
           robocopy $sourceDir $destDir /E
 
           if ($LASTEXITCODE -ge 8) {
-            Write-Error "Robocopy failed with exit code $LASTEXITCODE. This indi
-cates a serious error."
+            Write-Error "Robocopy failed with exit code $LASTEXITCODE. This indicates a serious error."
             exit 1
           }
 


### PR DESCRIPTION
A number of workflow files were restored from backups with corrupted formatting, causing extraneous line breaks that break the YAML syntax.

This commit removes the incorrect line breaks from the following files:
- build-electron-hybrid.yml
- build-msi-hat-trick-fusion.yml
- build-msi-hattrickfusion-ultimate.yml
- build-msi-revived.yml
- build-msi-supreme-combo.yml
- build-msi-unified.yml
- build-web-service-msi-jules.yml

This also includes a second pass on `build-electron-hybrid.yml` to ensure all formatting issues are resolved.