### PR TITLE
fix(script): Resolve PowerShell ParserError in quick-start script

### DIFF
--- a/scripts/fortuna-quick-start.ps1
+++ b/scripts/fortuna-quick-start.ps1
@@ -61,20 +61,20 @@ function Show-Header {
 }
 
 function Show-Step ([string]$msg) {
-    Write-Host "🔹 $msg" -ForegroundColor Cyan
+    Write-Host ('🔹 ' + $msg) -ForegroundColor Cyan
 }
 
 function Show-Success ([string]$msg) {
-    Write-Host "✅ $msg" -ForegroundColor Green
+    Write-Host ('✅ ' + $msg) -ForegroundColor Green
 }
 
 function Show-Warn ([string]$msg) {
-    Write-Host "⚠️  $msg" -ForegroundColor Yellow
+    Write-Host ('⚠️  ' + $msg) -ForegroundColor Yellow
 }
 
 function Show-Fail ([string]$msg) {
     Write-Host ""
-    Write-Host "❌ $msg" -ForegroundColor Red
+    Write-Host ('❌ ' + $msg) -ForegroundColor Red
     Write-Host ""
     Write-Host "💡 TIP: Run with -Help flag for setup instructions" -ForegroundColor Gray
     Write-Host ""
@@ -82,7 +82,7 @@ function Show-Fail ([string]$msg) {
 }
 
 function Show-Info ([string]$msg) {
-    Write-Host "ℹ️  $msg" -ForegroundColor Gray
+    Write-Host ('ℹ️  ' + $msg) -ForegroundColor Gray
 }
 
 # --- 3. PORT MANAGER (The "Self-Healing" Feature) ---


### PR DESCRIPTION
This commit fixes a PowerShell `ParserError` in the `scripts/fortuna-quick-start.ps1` script that was caused by incorrect string handling of special characters in several UI helper functions.

The `Write-Host` commands in the `Show-Step`, `Show-Success`, `Show-Warn`, `Show-Fail`, and `Show-Info` functions have been updated to use single-quoted strings with concatenation. This more robust syntax prevents the PowerShell parser from misinterpreting the string content and ensures the script can be executed without syntax errors on Windows PCs.

This change is submitted along with all previous CI/CD workflow hardening to provide a comprehensive stability update.