### PR TITLE
fix(ci): Add scipy pin and WiX extensions to fix failing workflows

### DIFF
--- a/.github/workflows/build-electron-hybrid.yml
+++ b/.github/workflows/build-electron-hybrid.yml
@@ -112,7 +112,7 @@ jobs:
           New-Item -ItemType Directory -Path $constraintDir -Force | Out-Null
           $constraintFile = Join-Path $constraintDir "constraint-${{ matrix.arch }}.txt"
           if ('${{ matrix.arch }}' -eq 'x86') {
-            "numpy==1.23.5`r`npandas==1.5.3" | Set-Content $constraintFile
+            "numpy==1.23.5`r`npandas==1.5.3`r`nscipy==1.10.1" | Set-Content $constraintFile
           } else { New-Item $constraintFile -ItemType File -Force }
           "file=$constraintFile" | Out-File $env:GITHUB_OUTPUT -Append
       - name: '🐍 Install Python Dependencies'

--- a/.github/workflows/build-msi-hat-trick-fusion.yml
+++ b/.github/workflows/build-msi-hat-trick-fusion.yml
@@ -121,9 +121,10 @@ jobs:
             @(
               "numpy==1.23.5",
               "pandas==1.5.3",
+              "scipy==1.10.1",
               "--only-binary=:all:"
             ) | Set-Content $constraintFile
-            Write-Host "✅ x86 constraints: numpy 1.23.5, pandas 1.5.3, wheel-only"
+            Write-Host "✅ x86 constraints: numpy 1.23.5, pandas 1.5.3, scipy 1.10.1, wheel-only"
           } else { New-Item $constraintFile -ItemType File -Force }
           "file=$constraintFile" | Out-File $env:GITHUB_OUTPUT -Append
       - name: Install Dependencies

--- a/.github/workflows/build-msi-hattrickfusion-ultimate.yml
+++ b/.github/workflows/build-msi-hattrickfusion-ultimate.yml
@@ -134,11 +134,12 @@ jobs:
             @(
               "numpy==1.23.5",
               "pandas==1.5.3",
+              "scipy==1.10.1",
               "sqlalchemy==1.4.53",
               "greenlet==3.1.1",
               "--only-binary=:all:"
             ) | Set-Content $constraintFile
-            Write-Host "✅ Constraints: SQLAlchemy 1.4.53, greenlet 3.1.1"
+            Write-Host "✅ Constraints: SQLAlchemy 1.4.53, greenlet 3.1.1, scipy 1.10.1"
           } else { New-Item $constraintFile -ItemType File -Force }
           "file=$constraintFile" | Out-File $env:GITHUB_OUTPUT -Append
       - name: Install Dependencies & Build Tools

--- a/.github/workflows/build-msi-revived.yml
+++ b/.github/workflows/build-msi-revived.yml
@@ -85,7 +85,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           # 🚀 Apply Constraints
           pip install -r ${{ env.BACKEND_DIR }}/requirements.txt -c ${{ steps.constraints.outputs.file }}
-          pip install pyinstaller==6.6.0 pywin32
+          pip install pyinstaller==6.6.0 pywin32 scipy==1.10.1
 
       - name: Build Backend (PyInstaller)
         env:

--- a/.github/workflows/build-msi-supreme-combo.yml
+++ b/.github/workflows/build-msi-supreme-combo.yml
@@ -108,7 +108,7 @@ jobs:
           $file = "constraints.txt"
           if ('${{ matrix.arch }}' -eq 'x86') {
             Write-Host "🛡️ ACTIVATING X86 SAFE MODE"
-            "numpy==1.23.5`r`npandas==1.5.3" | Set-Content $file
+            "numpy==1.23.5`r`npandas==1.5.3`r`nscipy==1.10.1" | Set-Content $file
           } else {
             New-Item $file -ItemType File -Force
           }

--- a/.github/workflows/build-msi-unified.yml
+++ b/.github/workflows/build-msi-unified.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           $file = "constraints.txt"
           if ('${{ matrix.arch }}' -eq 'x86') {
-            "numpy==1.23.5`r`npandas==1.5.3" | Set-Content $file
+            "numpy==1.23.5`r`npandas==1.5.3`r`nscipy==1.10.1" | Set-Content $file
           } else {
             New-Item $file -ItemType File -Force
           }

--- a/.github/workflows/build-web-service-msi-jules.yml
+++ b/.github/workflows/build-web-service-msi-jules.yml
@@ -460,7 +460,7 @@ jobs:
           New-Item -ItemType Directory -Path $constraintDir -Force | Out-Null
           $constraintFile = Join-Path $constraintDir "constraint-${{ matrix.arch }}.txt"
           if ('${{ matrix.arch }}' -eq 'x86') {
-            "numpy==1.23.5`r`npandas==1.5.3`r`nsqlalchemy==1.4.53`r`ngreenlet==3.1.1`r`n--only-binary=:all:" | Set-Content $constraintFile
+            "numpy==1.23.5`r`npandas==1.5.3`r`nscipy==1.10.1`r`nsqlalchemy==1.4.53`r`ngreenlet==3.1.1`r`n--only-binary=:all:" | Set-Content $constraintFile
           } else {
             New-Item $constraintFile -ItemType File -Force
           }

--- a/.github/workflows/formerly-the-core-of-reusable.yml
+++ b/.github/workflows/formerly-the-core-of-reusable.yml
@@ -250,7 +250,10 @@ jobs:
             -arch ${{ matrix.arch }} -o $msiName `
             -d Version="${{ needs.preflight.outputs.semver }}" -d SourceDir="staging" `
             -d ServicePort="${{ env.SERVICE_PORT }}" `
-            -d Platform=${{ matrix.arch }}
+            -d Platform=${{ matrix.arch }} `
+            -ext WixToolset.UI.wixext `
+            -ext WixToolset.Firewall.wixext `
+            -ext WixToolset.Util.wixext
           Write-Host "✅ Built: $msiName"
 
       - name: 🦜 The Canary


### PR DESCRIPTION
This commit addresses two separate issues causing build failures in the GitHub Actions workflows:

1.  **Scipy Build Failure on x86:** The x86 builds in several MSI workflows were failing due to an attempt to build the scipy package from source. This is caused by an architecture mismatch in the build toolchain on the Windows runners. This change adds a pin for scipy==1.10.1 to the x86 build steps in the affected workflows. This ensures that a pre-compiled 32-bit wheel is used, resolving the build failure.

2.  **WiX Extension Error:** The `formerly-the-core-of-reusable.yml` workflow was failing with WIX0200 errors. This was because the `wix build` command was missing the necessary `-ext` arguments to include the UI, Firewall, and Util extensions. This change adds the required extension arguments to the command.