### PR TITLE
fix(build): Correct WiX syntax and PyInstaller pathing across all wor…

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -66,13 +66,17 @@ jobs:
           pip install -r ${{ env.BACKEND_DIR }}/requirements.txt -c ${{ steps.constraints.outputs.file }}
           pip install pyinstaller==6.6.0 pywin32
 
+          # We add the BACKEND_DIR to the PYTHONPATH during build
+          # and tell PyInstaller to look there for imports.
           pyinstaller --noconfirm --onedir --clean `
             --name fortuna-backend `
+            --paths "${{ env.BACKEND_DIR }}" `
             --hidden-import=win32timezone `
             --hidden-import=win32serviceutil `
             --hidden-import=win32service `
             --hidden-import=win32event `
-            --add-data "${{ env.BACKEND_DIR }};backend" `
+            --collect-submodules web_service `
+            --add-data "${{ env.BACKEND_DIR }};." `
             ${{ env.BACKEND_DIR }}/service_entry.py
 
       - name: 📤 Upload

--- a/.github/workflows/build-msi-hat-trick-fusion.yml
+++ b/.github/workflows/build-msi-hat-trick-fusion.yml
@@ -127,7 +127,14 @@ jobs:
           pip install pyinstaller==6.6.0 pywin32
       - name: Build Backend (PyInstaller)
         run: |
-          python -m PyInstaller --noconfirm --onedir --clean --name fortuna-backend --hidden-import=win32timezone --hidden-import=win32serviceutil --add-data "web_service/backend;backend" web_service/backend/service_entry.py
+          python -m PyInstaller --noconfirm --onedir --clean `
+            --name fortuna-backend `
+            --paths "web_service/backend" `
+            --hidden-import=win32timezone `
+            --hidden-import=win32serviceutil `
+            --collect-submodules web_service `
+            --add-data "web_service/backend;." `
+            web_service/backend/service_entry.py
       - name: Upload Backend
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-msi-hattrickfusion-ultimate.yml
+++ b/.github/workflows/build-msi-hattrickfusion-ultimate.yml
@@ -141,7 +141,15 @@ jobs:
           pip install pyinstaller==6.6.0 pywin32
       - name: Build Backend (PyInstaller)
         run: |
-          python -m PyInstaller --noconfirm --onedir --clean --name fortuna-backend --hidden-import=win32timezone --hidden-import=win32serviceutil --add-data "web_service/backend;backend" --add-data "web_platform/frontend/out;ui" web_service/backend/service_entry.py
+          python -m PyInstaller --noconfirm --onedir --clean `
+            --name fortuna-backend `
+            --paths "web_service/backend" `
+            --hidden-import=win32timezone `
+            --hidden-import=win32serviceutil `
+            --collect-submodules web_service `
+            --add-data "web_service/backend;." `
+            --add-data "web_platform/frontend/out;ui" `
+            web_service/backend/service_entry.py
       - name: Upload Backend
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-msi-unified.yml
+++ b/.github/workflows/build-msi-unified.yml
@@ -157,9 +157,9 @@ jobs:
           block_cipher = None
           a = Analysis(
               ['{entry}'],
-              pathex=[],
+              pathex=['{bk_dir}'],
               binaries=[],
-              datas=collect_data_files('uvicorn') + collect_data_files('slowapi') + [('{frontend_out}', 'ui')],
+              datas=collect_data_files('uvicorn') + collect_data_files('slowapi') + [('{frontend_out}', 'ui'), ('{bk_dir}', '.')],
               # FIX: Added win32timezone to prevent Error 1053
               hiddenimports=collect_submodules('{mod_path}') + ['win32timezone'],
               hookspath=[],

--- a/build_wix/Product_WithService.wxs
+++ b/build_wix/Product_WithService.wxs
@@ -4,7 +4,7 @@
      xmlns:fire="http://wixtoolset.org/schemas/v4/wxs/firewall">
 
   <!-- 🔧 CRITICAL FIX: Define defaults for preprocessor variables -->
-  <?if not defined(ServicePort) ?>
+  <?if not defined(ServicePort)?>
     <?define ServicePort = 8102 ?>
   <?endif?>
 

--- a/electron/package.json
+++ b/electron/package.json
@@ -30,8 +30,8 @@
     },
     "extraResources": [
       {
-        "from": "resources",
-        "to": ".",
+        "from": "resources/fortuna-backend",
+        "to": "fortuna-backend",
         "filter": ["**/*"]
       }
     ],


### PR DESCRIPTION
…kflows

This commit addresses two critical build issues:
1.  A `WIX0159` syntax error in the shared `Product_WithService.wxs` template, which caused all MSI builds to fail. The preprocessor `defined()` function had an extra space, which has been removed.
2.  A recurring `ImportError` in PyInstaller-packaged backends due to incorrect module pathing. The robust fix, including `--paths`, `--collect-submodules`, and corrected `--add-data` flags, has been applied consistently across all relevant CI/CD workflows (`electron`, `hat-trick`, `ultimate`, `unified`).

Additionally, the Electron startup logic in `main.js` and the Python service entry point in `service_entry.py` have been hardened to ensure the correct `cwd` and `sys.path` are used, preventing module resolution failures at runtime.