### PR TITLE
Fix: Correct file not found error in WiX build workflow

### DIFF
--- a/.github/workflows/build-electron-hybrid.yml
+++ b/.github/workflows/build-electron-hybrid.yml
@@ -1,5 +1,5 @@
 # System Timestamp: 2024-05-21 12:00:00
-name:  Build Electron MSI (Hybrid V12 Engine)
+name:  🚀 Build Electron MSI (Hybrid V12 Engine)
 
 on:
   push:

--- a/.github/workflows/build-msi-hattrickfusion-ultimate.yml
+++ b/.github/workflows/build-msi-hattrickfusion-ultimate.yml
@@ -215,7 +215,7 @@ jobs:
         run: |
           Set-StrictMode -Version Latest
           if (-not (Test-Path build_wix)) { New-Item -ItemType Directory -Path build_wix | Out-Null }
-          Copy-Item build_wix/Product_WithService.wxs build_wix/Product.wxs -Force
+          Copy-Item build_wix/Product_WebService.wxs build_wix/Product.wxs -Force
           $wxsPath = 'build_wix/Product.wxs'
           $wxsContent = [xml](Get-Content $wxsPath -Raw)
           $serviceControl = $wxsContent.SelectSingleNode("//*[local-name()='ServiceControl']")

--- a/.github/workflows/build-msi-revived.yml
+++ b/.github/workflows/build-msi-revived.yml
@@ -147,30 +147,28 @@ jobs:
         shell: pwsh
         run: |
           Set-StrictMode -Version Latest
-          Copy-Item "${{ env.WIX_DIR }}/Product_WebService.wxs" "${{ env.WIX_DIR }}/Product.wxs" -Force
           $sourceDir = "staging/backend"
-          $distDir = "staging/backend/fortuna-core-service" # PyInstaller one-dir output, but the artifact download places it directly in backend
           $targetExe = "fortuna-webservice.exe"
 
           if (Test-Path (Join-Path $sourceDir "fortuna-core-service.exe")) {
-              Write-Host "PyInstaller 'onedir' output found. Staging entire directory..."
-              # In this workflow, the onedir contents are already at the root of staging/backend
-              # Just need to rename the executable for WiX
+              Write-Host "PyInstaller 'onedir' output found. Renaming for WiX..."
               Rename-Item -Path (Join-Path $sourceDir "fortuna-core-service.exe") -NewName $targetExe -Force
               Write-Host "✅ Staging complete for WiX."
           } else {
               Write-Host "##[error]Could not find fortuna-core-service.exe in the staging directory."
-              Write-Host "Listing contents for forensics:"
               Get-ChildItem -Path $sourceDir -Recurse
               exit 1
           }
           $proj = @(
             '<Project Sdk="WixToolset.Sdk/${{ env.WIX_VERSION }}">',
             '  <PropertyGroup>',
+            '    <Version Condition="''$(Version)'' == ''''">0.0.1</Version>',
+            '    <ServicePort Condition="''$(ServicePort)'' == ''''">8102</ServicePort>',
+            '    <SourceDir Condition="''$(SourceDir)'' == ''''">staging/backend</SourceDir>',
             '    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>',
             '    <OutputType>Package</OutputType>',
             '    <Platforms>x64;x86</Platforms>',
-            '    <DefineConstants>Version=$(Version);SourceDir=$(SourceDir);ServicePort=$(ServicePort)</DefineConstants>',
+            '    <DefineConstants>Version=$(Version);SourceDir=$(SourceDir);ServicePort=$(ServicePort);Platform=$(Platform)</DefineConstants>',
             '  </PropertyGroup>',
             '  <ItemGroup>',
             '    <PackageReference Include="WixToolset.UI.wixext" Version="${{ env.WIX_VERSION }}" />',
@@ -178,7 +176,7 @@ jobs:
             '    <PackageReference Include="WixToolset.Util.wixext" Version="${{ env.WIX_VERSION }}" />',
             '  </ItemGroup>',
             '  <ItemGroup>',
-            '    <Compile Include="Product.wxs" />',
+            '    <Compile Include="Product_WebService.wxs" />',
             '  </ItemGroup>',
             '</Project>'
           )
@@ -187,7 +185,6 @@ jobs:
       - name: Build MSI
         working-directory: ${{ env.WIX_DIR }}
         run: |
-          # 🚀 Pass Matrix Arch to WiX
           dotnet build Fortuna.wixproj -c Release -p:Platform=x86 -p:Version="${{ needs.preflight-check.outputs.semver }}" -p:SourceDir="../staging/backend" -p:ServicePort="${{ env.FORTUNA_PORT }}"
 
       - name: Rename & Hash

--- a/.github/workflows/build-web-service-msi-jules.yml
+++ b/.github/workflows/build-web-service-msi-jules.yml
@@ -770,10 +770,12 @@ jobs:
       - name: Prepare WiX Project
         run: |
           Set-StrictMode -Version Latest
-          Copy-Item "${{ env.WIX_DIR }}/Product_WebService.wxs" "${{ env.WIX_DIR }}/Product.wxs" -Force
           $proj = @(
             '<Project Sdk="WixToolset.Sdk/${{ env.WIX_VERSION }}">',
             '  <PropertyGroup>',
+            '    <Version Condition="''$(Version)'' == ''''">0.0.1</Version>',
+            '    <ServicePort Condition="''$(ServicePort)'' == ''''">8102</ServicePort>',
+            '    <SourceDir Condition="''$(SourceDir)'' == ''''">staging/backend</SourceDir>',
             '    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>',
             '    <OutputType>Package</OutputType>',
             '    <Platforms>x64;x86</Platforms>',
@@ -785,7 +787,7 @@ jobs:
             '    <PackageReference Include="WixToolset.Util.wixext" Version="${{ env.WIX_VERSION }}" />',
             '  </ItemGroup>',
             '  <ItemGroup>',
-            '    <Compile Include="Product.wxs" />',
+            '    <Compile Include="Product_WebService.wxs" />',
             '  </ItemGroup>',
             '</Project>'
           )

--- a/build_wix/Product_WebService.wxs
+++ b/build_wix/Product_WebService.wxs
@@ -3,19 +3,6 @@
      xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util"
      xmlns:fire="http://wixtoolset.org/schemas/v4/wxs/firewall">
 
-  <!-- 🔧 CRITICAL FIX: Define defaults for preprocessor variables -->
-  <?if !defined(ServicePort) ?>
-    <?define ServicePort = 8102 ?>
-  <?endif?>
-
-  <?if !defined(Version) ?>
-    <?define Version = 0.0.0 ?>
-  <?endif?>
-
-  <?if !defined(SourceDir) ?>
-    <?define SourceDir = staging/backend ?>
-  <?endif?>
-
   <Package Name="Fortuna Faucet Web Service"
            Manufacturer="Fortuna Engineering"
            Version="$(var.Version)"
@@ -36,27 +23,26 @@
     <ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLFOLDER" />
     <WixVariable Id="WixUILicenseRtf" Value="license.rtf" />
 
-    <!-- Properties for the auto-launch checkbox on the exit dialog -->
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Launch Fortuna Dashboard" />
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1" />
     <Property Id="WixShellExecTarget" Value="http://localhost:$(var.ServicePort)" />
 
     <?if $(var.Platform) = x64 ?>
-    <StandardDirectory Id="ProgramFiles64Folder">
-      <Directory Id="INSTALLFOLDER" Name="Fortuna Faucet Service">
-         <Directory Id="Dir_Data" Name="data" />
-         <Directory Id="Dir_Json" Name="json" />
-         <Directory Id="Dir_Logs" Name="logs" />
-      </Directory>
-    </StandardDirectory>
+      <StandardDirectory Id="ProgramFiles64Folder">
+        <Directory Id="INSTALLFOLDER" Name="Fortuna Faucet Service">
+           <Directory Id="Dir_Data" Name="data" />
+           <Directory Id="Dir_Json" Name="json" />
+           <Directory Id="Dir_Logs" Name="logs" />
+        </Directory>
+      </StandardDirectory>
     <?else?>
-    <StandardDirectory Id="ProgramFilesFolder">
-      <Directory Id="INSTALLFOLDER" Name="Fortuna Faucet Service">
-         <Directory Id="Dir_Data" Name="data" />
-         <Directory Id="Dir_Json" Name="json" />
-         <Directory Id="Dir_Logs" Name="logs" />
-      </Directory>
-    </StandardDirectory>
+      <StandardDirectory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLFOLDER" Name="Fortuna Faucet Service">
+           <Directory Id="Dir_Data" Name="data" />
+           <Directory Id="Dir_Json" Name="json" />
+           <Directory Id="Dir_Logs" Name="logs" />
+        </Directory>
+      </StandardDirectory>
     <?endif?>
 
     <StandardDirectory Id="ProgramMenuFolder">
@@ -66,10 +52,11 @@
     <StandardDirectory Id="DesktopFolder" />
 
     <ComponentGroup Id="ServiceComponents" Directory="INSTALLFOLDER">
-      <!-- Statically setting GUIDs is best practice for component stability -->
       <Component Id="ServiceExecutable" Guid="E4B9C2C2-5B4E-4B02-A2DA-820152433E72">
         <File Id="FortunaEXE" Source="$(var.SourceDir)/fortuna-webservice.exe" KeyPath="yes" />
-        <ServiceInstall Id="ServiceInstaller" Type="ownProcess" Name="FortunaWebService" DisplayName="Fortuna Web Service" Description="Background service for Fortuna Faucet" Start="auto" Account="LocalSystem" ErrorControl="normal" Vital="yes" />
+        <ServiceInstall Id="ServiceInstaller" Type="ownProcess" Name="FortunaWebService"
+                        DisplayName="Fortuna Web Service" Description="Background service for Fortuna Faucet"
+                        Start="auto" Account="LocalSystem" ErrorControl="normal" Vital="yes" />
         <ServiceControl Id="StartService" Stop="both" Remove="uninstall" Name="FortunaWebService" Wait="no" />
         <fire:FirewallException Id="FirewallRule" Name="Fortuna Faucet" Port="$(var.ServicePort)" Protocol="tcp" Scope="any" />
       </Component>
@@ -107,6 +94,5 @@
             <RegistryValue Root="HKCU" Key="Software\Fortuna Faucet" Name="StartMenuShortcut" Type="integer" Value="1" KeyPath="yes" />
         </Component>
     </ComponentGroup>
-
   </Package>
 </Wix>


### PR DESCRIPTION
This commit resolves a `Copy-Item` failure in the `build-msi-hattrickfusion-ultimate.yml` workflow by correcting a typo in a filename. The workflow was attempting to copy a non-existent `Product_WithService.wxs` when the correct file is `Product_WebService.wxs`.

This is the final fix in a series of changes to stabilize the MSI build processes. The cumulative changes include:
- Fixing multiple WiX build errors (WIX0006, WIX0114) across several workflows.
- Implementing robust MSBuild-based versioning to prevent empty version errors.
- Cleaning up and correcting WiX preprocessor syntax and file references.