### PR TITLE
fix(ci): Correct backend staging path for Electron build

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -123,8 +123,9 @@ jobs:
       - name: 🚚 Stage Backend
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Path "electron/resources" -Force
-          Copy-Item -Path "temp_backend/*" -Destination "electron/resources" -Recurse -Force
+          $dest = "electron/resources/fortuna-backend"
+          New-Item -ItemType Directory -Path $dest -Force
+          Copy-Item -Path "temp_backend/*" -Destination $dest -Recurse -Force
       - name: 🏗️ Build MSI
         working-directory: electron
         shell: pwsh
@@ -134,7 +135,7 @@ jobs:
           npm ci
           $archFlag = if ($env:ARCH -eq 'x86') { '--ia32' } else { '--x64' }
           $name = "Fortuna-${{ matrix.arch }}-${{ needs.validate-environment.outputs.semver }}.msi"
-          npx electron-builder --win msi $archFlag --publish never -c.extraMetadata.version="${{ needs.validate-environment.outputs.semver }}" -c.artifactName="$name"
+          npx electron-builder --win msi $archFlag --publish never --config.extraMetadata.version="${{ needs.validate-environment.outputs.semver }}" --config.artifactName="$name"
       - name: 📤 Upload MSI
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The smoke test was failing because the main Electron process could not find the backend executable. The backend files were being staged into the root of the `resources` directory, but the main process expected them to be in a `fortuna-backend` subdirectory.

This commit updates the `Stage Backend` step to create the `fortuna-backend` subdirectory within `electron/resources` and copies the backend files into it, aligning the packaged directory structure with the application's expectations.