### PR TITLE
Fix: Resolve multiple build failures and import crashes

### DIFF
--- a/.github/workflows/build-msi-hattrickfusion-ultimate.yml
+++ b/.github/workflows/build-msi-hattrickfusion-ultimate.yml
@@ -137,11 +137,11 @@ jobs:
               "numpy==1.23.5",
               "pandas==1.5.3",
               "scipy==1.10.1",
-              "sqlalchemy==1.4.53",
-              "greenlet==3.1.1",
+              "sqlalchemy==2.0.44",
+              "greenlet==3.0.3",
               "--only-binary=:all:"
             ) | Set-Content $constraintFile
-            Write-Host "✅ Constraints: SQLAlchemy 1.4.53, greenlet 3.1.1, scipy 1.10.1"
+            Write-Host "✅ Constraints: SQLAlchemy 2.0.44, greenlet 3.0.3, scipy 1.10.1"
           } else { New-Item $constraintFile -ItemType File -Force }
           "file=$constraintFile" | Out-File $env:GITHUB_OUTPUT -Append
       - name: Install Dependencies & Build Tools

--- a/fortuna-backend-electron.spec
+++ b/fortuna-backend-electron.spec
@@ -5,12 +5,17 @@ Final working version with collect_submodules() integration
 """
 
 import sys
+import os
 from pathlib import Path
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+block_cipher = None
 
 # ============================================================================
-# Spec file directory
+# Spec file directory (Corrected for CI environment)
 # ============================================================================
-spec_file_dir = Path(SPECPATH).parent.resolve()
+# In a CI environment, SPECPATH can be unreliable. os.getcwd() is more robust.
+spec_file_dir = Path(os.getcwd())
 hooks_directory = spec_file_dir / 'fortuna-backend-hooks'
 
 print(f"[SPEC] Spec directory: {spec_file_dir}")

--- a/web_service/backend/credentials_manager.py
+++ b/web_service/backend/credentials_manager.py
@@ -1,14 +1,21 @@
 # python_service/credentials_manager.py
-try:
-    import keyring
+import sys
 
-    # This check is crucial for cross-platform compatibility
-    import keyring.backends.windows
+keyring = None
+IS_WINDOWS = False
 
+# Only attempt to import keyring on a Windows system.
+if sys.platform == "win32":
     IS_WINDOWS = True
-except ImportError:
-    keyring = None
-    IS_WINDOWS = False
+    try:
+        import keyring
+        # This check is crucial for cross-platform compatibility
+        import keyring.backends.windows
+    except ImportError:
+        # If imports fail even on Windows, gracefully disable keyring
+        keyring = None
+        IS_WINDOWS = False
+        print("Warning: keyring or its Windows backend is not available. Secure credential storage is disabled.")
 
 
 class SecureCredentialsManager:


### PR DESCRIPTION
This commit addresses several critical issues that were causing CI/CD workflows to fail at different stages of the build process.

1.  **Fix NameErrors in `fortuna-backend-electron.spec`:**
    - Added a missing import for `collect_data_files` and `collect_submodules`.
    - Defined the `block_cipher = None` variable.

2.  **Fix Import Crash in `credentials_manager.py`:**
    - Wrapped the import of the Windows-specific `keyring` library in a check for `sys.platform == "win32"`. This prevents the application from crashing when imported in non-Windows CI environments.

3.  **Fix PyInstaller Hooks Path in `fortuna-backend-electron.spec`:**
    - Modified the spec file to use `os.getcwd()` to determine the project root. This ensures that the custom PyInstaller hooks (e.g., for Uvicorn) are reliably found, allowing critical dependencies to be bundled correctly.

4.  **Fix Dependency Conflict in `build-msi-hattrickfusion-ultimate.yml`:**
    - Aligned the pinned versions of `sqlalchemy` and `greenlet` in the x86 build constraints with the versions specified in `requirements.txt` to resolve a `ResolutionImpossible` error from pip.

These changes collectively resolve the cascading build and import failures, creating a much more robust build process.