### PR TITLE
fix(ci): Resolve multiple build failures in GitHub Actions

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -60,7 +60,7 @@ jobs:
           "file=$file" | Out-File $env:GITHUB_OUTPUT -Append
 
       - name: 📦 Build Binary
-        shell: python
+        shell: pwsh
         run: |
           pip install --upgrade pip setuptools wheel
           pip install -r ${{ env.BACKEND_DIR }}/requirements.txt -c ${{ steps.constraints.outputs.file }}
@@ -105,7 +105,7 @@ jobs:
           )
           $spec_script | Out-File -FilePath "electron.spec" -Encoding utf8
 
-          pyinstaller --noconfirm --onedir --clean electron.spec
+          pyinstaller --noconfirm --clean electron.spec
 
       - name: 📤 Upload
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-msi-hat-trick-fusion.yml
+++ b/.github/workflows/build-msi-hat-trick-fusion.yml
@@ -167,7 +167,7 @@ jobs:
           )
           $spec_script | Out-File -FilePath "hat-trick-fusion.spec" -Encoding utf8
 
-          python -m PyInstaller --noconfirm --onedir --clean hat-trick-fusion.spec
+          python -m PyInstaller --noconfirm --clean hat-trick-fusion.spec
       - name: Upload Backend
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-msi-hattrickfusion-ultimate.yml
+++ b/.github/workflows/build-msi-hattrickfusion-ultimate.yml
@@ -181,7 +181,7 @@ jobs:
           )
           $spec_script | Out-File -FilePath "hat-trick-ultimate.spec" -Encoding utf8
 
-          python -m PyInstaller --noconfirm --onedir --clean hat-trick-ultimate.spec
+          python -m PyInstaller --noconfirm --clean hat-trick-ultimate.spec
       - name: Upload Backend
         uses: actions/upload-artifact@v4
         with:

--- a/build_wix/Product_WithService.wxs
+++ b/build_wix/Product_WithService.wxs
@@ -4,15 +4,15 @@
      xmlns:fire="http://wixtoolset.org/schemas/v4/wxs/firewall">
 
   <!-- 🔧 CRITICAL FIX: Define defaults for preprocessor variables -->
-  <?if not defined(ServicePort)?>
+  <?if not (defined(ServicePort))?>
     <?define ServicePort = 8102 ?>
   <?endif?>
 
-  <?if not defined(Version) ?>
+  <?if not (defined(Version)) ?>
     <?define Version = 0.0.0 ?>
   <?endif?>
 
-  <?if not defined(SourceDir) ?>
+  <?if not (defined(SourceDir)) ?>
     <?define SourceDir = staging/backend ?>
   <?endif?>
 


### PR DESCRIPTION
This commit addresses and resolves three distinct build errors that were causing multiple GitHub Actions workflows to fail.

1.  **WiX Preprocessor Syntax (`WIX0159`):** Corrected the preprocessor conditional syntax in `build_wix/Product_WithService.wxs` from `not defined(...)` to the valid `not (defined(...))`.

2.  **PyInstaller Option Error:** Removed the redundant `--onedir` flag from the `pyinstaller` command in the `build-electron-msi-gpt5.yml`, `build-msi-hat-trick-fusion.yml`, and `build-msi-hattrickfusion-ultimate.yml` workflows. The output type is already defined within the `.spec` file, making the flag invalid.

3.  **Shell SyntaxError:** Changed the shell from `python` to `pwsh` in the `build-electron-msi-gpt5.yml` workflow for steps that execute shell commands, resolving the syntax errors.