### PR TITLE
feat: Enhance Electron build workflow with caching and analysis

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -157,16 +157,44 @@ jobs:
           # If this step fails, a simple re-run of the workflow may be all that is needed.
           npm ci --prefer-offline --no-audit
 
+      - name:  Cache Frontend Build
+        id: cache-frontend
+        uses: actions/cache@v4
+        with:
+          path: electron/out
+          key: ${{ runner.os }}-frontend-${{ hashFiles('electron/package-lock.json', 'electron/src/**/*.js', 'electron/src/**/*.ts', 'electron/src/**/*.tsx', 'electron/src/**/*.css') }}
+          restore-keys: |
+            ${{ runner.os }}-frontend-
+
       - name: 🔨 Build Frontend
+        if: steps.cache-frontend.outputs.cache-hit != 'true'
         shell: pwsh
         working-directory: electron
         run: npm run build
+
+      - name: 📝 Generate Artifact Manifest
+        shell: pwsh
+        working-directory: electron
+        run: |
+          Set-StrictMode -Version Latest
+          $outDir = Resolve-Path "out"
+          $manifestPath = "frontend-manifest.tsv"
+          "RelativePath`tSizeBytes`tSHA256" | Out-File $manifestPath -Encoding utf8
+          $files = Get-ChildItem -Path $outDir -Recurse -File
+          foreach ($f in $files) {
+            $rel = $f.FullName.Substring($outDir.Path.Length).TrimStart('\\','/')
+            $hash = (Get-FileHash $f.FullName -Algorithm SHA256).Hash.Substring(0,16)
+            "$rel`t$($f.Length)`t$hash" | Out-File $manifestPath -Encoding utf8 -Append
+          }
+          Write-Host "✅ Generated frontend artifact manifest."
 
       - name: 📤 Upload Frontend Artifact
         uses: actions/upload-artifact@v4
         with:
           name: frontend-dist
-          path: electron/out/
+          path: |
+            electron/out/
+            electron/frontend-manifest.tsv
           retention-days: 7
 
   verify-assets:
@@ -223,6 +251,25 @@ jobs:
           }
           Write-Host "✅ Backend staged correctly"
 
+      - name: '🧐 The Dietician (Size Analysis)'
+        shell: pwsh
+        run: |
+          $target = "."
+          $limitMB = 450
+          Write-Host "--- 📊 Size Breakdown ---"
+          $files = Get-ChildItem -Path $target -Recurse -File -ErrorAction SilentlyContinue
+          if (!$files) { Write-Warning "No files found to weigh."; exit 0 }
+          $totalBytes = ($files | Measure-Object -Property Length -Sum).Sum
+          $totalMB = [math]::Round($totalBytes / 1MB, 2)
+          Write-Host "Total Payload Size: $totalMB MB"
+          if ($totalMB -gt $limitMB) {
+              Write-Warning " overweight: Build exceeds $limitMB MB limit!"
+          } else {
+              Write-Host "✅ Size within limits (< $limitMB MB)." -ForegroundColor Green
+          }
+          Write-Host "`n--- 🐘 Top 10 Heaviest Files ---"
+          $files | Sort-Object Length -Descending | Select-Object -First 10 @{N='File';E={$_.FullName.Replace($pwd,'')}}, @{N='Size(MB)';E={"_"{0:N2}_" -f ($_.Length/1MB)}} | Format-Table -AutoSize
+
       - name: 📥 Install Electron Dependencies
         shell: pwsh
         working-directory: electron
@@ -267,7 +314,7 @@ jobs:
           # 🔥 FIX: Added --config.win.icon flag to set icon without parsing YAML
           npm run dist -- --win msi $archFlag --config temp-builder-config.yml --publish never --config.artifactName=$artifactName --config.win.icon="assets/icon.ico"
 
-      - name: Rename & Hash MSI
+      - name: Stage MSI for Upload
         id: name_msi
         shell: pwsh
         run: |


### PR DESCRIPTION
This change improves the `build-electron-msi-gpt5.yml` workflow by adding:
- Frontend output caching to speed up subsequent builds.
- Artifact manifest generation for better traceability.
- A build size analysis step ('The Dietician') to monitor for bloat.

This addresses the user's request to implement Claude's suggestions for improving the Electron build pipeline.