### PR TITLE
fix(workflows): Comprehensive fixes for multiple CI workflows

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -280,7 +280,7 @@ jobs:
               Write-Host "✅ Size within limits (< $limitMB MB)." -ForegroundColor Green
           }
           Write-Host "`n--- 🐘 Top 10 Heaviest Files ---"
-          $files | Sort-Object Length -Descending | Select-Object -First 10 @{N='File';E={$_.FullName.Replace($pwd,'')}}, @{N='Size(MB)';E={"_"{0:N2}_" -f ($_.Length/1MB)}} | Format-Table -AutoSize
+          $files | Sort-Object Length -Descending | Select-Object -First 10 @{N='File';E={$_.FullName.Replace($pwd,'')}}, @{N='Size(MB)';E={"{0:N2}" -f ($_.Length/1MB)}} | Format-Table -AutoSize
 
       - name: 📥 Install Electron Dependencies
         shell: pwsh

--- a/.github/workflows/build-msi-hat-trick-fusion.yml
+++ b/.github/workflows/build-msi-hat-trick-fusion.yml
@@ -127,7 +127,7 @@ jobs:
           pip install pyinstaller==6.6.0 pywin32
       - name: Build Backend (PyInstaller)
         run: |
-          pyinstaller --noconfirm --onedir --clean --name fortuna-backend --hidden-import=win32timezone --hidden-import=win32serviceutil --add-data "web_service/backend;backend" web_service/backend/service_entry.py
+          python -m PyInstaller --noconfirm --onedir --clean --name fortuna-backend --hidden-import=win32timezone --hidden-import=win32serviceutil --add-data "web_service/backend;backend" web_service/backend/service_entry.py
       - name: Upload Backend
         uses: actions/upload-artifact@v4
         with:
@@ -309,7 +309,6 @@ jobs:
           New-Item -ItemType Directory -Path (Join-Path $installDir "data") -Force | Out-Null
           New-Item -ItemType Directory -Path (Join-Path $installDir "json") -Force | Out-Null
           New-Item -ItemType Directory -Path (Join-Path $installDir "logs") -Force | Out-Null
-          Get-Service | Where-Object { $_.DisplayName -like "*Fortuna*" } | Format-Table -AutoSize
           Start-Service -Name "FortunaWebService" -ErrorAction Stop
           Start-Sleep -Seconds 10
 

--- a/.github/workflows/build-msi-hattrickfusion-ultimate.yml
+++ b/.github/workflows/build-msi-hattrickfusion-ultimate.yml
@@ -135,7 +135,7 @@ jobs:
           pip install pyinstaller==6.6.0 pywin32
       - name: Build Backend (PyInstaller)
         run: |
-          pyinstaller --noconfirm --onedir --clean --name fortuna-backend --hidden-import=win32timezone --hidden-import=win32serviceutil --add-data "web_service/backend;backend" --add-data "web_platform/frontend/out;ui" web_service/backend/service_entry.py
+          python -m PyInstaller --noconfirm --onedir --clean --name fortuna-backend --hidden-import=win32timezone --hidden-import=win32serviceutil --add-data "web_service/backend;backend" --add-data "web_platform/frontend/out;ui" web_service/backend/service_entry.py
       - name: Upload Backend
         uses: actions/upload-artifact@v4
         with:
@@ -299,7 +299,7 @@ jobs:
           New-Item -ItemType Directory -Path (Join-Path $installDir "data") -Force | Out-Null
           New-Item -ItemType Directory -Path (Join-Path $installDir "json") -Force | Out-Null
           New-Item -ItemType Directory -Path (Join-Path $installDir "logs") -Force | Out-Null
-          Start-Service -Name "Fortuna Faucet Service"
+          Start-Service -Name "FortunaWebService"
           Start-Sleep -Seconds 10
           # 4. HEALTH CHECK
           $maxRetries = 5

--- a/.github/workflows/build-msi-revived.yml
+++ b/.github/workflows/build-msi-revived.yml
@@ -119,10 +119,9 @@ jobs:
         id: git_version
         shell: pwsh
         run: |
-          $tag = git describe --tags --abbrev=0 2>$null
-          if (-not $tag) { Write-Host "No tags found, defaulting to v0.0.0"; $tag = "v0.0.${{ github.run_number }}" }
-          echo "Build Version: $tag"
-          "semver=$tag" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          $semver = "0.0.${{ github.run_number }}"
+          Write-Host "Build Version: $semver"
+          "semver=$semver" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
       - uses: actions/download-artifact@v4
         with:
           name: backend-dist-${{ matrix.arch }}

--- a/.github/workflows/build-web-service-msi-jules.yml
+++ b/.github/workflows/build-web-service-msi-jules.yml
@@ -555,7 +555,7 @@ jobs:
         env:
           BACKEND_DIR: ${{ needs.path-finder.outputs.backend_dir }}
           BACKEND_MODULE_PATH: ${{ needs.path-finder.outputs.backend_module_path }}
-          FRONTEND_OUT: ${{ env.FRONTEND_DIR }}/out
+          FRONTEND_OUT: 'staging/ui'
         run: |
           import os
           from pathlib import Path

--- a/.github/workflows/formerly-the-core-of-reusable.yml
+++ b/.github/workflows/formerly-the-core-of-reusable.yml
@@ -147,7 +147,7 @@ jobs:
 
   build-backend:
     name: 🐍 Backend (${{ matrix.arch }})
-    needs: [preflight]
+    needs: [preflight, build-frontend]
     runs-on: windows-latest
     timeout-minutes: 30
     strategy:


### PR DESCRIPTION
This commit addresses a series of critical failures across multiple GitHub Actions workflows to improve reliability and achieve successful runs.

1.  **`build-electron-msi-gpt5.yml`**: Corrected a PowerShell `ParserError` in the "Dietician" step by fixing a malformed format string.

2.  **`build-msi-hat-trick-fusion.yml` & `build-msi-hattrickfusion-ultimate.yml`**:
    *   Modified the `pyinstaller` command to be invoked as a module (`python -m PyInstaller`) to resolve PATH issues on the runner.
    *   Corrected the `Start-Service` command in the `ultimate` version's smoke test to use the correct service name (`FortunaWebService`).
    *   Removed a broad `Get-Service` command from the `standard` version's smoke test that was causing `PermissionDenied` errors.

3.  **`build-msi-revived.yml`**: Simplified the versioning logic to use the `github.run_number`, resolving a failure caused by the absence of git tags in the CI environment.

4.  **`formerly-the-core-of-reusable.yml`**: Added a `needs` dependency to the `build-backend` job to ensure the frontend artifact is created before the backend job attempts to download it, fixing a race condition.

5.  **`build-web-service-msi-jules.yml`**: Corrected the path to the frontend assets in the dynamic PyInstaller spec generation step to point to the correct staged artifact directory.