### PR TITLE
fix(ci): Resolve multiple workflow build failures

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -60,10 +60,9 @@ jobs:
               "numpy==1.23.5",
               "pandas==1.5.3",
               "sqlalchemy==1.4.53",
-              "greenlet==3.1.1",
               "--only-binary=:all:"
             ) | Set-Content $file
-            Write-Host "✅ Constraints: SQLAlchemy 1.4.53, greenlet 3.1.1"
+            Write-Host "✅ Constraints: SQLAlchemy 1.4.53"
           } else {
             New-Item $file -ItemType File -Force
           }

--- a/.github/workflows/build-msi-supreme-combo.yml
+++ b/.github/workflows/build-msi-supreme-combo.yml
@@ -221,7 +221,8 @@ jobs:
             -o "Fortuna-${{ needs.preflight-check.outputs.semver }}-${arch}.msi" `
             -d Version="${{ needs.preflight-check.outputs.semver }}" `
             -d SourceDir="staging/backend" `
-            -d Platform=$arch
+            -d Platform=$arch `
+            -d ServicePort="${{ env.SERVICE_PORT }}"
 
       - name: 🦜 The Canary (Malware Scan)
         continue-on-error: true

--- a/.github/workflows/formerly-the-core-of-reusable.yml
+++ b/.github/workflows/formerly-the-core-of-reusable.yml
@@ -247,7 +247,8 @@ jobs:
           $msiName = "Fortuna-${{ needs.preflight.outputs.semver }}-${{ matrix.arch }}.msi"
           wix build build_wix/Product_WebService.wxs `
             -arch ${{ matrix.arch }} -o $msiName `
-            -d Version="${{ needs.preflight.outputs.semver }}" -d SourceDir="staging"
+            -d Version="${{ needs.preflight.outputs.semver }}" -d SourceDir="staging" `
+            -d ServicePort="${{ env.SERVICE_PORT }}"
           Write-Host "✅ Built: $msiName"
 
       - name: 🦜 The Canary


### PR DESCRIPTION
This commit addresses two separate issues causing CI/CD pipelines to fail:

1.  **Resolves Python dependency conflict:** The `build-electron-msi-gpt5.yml` workflow was failing during dependency installation due to a pinned `greenlet==3.1.1` version that conflicted with other packages. This constraint has been removed to allow `pip` to resolve a valid dependency tree. An inaccurate log message related to this constraint has also been corrected.

2.  **Fixes missing WiX build variable:** The `build-msi-supreme-combo.yml` and `formerly-the-core-of-reusable.yml` workflows were failing with a `WIX0150` error because the required `ServicePort` variable was not being passed to the WiX compiler. The `wix build` commands in both files have been updated to include the `-d ServicePort` argument.