### PR TITLE
fix: Correct syntax in CI workflows

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -60,7 +60,7 @@ jobs:
           "file=$file" | Out-File $env:GITHUB_OUTPUT -Append
 
       - name: 📦 Build Binary
-        shell: python
+        shell: pwsh
         run: |
           pip install --upgrade pip setuptools wheel
           pip install -r ${{ env.BACKEND_DIR }}/requirements.txt -c ${{ steps.constraints.outputs.file }}

--- a/build_wix/Product_WithService.wxs
+++ b/build_wix/Product_WithService.wxs
@@ -4,15 +4,15 @@
      xmlns:fire="http://wixtoolset.org/schemas/v4/wxs/firewall">
 
   <!-- 🔧 CRITICAL FIX: Define defaults for preprocessor variables -->
-  <?if not defined(ServicePort)?>
+  <?if not (defined(ServicePort))?>
     <?define ServicePort = 8102 ?>
   <?endif?>
 
-  <?if not defined(Version) ?>
+  <?if not (defined(Version)) ?>
     <?define Version = 0.0.0 ?>
   <?endif?>
 
-  <?if not defined(SourceDir) ?>
+  <?if not (defined(SourceDir)) ?>
     <?define SourceDir = staging/backend ?>
   <?endif?>
 


### PR DESCRIPTION
Fixes two separate build errors in the GitHub Actions workflows.

1. In the 'build-electron-msi-gpt5.yml' workflow, the 'build-python-service' job was incorrectly using 'shell: python' to execute shell commands, causing a SyntaxError. This has been corrected to 'shell: pwsh'.

2. In the 'Product_WithService.wxs' WiX template, the preprocessor directives were using incorrect syntax for the 'not defined()' check. This was causing a WIX0159 error. The expressions have been corrected to 'not (defined(...))' to resolve the build failure.