### PR TITLE
refactor(ci): Separate WiX templates for Electron and Web Service builds

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -76,10 +76,16 @@ jobs:
             '# -*- mode: python ; coding: utf-8 -*-',
             'from PyInstaller.utils.hooks import collect_data_files, collect_submodules',
             '',
+            "uvicorn_datas = collect_data_files('uvicorn')",
+            "uvicorn_hidden = collect_submodules('uvicorn')",
+            "fastapi_hidden = collect_submodules('fastapi')",
+            "starlette_hidden = collect_submodules('starlette')",
+            "anyio_hidden = collect_submodules('anyio')",
+            '',
             "a = Analysis(['${{ env.BACKEND_DIR }}/service_entry.py'],",
             "             pathex=['${{ env.BACKEND_DIR }}'],",
-            "             datas=collect_data_files('uvicorn') + [('${{ env.BACKEND_DIR }}', '.')],",
-            "             hiddenimports=['uvicorn', 'win32timezone', 'win32serviceutil', 'win32service', 'win32event'] + collect_submodules('web_service'),",
+            "             datas=uvicorn_datas + [('${{ env.BACKEND_DIR }}', '.')],",
+            "             hiddenimports=['win32timezone', 'win32serviceutil', 'win32service', 'win32event'] + uvicorn_hidden + fastapi_hidden + starlette_hidden + anyio_hidden + collect_submodules('web_service'),",
             "             hookspath=[],",
             "             runtime_hooks=[],",
             "             excludes=[],",
@@ -112,6 +118,11 @@ jobs:
           $spec_script | Out-File -FilePath "electron.spec" -Encoding utf8
 
           pyinstaller --noconfirm --clean electron.spec
+
+      - name: 🔍 Sanity Check Executable
+        shell: pwsh
+        run: |
+          dist/fortuna-backend/fortuna-backend.exe --help
 
       - name: 📤 Upload
         uses: actions/upload-artifact@v4
@@ -164,6 +175,10 @@ jobs:
           $dest = "electron/resources/fortuna-backend"
           New-Item -ItemType Directory -Path $dest -Force
           Copy-Item -Path "temp_backend/*" -Destination $dest -Recurse -Force
+      - name: ✅ Verify backend staged for Electron
+        shell: pwsh
+        run: |
+          Test-Path electron/resources/fortuna-backend/fortuna-backend.exe
       - name: '🏗️ Build MSI'
         working-directory: electron
         shell: pwsh

--- a/.github/workflows/build-msi-hat-trick-fusion.yml
+++ b/.github/workflows/build-msi-hat-trick-fusion.yml
@@ -137,10 +137,16 @@ jobs:
             '# -*- mode: python ; coding: utf-8 -*-',
             'from PyInstaller.utils.hooks import collect_data_files, collect_submodules',
             '',
+            "uvicorn_datas = collect_data_files('uvicorn')",
+            "uvicorn_hidden = collect_submodules('uvicorn')",
+            "fastapi_hidden = collect_submodules('fastapi')",
+            "starlette_hidden = collect_submodules('starlette')",
+            "anyio_hidden = collect_submodules('anyio')",
+            '',
             "a = Analysis(['web_service/backend/service_entry.py'],",
             "             pathex=['web_service/backend'],",
-            "             datas=collect_data_files('uvicorn') + [('web_service/backend', '.'), ('web_platform/frontend/out', 'ui')],",
-            "             hiddenimports=['uvicorn', 'win32timezone', 'win32serviceutil'] + collect_submodules('web_service'),",
+            "             datas=uvicorn_datas + [('web_service/backend', '.'), ('web_platform/frontend/out', 'ui')],",
+            "             hiddenimports=['win32timezone', 'win32serviceutil', 'win32service', 'win32event'] + uvicorn_hidden + fastapi_hidden + starlette_hidden + anyio_hidden + collect_submodules('web_service'),",
             "             hookspath=[],",
             "             runtime_hooks=[],",
             "             excludes=[],",
@@ -173,6 +179,10 @@ jobs:
           $spec_script | Out-File -FilePath "hat-trick-fusion.spec" -Encoding utf8
 
           python -m PyInstaller --noconfirm --clean hat-trick-fusion.spec
+      - name: 🔍 Sanity Check Executable
+        shell: pwsh
+        run: |
+          dist/fortuna-backend/fortuna-backend.exe --help
       - name: Upload Backend
         uses: actions/upload-artifact@v4
         with:
@@ -254,7 +264,7 @@ jobs:
         run: |
           Set-StrictMode -Version Latest
           if (-not (Test-Path build_wix)) { New-Item -ItemType Directory -Path build_wix | Out-Null }
-          Copy-Item build_wix/Product_WithService.wxs build_wix/Product.wxs -Force
+          Copy-Item build_wix/Product_WebService.wxs build_wix/Product.wxs -Force
           $wxsPath = 'build_wix/Product.wxs'
           $wxsContent = [xml](Get-Content $wxsPath -Raw)
           $serviceControl = $wxsContent.SelectSingleNode("//*[local-name()='ServiceControl']")

--- a/.github/workflows/build-web-service-msi-jules.yml
+++ b/.github/workflows/build-web-service-msi-jules.yml
@@ -571,13 +571,20 @@ jobs:
           spec = f"""
           # -- mode: python ; coding: utf-8 --
           from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+          uvicorn_datas = collect_data_files('uvicorn')
+          uvicorn_hidden = collect_submodules('uvicorn')
+          fastapi_hidden = collect_submodules('fastapi')
+          starlette_hidden = collect_submodules('starlette')
+          anyio_hidden = collect_submodules('anyio')
+
           block_cipher = None
           a = Analysis(
               ['{entry}'],
               pathex=[],
               binaries=[],
-              datas=collect_data_files('uvicorn') + collect_data_files('slowapi') + [('{frontend_out}', 'ui')],
-              hiddenimports=collect_submodules('{mod_path}') + ['win32timezone'],
+              datas=uvicorn_datas + collect_data_files('slowapi') + [('{frontend_out}', 'ui'), ('{bk_dir}', '.')],
+              hiddenimports=uvicorn_hidden + fastapi_hidden + starlette_hidden + anyio_hidden + collect_submodules('{mod_path}') + ['win32timezone', 'win32serviceutil', 'win32service', 'win32event'],
               hookspath=[],
               runtime_hooks=[],
               excludes=['tests', 'pytest'],
@@ -607,6 +614,10 @@ jobs:
         run: |
           Set-StrictMode -Version Latest
           pyinstaller "${{ env.BACKEND_SPEC }}" --clean --log-level=WARN --noconfirm
+      - name: 🔍 Sanity Check Executable
+        shell: pwsh
+        run: |
+          dist/fortuna-backend/fortuna-backend.exe --help
       - name: Verify Executable
         run: |
           Set-StrictMode -Version Latest
@@ -814,7 +825,7 @@ jobs:
       - name: Prepare WiX Project
         run: |
           Set-StrictMode -Version Latest
-          Copy-Item "${{ env.WIX_DIR }}/Product_WithService.wxs" "${{ env.WIX_DIR }}/Product.wxs" -Force
+          Copy-Item "${{ env.WIX_DIR }}/Product_WebService.wxs" "${{ env.WIX_DIR }}/Product.wxs" -Force
           $proj = @(
             '<Project Sdk="WixToolset.Sdk/${{ env.WIX_VERSION }}">',
             '  <PropertyGroup>',

--- a/build_wix/Product_Electron.wxs
+++ b/build_wix/Product_Electron.wxs
@@ -1,0 +1,60 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui"
+     xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+
+  <?define Version = 0.0.0 ?>
+
+  <Package Name="Fortuna Faucet"
+           Manufacturer="Fortuna Engineering"
+           Version="$(var.Version)"
+           UpgradeCode="FA689549-366B-4C5C-A482-1132F9A34B10"
+           Scope="perMachine"
+           Compressed="yes">
+
+    <MajorUpgrade DowngradeErrorMessage="A newer version is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <Feature Id="Main">
+      <ComponentGroupRef Id="AppFiles" />
+      <ComponentGroupRef Id="Shortcuts" />
+    </Feature>
+
+    <ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLFOLDER" />
+    <WixVariable Id="WixUILicenseRtf" Value="license.rtf" />
+
+    <?if $(var.Platform) = x64 ?>
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="Fortuna Faucet" />
+    </StandardDirectory>
+    <?else?>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="Fortuna Faucet" />
+    </StandardDirectory>
+    <?endif?>
+
+    <StandardDirectory Id="ProgramMenuFolder">
+      <Directory Id="ApplicationProgramsFolder" Name="Fortuna Faucet"/>
+    </StandardDirectory>
+
+    <ComponentGroup Id="AppFiles" Directory="INSTALLFOLDER">
+      <Component Id="ElectronExe" Guid="*">
+        <File Source="$(var.SourceDir)\Fortuna Faucet.exe" KeyPath="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Shortcuts">
+      <Component Id="StartMenuShortcut" Guid="*" Directory="ApplicationProgramsFolder">
+        <Shortcut Name="Fortuna Faucet"
+                  Target="[INSTALLFOLDER]Fortuna Faucet.exe" />
+        <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall" />
+        <RegistryValue Root="HKCU"
+                       Key="Software\Fortuna Faucet"
+                       Name="Installed"
+                       Type="integer"
+                       Value="1"
+                       KeyPath="yes" />
+      </Component>
+    </ComponentGroup>
+
+  </Package>
+</Wix>

--- a/build_wix/Product_WebService.wxs
+++ b/build_wix/Product_WebService.wxs
@@ -4,11 +4,11 @@
      xmlns:fire="http://wixtoolset.org/schemas/v4/wxs/firewall">
 
   <!-- 🔧 CRITICAL FIX: Define defaults for preprocessor variables -->
-  <?if not (defined(ServicePort))?>
+  <?if not defined(ServicePort)?>
     <?define ServicePort = 8102 ?>
   <?endif?>
 
-  <?if not (defined(Version)) ?>
+  <?if not defined(Version) ?>
     <?define Version = 0.0.0 ?>
   <?endif?>
 

--- a/electron/electron-builder-config.yml
+++ b/electron/electron-builder-config.yml
@@ -8,6 +8,7 @@ directories:
 files:
   - filter:
       - "**/*"
+      - "build_wix"
 
 
 win:
@@ -21,3 +22,4 @@ msi:
   # Explicitly pointing to the file ensures WiX picks it up
   shortcutName: "Fortuna Faucet"
   warningsAsErrors: false
+  template: "build_wix/Product_Electron.wxs"

--- a/electron/main.js
+++ b/electron/main.js
@@ -79,6 +79,7 @@ async startBackend() {
 
     this.backendProcess = spawn(backendCommand, [], {
         cwd: backendCwd, // CRITICAL: This allows the EXE to find the '_internal' folder
+        windowsHide: true,
         env: {
             ...process.env,
             PYTHONPATH: backendCwd // Force python to look at the root of the extract dir


### PR DESCRIPTION
This commit refactors the build process to use two distinct WiX installer templates, one for the Electron desktop application and one for the standalone Web Service. This separation resolves conflicts and ensures each build pipeline produces a correctly configured installer for its specific target.

- A new `Product_Electron.wxs` file has been created for the Electron build. This template is a clean, standard installer for a desktop application and does not include any service-related logic.
- The existing `Product_WithService.wxs` has been renamed to `Product_WebService.wxs` and now exclusively serves the web service builds.
- The `build-electron-msi-gpt5.yml` workflow has been updated to use `Product_Electron.wxs` via the `electron-builder-config.yml` file.
- The `build-msi-hat-trick-fusion.yml` and `build-web-service-msi-jules.yml` workflows have been updated to use `Product_WebService.wxs`.

This change implements a clearer and more robust installer architecture for the project's dual-delivery targets.