### PR TITLE
fix(workflows): Downgrade Python and pin dependencies for x86 builds

### DIFF
--- a/.github/workflows/build-electron-hybrid.yml
+++ b/.github/workflows/build-electron-hybrid.yml
@@ -12,7 +12,7 @@ concurrency:
 
 env:
   NODE_VERSION: '20'
-  PYTHON_VERSION: '3.11' # 🚀 DOWNGRADE
+  PYTHON_VERSION: '3.9' # 🚀 DOWNGRADE
   # Paths
   BACKEND_DIR: 'web_service/backend'
   FRONTEND_DIR: 'web_platform/frontend'
@@ -112,7 +112,7 @@ jobs:
           New-Item -ItemType Directory -Path $constraintDir -Force | Out-Null
           $constraintFile = Join-Path $constraintDir "constraint-${{ matrix.arch }}.txt"
           if ('${{ matrix.arch }}' -eq 'x86') {
-            "numpy==1.23.5`r`npandas==1.5.3`r`nscipy==1.10.1" | Set-Content $constraintFile
+            "numpy==1.23.5`r`npandas==1.5.3`r`nscipy==1.10.1`r`ngreenlet==1.1.2`r`nsqlalchemy==1.4.46" | Set-Content $constraintFile
           } else { New-Item $constraintFile -ItemType File -Force }
           "file=$constraintFile" | Out-File $env:GITHUB_OUTPUT -Append
       - name: '🐍 Install Python Dependencies'

--- a/.github/workflows/build-msi-hat-trick-fusion.yml
+++ b/.github/workflows/build-msi-hat-trick-fusion.yml
@@ -12,7 +12,7 @@ concurrency:
 
 env:
   NODE_VERSION: '20'
-  PYTHON_VERSION: '3.11' # 🚀 DOWNGRADED for x86
+  PYTHON_VERSION: '3.9' # 🚀 DOWNGRADED for x86
   DOTNET_VERSION: '8.0.x'
   WIX_VERSION: '4.0.5'
   SERVICE_PORT: '8102'
@@ -134,8 +134,8 @@ jobs:
 
           Write-Host "[BUILD] Installing x86-constrained packages first..."
           pip install --only-binary=:all: `
-            "sqlalchemy==2.0.28" `
-            "greenlet==3.0.3" `
+            "sqlalchemy==1.4.46" `
+            "greenlet==1.1.2" `
             "pandas==1.5.3" `
             "numpy==1.23.5" `
             "scipy==1.10.1"

--- a/.github/workflows/build-msi-hattrickfusion-ultimate.yml
+++ b/.github/workflows/build-msi-hattrickfusion-ultimate.yml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   NODE_VERSION: '20'
-  PYTHON_VERSION: '3.11' # 🚀 DOWNGRADE
+  PYTHON_VERSION: '3.9' # 🚀 DOWNGRADE
   DOTNET_VERSION: '8.0.x'
   WIX_VERSION: '4.0.5'
   SERVICE_PORT: '8102'
@@ -154,8 +154,8 @@ jobs:
           # CRITICAL: Install x86-constrained packages FIRST with exact versions
           # These versions are guaranteed to have pre-built x86 wheels
           pip install --only-binary=:all: `
-            "sqlalchemy==2.0.28" `
-            "greenlet==3.0.3" `
+            "sqlalchemy==1.4.46" `
+            "greenlet==1.1.2" `
             "pandas==1.5.3" `
             "numpy==1.23.5" `
             "scipy==1.10.1"

--- a/.github/workflows/build-msi-revived.yml
+++ b/.github/workflows/build-msi-revived.yml
@@ -12,7 +12,7 @@ concurrency:
 
 env:
   NODE_VERSION: '20'
-  PYTHON_VERSION: '3.11' # 🚀 CRITICAL: 3.12 breaks x86 builds
+  PYTHON_VERSION: '3.9' # 🚀 CRITICAL: 3.12 breaks x86 builds
   DOTNET_VERSION: '8.0.x'
   WIX_VERSION: '4.0.5'
   FORTUNA_PORT: '8102'
@@ -66,7 +66,7 @@ jobs:
       - name: 🐍 Setup Python (x86 Safe Mode)
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.9'
           architecture: 'x86' # FIXED: Force 32-bit Python to match the 'Safe Mode' MSI target
           cache: 'pip'
 
@@ -87,8 +87,8 @@ jobs:
 
           Write-Host "[BUILD] Installing x86-constrained packages first..."
           pip install --only-binary=:all: `
-            "sqlalchemy==2.0.28" `
-            "greenlet==3.0.3" `
+            "sqlalchemy==1.4.46" `
+            "greenlet==1.1.2" `
             "pandas==1.5.3" `
             "numpy==1.23.5" `
             "scipy==1.10.1"

--- a/.github/workflows/build-msi-supreme-combo.yml
+++ b/.github/workflows/build-msi-supreme-combo.yml
@@ -19,7 +19,7 @@ concurrency:
 
 env:
   NODE_VERSION: '20'
-  PYTHON_VERSION: '3.11' # 3.12 breaks some x86 wheels
+  PYTHON_VERSION: '3.9' # 3.12 breaks some x86 wheels
   DOTNET_VERSION: '8.0.x'
   WIX_VERSION: '4.0.5'
   SERVICE_PORT: '8102'
@@ -121,8 +121,8 @@ jobs:
 
           Write-Host "[BUILD] Installing x86-constrained packages first..."
           pip install --only-binary=:all: `
-            "sqlalchemy==2.0.28" `
-            "greenlet==3.0.3" `
+            "sqlalchemy==1.4.46" `
+            "greenlet==1.1.2" `
             "pandas==1.5.3" `
             "numpy==1.23.5" `
             "scipy==1.10.1"

--- a/.github/workflows/build-msi-unified.yml
+++ b/.github/workflows/build-msi-unified.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   NODE_VERSION: '20'
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.9'
   DOTNET_VERSION: '8.0.x'
   WIX_VERSION: '4.0.5'
   FRONTEND_DIR: 'web_platform/frontend'
@@ -140,8 +140,8 @@ jobs:
 
           Write-Host "[BUILD] Installing x86-constrained packages first..."
           pip install --only-binary=:all: `
-            "sqlalchemy==2.0.28" `
-            "greenlet==3.0.3" `
+            "sqlalchemy==1.4.46" `
+            "greenlet==1.1.2" `
             "pandas==1.5.3" `
             "numpy==1.23.5" `
             "scipy==1.10.1"

--- a/.github/workflows/build-web-service-msi-jules.yml
+++ b/.github/workflows/build-web-service-msi-jules.yml
@@ -21,7 +21,7 @@ defaults:
 
 env:
   NODE_VERSION: '20'
-  PYTHON_VERSION: '3.11' # 🚀 DOWNGRADE
+  PYTHON_VERSION: '3.9' # 🚀 DOWNGRADE
   DOTNET_VERSION: '8.0.x'
   PYTHONUTF8: '1'
   PIP_DISABLE_PIP_VERSION_CHECK: '1'
@@ -460,7 +460,7 @@ jobs:
           New-Item -ItemType Directory -Path $constraintDir -Force | Out-Null
           $constraintFile = Join-Path $constraintDir "constraint-${{ matrix.arch }}.txt"
           if ('${{ matrix.arch }}' -eq 'x86') {
-            "numpy==1.23.5`r`npandas==1.5.3`r`nscipy==1.10.1`r`nsqlalchemy==1.4.53`r`ngreenlet==3.1.1`r`n--only-binary=:all:" | Set-Content $constraintFile
+            "numpy==1.23.5`r`npandas==1.5.3`r`nscipy==1.10.1`r`nsqlalchemy==1.4.46`r`ngreenlet==1.1.2`r`n--only-binary=:all:" | Set-Content $constraintFile
           } else {
             New-Item $constraintFile -ItemType File -Force
           }
@@ -473,8 +473,8 @@ jobs:
 
           Write-Host "[BUILD] Installing x86-constrained packages first..."
           pip install --only-binary=:all: `
-            "sqlalchemy==2.0.28" `
-            "greenlet==3.0.3" `
+            "sqlalchemy==1.4.46" `
+            "greenlet==1.1.2" `
             "pandas==1.5.3" `
             "numpy==1.23.5" `
             "scipy==1.10.1"


### PR DESCRIPTION
Downgrades the Python version from 3.11 to 3.9 in all active workflows that build for the x86 architecture.

Pins the following dependencies for x86 builds to ensure the availability of pre-compiled wheels:
- greenlet==1.1.2
- sqlalchemy==1.4.46

This resolves the `ERROR: No matching distribution found for greenlet==3.0.3` error that was causing all x86 builds to fail.