### PR TITLE
fix(ci): Resolve multiple workflow failures

### DIFF
--- a/.github/workflows/build-electron-hybrid.yml
+++ b/.github/workflows/build-electron-hybrid.yml
@@ -112,7 +112,7 @@ jobs:
           New-Item -ItemType Directory -Path $constraintDir -Force | Out-Null
           $constraintFile = Join-Path $constraintDir "constraint-${{ matrix.arch }}.txt"
           if ('${{ matrix.arch }}' -eq 'x86') {
-            "numpy==1.23.5`r`npandas==1.5.3" | Set-Content $constraintFile
+            "numpy==1.23.5`r`npandas==1.5.3`r`nscipy==1.10.1" | Set-Content $constraintFile
           } else { New-Item $constraintFile -ItemType File -Force }
           "file=$constraintFile" | Out-File $env:GITHUB_OUTPUT -Append
       - name: '🐍 Install Python Dependencies'

--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -56,34 +56,43 @@ jobs:
           New-Item -ItemType Directory -Path "${{ env.BACKEND_DIR }}/json" -Force
           New-Item -ItemType Directory -Path "${{ env.BACKEND_DIR }}/adapters" -Force
 
-      - name: 📦 Install Dependencies
+      - name: 📦 Install Dependencies and Verify Imports
         shell: pwsh
         env:
           PYTHONUTF8: '1'
         run: |
           $ErrorActionPreference = 'Stop'
-
           pip install --upgrade pip
-
           if ('${{ matrix.arch }}' -eq 'x86') {
             Write-Host "--- Using x86-specific requirements file ---"
-            # Pre-install specific versions of packages with known good 32-bit wheels for Python 3.11
-            # to avoid building from source which is failing for scipy.
-            Write-Host "--- Pre-installing numpy, pandas, and scipy for x86 ---"
             pip install numpy==1.23.5 pandas==1.5.3 scipy==1.10.1
             $requirementsFile = "${{ env.BACKEND_DIR }}/requirements-x86.txt"
-            # Install the rest of the requirements. Pip will skip already satisfied packages.
             pip install -r $requirementsFile
           } else {
             Write-Host "--- Using standard requirements file ---"
             $requirementsFile = "${{ env.BACKEND_DIR }}/requirements.txt"
             pip install -r $requirementsFile
           }
-
+          pip install structlog uvicorn fastapi starlette pydantic pydantic_settings sqlalchemy aiosqlite httpx redis slowapi limits
           pip install --upgrade "pyinstaller>=6.12" pywin32
-
           Write-Host "--- Final installed packages (pip list) ---"
           pip list
+
+          Write-Host "--- Verifying all critical modules can be imported before build ---"
+          $modules = @(
+              'structlog', 'uvicorn', 'fastapi', 'starlette', 'pydantic',
+              'pydantic_settings', 'sqlalchemy', 'aiosqlite', 'httpx', 'redis',
+              'slowapi', 'limits', 'web_service', 'web_service.backend', 'web_service.backend.api'
+          )
+          $ErrorActionPreference = "Continue"
+          foreach ($module in $modules) {
+              python -c "import $module; print('✅ $module')"
+              if ($LASTEXITCODE -ne 0) {
+                  Write-Error "❌ Failed to import '$module'. This module is required for the application to run."
+                  exit 1
+              }
+          }
+          Write-Host "✅ All critical modules imported successfully."
 
       - name: 🐍 Set up PYTHONPATH
         shell: pwsh
@@ -100,38 +109,6 @@ jobs:
           } else {
             Write-Host "Directory '${{ env.BACKEND_DIR }}/json' not found, skipping rename."
           }
-
-      - name: '🔬 Pre-build Import Verification'
-        id: verify-imports
-        shell: pwsh
-        run: |
-          Write-Host "--- Verifying all critical modules can be imported before build ---"
-          $modules = @(
-              'structlog',
-              'uvicorn',
-              'fastapi',
-              'starlette',
-              'pydantic',
-              'pydantic_settings',
-              'sqlalchemy',
-              'aiosqlite',
-              'httpx',
-              'redis',
-              'slowapi',
-              'limits',
-              'web_service',
-              'web_service.backend',
-              'web_service.backend.api'
-          )
-          $ErrorActionPreference = "Continue"
-          foreach ($module in $modules) {
-              python -c "import $module; print('✅ $module')"
-              if ($LASTEXITCODE -ne 0) {
-                  Write-Error "❌ Failed to import '$module'. This module is required for the application to run."
-                  exit 1
-              }
-          }
-          Write-Host "✅ All critical modules imported successfully."
 
       - name: '🩹 Restore Shadowing Directory Name'
         if: always()

--- a/.github/workflows/build-msi-hat-trick-fusion.yml
+++ b/.github/workflows/build-msi-hat-trick-fusion.yml
@@ -121,9 +121,10 @@ jobs:
             @(
               "numpy==1.23.5",
               "pandas==1.5.3",
+              "scipy==1.10.1",
               "--only-binary=:all:"
             ) | Set-Content $constraintFile
-            Write-Host "✅ x86 constraints: numpy 1.23.5, pandas 1.5.3, wheel-only"
+            Write-Host "✅ x86 constraints: numpy 1.23.5, pandas 1.5.3, scipy 1.10.1, wheel-only"
           } else { New-Item $constraintFile -ItemType File -Force }
           "file=$constraintFile" | Out-File $env:GITHUB_OUTPUT -Append
       - name: Install Dependencies

--- a/.github/workflows/build-msi-hattrickfusion-ultimate.yml
+++ b/.github/workflows/build-msi-hattrickfusion-ultimate.yml
@@ -134,11 +134,12 @@ jobs:
             @(
               "numpy==1.23.5",
               "pandas==1.5.3",
+              "scipy==1.10.1",
               "sqlalchemy==1.4.53",
               "greenlet==3.1.1",
               "--only-binary=:all:"
             ) | Set-Content $constraintFile
-            Write-Host "✅ Constraints: SQLAlchemy 1.4.53, greenlet 3.1.1"
+            Write-Host "✅ Constraints: SQLAlchemy 1.4.53, greenlet 3.1.1, scipy 1.10.1"
           } else { New-Item $constraintFile -ItemType File -Force }
           "file=$constraintFile" | Out-File $env:GITHUB_OUTPUT -Append
       - name: Install Dependencies & Build Tools

--- a/.github/workflows/build-msi-revived.yml
+++ b/.github/workflows/build-msi-revived.yml
@@ -85,7 +85,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           # 🚀 Apply Constraints
           pip install -r ${{ env.BACKEND_DIR }}/requirements.txt -c ${{ steps.constraints.outputs.file }}
-          pip install pyinstaller==6.6.0 pywin32
+          pip install pyinstaller==6.6.0 pywin32 scipy==1.10.1
 
       - name: Build Backend (PyInstaller)
         env:

--- a/.github/workflows/build-msi-supreme-combo.yml
+++ b/.github/workflows/build-msi-supreme-combo.yml
@@ -108,7 +108,7 @@ jobs:
           $file = "constraints.txt"
           if ('${{ matrix.arch }}' -eq 'x86') {
             Write-Host "🛡️ ACTIVATING X86 SAFE MODE"
-            "numpy==1.23.5`r`npandas==1.5.3" | Set-Content $file
+            "numpy==1.23.5`r`npandas==1.5.3`r`nscipy==1.10.1" | Set-Content $file
           } else {
             New-Item $file -ItemType File -Force
           }

--- a/.github/workflows/build-msi-unified.yml
+++ b/.github/workflows/build-msi-unified.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           $file = "constraints.txt"
           if ('${{ matrix.arch }}' -eq 'x86') {
-            "numpy==1.23.5`r`npandas==1.5.3" | Set-Content $file
+            "numpy==1.23.5`r`npandas==1.5.3`r`nscipy==1.10.1" | Set-Content $file
           } else {
             New-Item $file -ItemType File -Force
           }

--- a/.github/workflows/build-web-service-msi-jules.yml
+++ b/.github/workflows/build-web-service-msi-jules.yml
@@ -460,7 +460,7 @@ jobs:
           New-Item -ItemType Directory -Path $constraintDir -Force | Out-Null
           $constraintFile = Join-Path $constraintDir "constraint-${{ matrix.arch }}.txt"
           if ('${{ matrix.arch }}' -eq 'x86') {
-            "numpy==1.23.5`r`npandas==1.5.3`r`nsqlalchemy==1.4.53`r`ngreenlet==3.1.1`r`n--only-binary=:all:" | Set-Content $constraintFile
+            "numpy==1.23.5`r`npandas==1.5.3`r`nscipy==1.10.1`r`nsqlalchemy==1.4.53`r`ngreenlet==3.1.1`r`n--only-binary=:all:" | Set-Content $constraintFile
           } else {
             New-Item $constraintFile -ItemType File -Force
           }


### PR DESCRIPTION
This commit addresses several critical issues causing CI/CD workflows to fail on Windows runners.

- Resolves a `ModuleNotFoundError` in `build-electron-msi-gpt5.yml` by ensuring all required dependencies, including `structlog`, are installed in the same step that runs the import verification script.

- Proactively pins `scipy==1.10.1` in all workflows with an x86 build matrix. This prevents build failures caused by `scipy` attempting to compile from source on 32-bit Python where pre-compiled wheels for newer versions are unavailable. This fix is applied to `build-msi-revived.yml`, `build-msi-hat-trick-fusion.yml`, `build-msi-hattrickfusion-ultimate.yml`, `build-msi-unified.yml`, `build-electron-hybrid.yml`, `build-web-service-msi-jules.yml`, and `build-msi-supreme-combo.yml`.