### PR TITLE
fix(ci): Resolve WIX0288 duplicate variable error in MSI builds

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -60,7 +60,7 @@ jobs:
           "file=$file" | Out-File $env:GITHUB_OUTPUT -Append
 
       - name: 📦 Build Binary
-        shell: python
+        shell: pwsh
         run: |
           pip install --upgrade pip setuptools wheel
           pip install -r ${{ env.BACKEND_DIR }}/requirements.txt -c ${{ steps.constraints.outputs.file }}
@@ -105,7 +105,7 @@ jobs:
           )
           $spec_script | Out-File -FilePath "electron.spec" -Encoding utf8
 
-          pyinstaller --noconfirm --onedir --clean electron.spec
+          pyinstaller --noconfirm --clean electron.spec
 
       - name: 📤 Upload
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-msi-hat-trick-fusion.yml
+++ b/.github/workflows/build-msi-hat-trick-fusion.yml
@@ -167,7 +167,7 @@ jobs:
           )
           $spec_script | Out-File -FilePath "hat-trick-fusion.spec" -Encoding utf8
 
-          python -m PyInstaller --noconfirm --onedir --clean hat-trick-fusion.spec
+          python -m PyInstaller --noconfirm --clean hat-trick-fusion.spec
       - name: Upload Backend
         uses: actions/upload-artifact@v4
         with:
@@ -282,7 +282,6 @@ jobs:
             '  <PropertyGroup>',
             '    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>',
             '    <OutputType>Package</OutputType>',
-            '    <Platforms>x64;x86</Platforms>',
             '    <DefineConstants>Version=$(Version);SourceDir=$(SourceDir);ServicePort=$(ServicePort)</DefineConstants>',
             '  </PropertyGroup>',
             '  <ItemGroup>',

--- a/.github/workflows/build-msi-hattrickfusion-ultimate.yml
+++ b/.github/workflows/build-msi-hattrickfusion-ultimate.yml
@@ -181,7 +181,7 @@ jobs:
           )
           $spec_script | Out-File -FilePath "hat-trick-ultimate.spec" -Encoding utf8
 
-          python -m PyInstaller --noconfirm --onedir --clean hat-trick-ultimate.spec
+          python -m PyInstaller --noconfirm --clean hat-trick-ultimate.spec
       - name: Upload Backend
         uses: actions/upload-artifact@v4
         with:
@@ -265,7 +265,6 @@ jobs:
             '  <PropertyGroup>',
             '    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>',
             '    <OutputType>Package</OutputType>',
-            '    <Platforms>x64;x86</Platforms>',
             '    <DefineConstants>Version=$(Version);SourceDir=$(SourceDir);ServicePort=$(ServicePort)</DefineConstants>',
             '  </PropertyGroup>',
             '  <ItemGroup>',

--- a/build_wix/Product_WithService.wxs
+++ b/build_wix/Product_WithService.wxs
@@ -4,15 +4,15 @@
      xmlns:fire="http://wixtoolset.org/schemas/v4/wxs/firewall">
 
   <!-- 🔧 CRITICAL FIX: Define defaults for preprocessor variables -->
-  <?if not defined(ServicePort)?>
+  <?if not (defined(ServicePort))?>
     <?define ServicePort = 8102 ?>
   <?endif?>
 
-  <?if not defined(Version) ?>
+  <?if not (defined(Version)) ?>
     <?define Version = 0.0.0 ?>
   <?endif?>
 
-  <?if not defined(SourceDir) ?>
+  <?if not (defined(SourceDir)) ?>
     <?define SourceDir = staging/backend ?>
   <?endif?>
 


### PR DESCRIPTION
The WiX build process was failing with a `WIX0288` error, indicating that the 'Platform' variable was being declared more than once.

This occurred because the `<Platforms>x64;x86</Platforms>` tag was being dynamically written into the `Fortuna.wixproj` file, while the platform was also being specified via the `-p:Platform=` argument in the `dotnet build` command.

This commit resolves the conflict by removing the `<Platforms>` tag from the `.wixproj` generation script in the affected workflows. The build command now serves as the single source of truth for the platform, eliminating the duplicate definition and allowing the build to proceed.