### PR TITLE
Fix(workflows): Correct syntax and add network failure note

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -152,7 +152,10 @@ jobs:
       - name: 📥 Install Frontend Dependencies
         shell: pwsh
         working-directory: electron
-        run: npm ci --prefer-offline --no-audit
+        run: |
+          # NOTE: This step can be prone to intermittent network failures (e.g., 502 Bad Gateway).
+          # If this step fails, a simple re-run of the workflow may be all that is needed.
+          npm ci --prefer-offline --no-audit
 
       - name: 🔨 Build Frontend
         shell: pwsh

--- a/.github/workflows/formerly-the-core-of-reusable.yml
+++ b/.github/workflows/formerly-the-core-of-reusable.yml
@@ -213,10 +213,11 @@ jobs:
       - name: 📝 Generate Service Scripts
         shell: pwsh
         run: |
-          @"
-net stop ${{ env.SERVICE_NAME }}
-net start ${{ env.SERVICE_NAME }}
-"@ | Out-File -FilePath staging/backend/restart_service.bat -Encoding ASCII
+          $scriptContent = @(
+            "net stop ${{ env.SERVICE_NAME }}",
+            "net start ${{ env.SERVICE_NAME }}"
+          )
+          $scriptContent | Out-File -FilePath staging/backend/restart_service.bat -Encoding ASCII
 
       - name: ⚖️ The Dietician
         if: env.ENABLE_DIETICIAN == 'true'
@@ -337,7 +338,7 @@ net start ${{ env.SERVICE_NAME }}
   ui-proof:
     name: 📸 Paparazzi (${{ matrix.arch }})
     needs: [preflight, smoke-test]
-    if: env.ENABLE_PAPARAZZI == 'true'
+    if: github.event.inputs.enable_paparazzi == 'true'
     runs-on: windows-latest
     timeout-minutes: 15
     strategy:
@@ -367,21 +368,21 @@ net start ${{ env.SERVICE_NAME }}
           npm install playwright
           npx playwright install chromium --with-deps
 
-          $script = @"
-          const { chromium } = require('playwright');
-          (async () => {
-            const browser = await chromium.launch();
-            const page = await browser.newPage();
-            await page.goto('http://127.0.0.1:${{ env.SERVICE_PORT }}/docs');
-            await page.waitForTimeout(2000);
-            await page.screenshot({
-              path: 'ui-proof-${{ matrix.arch }}.png',
-              fullPage: true
-            });
-            await browser.close();
-            console.log('✅ Screenshot captured');
-          })();
-"@
+          $script = @(
+            "const { chromium } = require('playwright');",
+            "(async () => {",
+            "  const browser = await chromium.launch();",
+            "  const page = await browser.newPage();",
+            "  await page.goto('http://127.0.0.1:${{ env.SERVICE_PORT }}/docs');",
+            "  await page.waitForTimeout(2000);",
+            "  await page.screenshot({",
+            "    path: 'ui-proof-${{ matrix.arch }}.png',",
+            "    fullPage: true",
+            "  });",
+            "  await browser.close();",
+            "  console.log('✅ Screenshot captured');",
+            "})();"
+          )
 
           $script | Out-File screenshot.js -Encoding UTF8
           node screenshot.js
@@ -407,19 +408,17 @@ net start ${{ env.SERVICE_NAME }}
       - name: 📊 Build Report
         shell: pwsh
         run: |
-          Write-Host @"
-
-╔════════════════════════════════════════════════════════╗
-║         🧬 FormerlyTheCoreOfReusable                   ║
-╠════════════════════════════════════════════════════════╣
-║  Version:     ${{ needs.preflight.outputs.semver }}
-║  Build ID:    ${{ needs.preflight.outputs.build_id }}
-║  Commit:      ${{ needs.preflight.outputs.short_sha }}
-║  Status:      ${{ needs.smoke-test.result }}
-║  Node:        ${{ env.NODE_VERSION }}
-║  Python:      ${{ env.PYTHON_VERSION }}
-║  WiX:         ${{ env.WIX_VERSION }}
-╚════════════════════════════════════════════════════════╝
-
-Artifacts: msi-{x64,x86}-${{ needs.preflight.outputs.build_id }}
-"@
+          Write-Host ""
+          Write-Host "╔════════════════════════════════════════════════════════╗"
+          Write-Host "║         🧬 FormerlyTheCoreOfReusable                   ║"
+          Write-Host "╠════════════════════════════════════════════════════════╣"
+          Write-Host "║  Version:     ${{ needs.preflight.outputs.semver }}"
+          Write-Host "║  Build ID:    ${{ needs.preflight.outputs.build_id }}"
+          Write-Host "║  Commit:      ${{ needs.preflight.outputs.short_sha }}"
+          Write-Host "║  Status:      ${{ needs.smoke-test.result }}"
+          Write-Host "║  Node:        ${{ env.NODE_VERSION }}"
+          Write-Host "║  Python:      ${{ env.PYTHON_VERSION }}"
+          Write-Host "║  WiX:         ${{ env.WIX_VERSION }}"
+          Write-Host "╚════════════════════════════════════════════════════════╝"
+          Write-Host ""
+          Write-Host "Artifacts: msi-{x64,x86}-${{ needs.preflight.outputs.build_id }}"


### PR DESCRIPTION
This commit addresses two separate issues in the GitHub Actions workflows:

1.  In `formerly-the-core-of-reusable.yml`, the `if` condition for the `ui-proof` job was using an invalid `env` context, causing a workflow validation error. This has been corrected to use the `github.event.inputs` context, which is the proper way to access workflow dispatch inputs at the job level.

2.  In `build-electron-msi-gpt5.yml`, a comment has been added to the `npm ci` step to note that it is prone to intermittent network failures (e.g., 502 Bad Gateway). This provides context for future failures and suggests that a re-run may resolve the issue.