### PR TITLE
fix(ci): correct wix preprocessor syntax in Product_WebService.wxs

### DIFF
--- a/build_wix/Product_WebService.wxs
+++ b/build_wix/Product_WebService.wxs
@@ -4,7 +4,7 @@
      xmlns:fire="http://wixtoolset.org/schemas/v4/wxs/firewall">
 
   <!-- 🔧 CRITICAL FIX: Define defaults for preprocessor variables -->
-  <?if not defined(ServicePort)?>
+  <?if not defined(ServicePort) ?>
     <?define ServicePort = 8102 ?>
   <?endif?>
 
@@ -12,7 +12,7 @@
     <?define Version = 0.0.0 ?>
   <?endif?>
 
-  <?if not (defined(SourceDir)) ?>
+  <?if not defined(SourceDir) ?>
     <?define SourceDir = staging/backend ?>
   <?endif?>
 


### PR DESCRIPTION
- The WiX build was failing with error WIX0159 due to a parenthesis mismatch in a preprocessor `if` directive.
- The expression `<?if not defined(ServicePort)?>` is invalid. The correct syntax requires a space before the closing parenthesis: `<?if not defined(ServicePort) ?>`.
- This commit corrects the syntax for all `defined()` checks in the `Product_WebService.wxs` file, resolving the build failure.