### PR TITLE
fix(ci): Correct electron-builder command syntax

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -134,7 +134,7 @@ jobs:
           npm ci
           $archFlag = if ($env:ARCH -eq 'x86') { '--ia32' } else { '--x64' }
           $name = "Fortuna-${{ matrix.arch }}-${{ needs.validate-environment.outputs.semver }}.msi"
-          npx electron-builder --win msi $archFlag --publish never -c.extraMetadata.version="${{ needs.validate-environment.outputs.semver }}" -c.artifactName="$name"
+          npx electron-builder --win msi $archFlag --publish never --config.extraMetadata.version="${{ needs.validate-environment.outputs.semver }}" --config.artifactName="$name"
       - name: 📤 Upload MSI
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The electron-builder command was failing due to an incorrect syntax for passing configuration options. Changed the -c.key=value format to the correct --config.key=value format.