### PR TITLE
Fix: Add missing PyInstaller imports to spec file

### DIFF
--- a/fortuna-backend-electron.spec
+++ b/fortuna-backend-electron.spec
@@ -6,6 +6,7 @@ Final working version with collect_submodules() integration
 
 import sys
 from pathlib import Path
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
 # ============================================================================
 # Spec file directory


### PR DESCRIPTION
The `fortuna-backend-electron.spec` file was missing the necessary imports for `collect_data_files` and `collect_submodules` from `PyInstaller.utils.hooks`.

This caused a `NameError` during the PyInstaller build process, leading to the failure of the `build-electron-msi-gpt5.yml` workflow and any other workflows that depended on it.

This change adds the required import statement to resolve the error and allow the builds to proceed.