### PR TITLE
feat(cicd): Harden CI/CD workflows based on expert analysis

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -73,15 +73,36 @@ jobs:
           pip install uv
           if ('${{ matrix.arch }}' -eq 'x86') {
             Write-Host "--- Using x86-specific requirements file ---"
-            uv pip install --system numpy==1.23.5 pandas==1.5.3 scipy==1.10.1
-            $requirementsFile = "${{ env.BACKEND_DIR }}/requirements-x86.txt"
-            uv pip install --system -r $requirementsFile
+            $tempReqs = "temp-requirements-x86.txt"
+
+            # Constraints MUST come first
+            @(
+              "sqlalchemy==1.4.46",
+              "greenlet==1.1.2",
+              "pandas==1.5.3",
+              "numpy==1.23.5",
+              "scipy==1.10.1",
+              "--only-binary=:all:"
+            ) | Set-Content $tempReqs
+
+            # Append all other requirements
+            Get-Content web_service/backend/requirements-x86.txt |
+              Where-Object {$_ -notmatch "^(sqlalchemy|greenlet|pandas|numpy|scipy)=="} |
+              Add-Content $tempReqs
+
+            # Single atomic install - no partial state possible
+            uv pip install --system -r $tempReqs
+
+            if ($LASTEXITCODE -ne 0) {
+              throw "Installation failed - no partial state written"
+            }
           } else {
             Write-Host "--- Using standard requirements file ---"
             $requirementsFile = "${{ env.BACKEND_DIR }}/requirements.txt"
             uv pip install --system -r $requirementsFile
           }
           uv pip install --system structlog uvicorn fastapi starlette pydantic pydantic_settings sqlalchemy aiosqlite httpx redis slowapi limits beautifulsoup4 pywin32 tenacity
+          uv pip install --system pyinstaller==5.13.2
           Write-Host "--- Final installed packages (pip list) ---"
           pip list
 

--- a/.github/workflows/build-msi-hattrickfusion-ultimate.yml
+++ b/.github/workflows/build-msi-hattrickfusion-ultimate.yml
@@ -159,38 +159,29 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install uv
+          $tempReqs = "temp-requirements-x86.txt"
 
-          Write-Host "[BUILD] Installing x86-constrained packages first..."
+          # Constraints MUST come first
+          @(
+            "sqlalchemy==1.4.46",
+            "greenlet==1.1.2",
+            "pandas==1.5.3",
+            "numpy==1.23.5",
+            "scipy==1.10.1",
+            "--only-binary=:all:"
+          ) | Set-Content $tempReqs
 
-          # CRITICAL: Install x86-constrained packages FIRST with exact versions
-          # These versions are guaranteed to have pre-built x86 wheels
-          uv pip install --system --only-binary=:all: `
-            "sqlalchemy==1.4.46" `
-            "greenlet==1.1.2" `
-            "pandas==1.5.3" `
-            "numpy==1.23.5" `
-            "scipy==1.8.1"
+          # Append all other requirements
+          Get-Content web_service/backend/requirements.txt |
+            Where-Object {$_ -notmatch "^(sqlalchemy|greenlet|pandas|numpy|scipy)=="} |
+            Add-Content $tempReqs
 
-          if ($LASTEXITCODE -ne 0) {
-            throw "[BUILD] ❌ Failed to install x86-constrained packages"
-          }
-
-          Write-Host "[BUILD] Installing remaining dependencies..."
-
-          # Now install the rest of the requirements
-          # Use --no-deps to prevent pip from upgrading the packages we just installed
-          uv pip install --system -r web_service/backend/requirements.txt --no-deps
+          # Single atomic install - no partial state possible
+          uv pip install --system -r $tempReqs
 
           if ($LASTEXITCODE -ne 0) {
-            throw "[BUILD] ❌ Failed to install remaining requirements"
+            throw "Installation failed - no partial state written"
           }
-
-          Write-Host "[BUILD] Verifying all dependencies are satisfied..."
-
-          # Finally, run a dependency check to install any missing transitive dependencies
-          # This will NOT upgrade the packages we pinned earlier
-          pip check
-
           Write-Host "[BUILD] Installing PyInstaller..."
           uv pip install --system pyinstaller==5.13.2
 

--- a/web_service/backend/main.py
+++ b/web_service/backend/main.py
@@ -4,11 +4,14 @@ Fortuna Backend Entry Point
 """
 
 # ============================================================================
-# CRITICAL: Windows Compatibility Layer
-# This MUST be the first import to ensure event loop is configured correctly
+# CRITICAL: Eager Windows Event Loop Configuration
+# This MUST be the first code to run, before any other imports, to ensure
+# the correct asyncio event loop policy is applied for PyInstaller bundles.
 # ============================================================================
-from web_service.backend.windows_compat import setup_windows_event_loop
-setup_windows_event_loop()
+import sys
+if sys.platform == 'win32' and getattr(sys, 'frozen', False):
+    import asyncio
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 # ============================================================================
 
 


### PR DESCRIPTION
This commit implements several critical fixes to the `build-msi-hattrickfusion-ultimate.yml` and `build-electron-msi-gpt5.yml` workflows to address persistent build failures. The changes are based on a detailed forensic analysis provided by an external AI.

The key fixes include:
1.  **Eager Event Loop Policy:** The `main.py` entry point for the web service was modified to set the `WindowsSelectorEventLoopPolicy` at the absolute top of the file, before any other imports. This prevents `asyncio` from initializing with the wrong policy in a frozen (PyInstaller) environment.
2.  **PyInstaller Downgrade:** Both workflows now explicitly pin `pyinstaller==5.13.2`. This avoids a suspected regression in newer versions that affects module collection and runtime imports.
3.  **Atomic x86 Dependency Installation:** The fragile, multi-step dependency installation for the x86 architecture has been replaced with a single, atomic `uv pip install` command. This ensures that pinned versions for critical libraries like `SQLAlchemy` and `greenlet` are respected and not overwritten by transitive dependencies.
4.  **Restoration of `json` Workaround:** The temporary directory renaming steps for the `web_service/backend/json` directory were restored. This is a critical workaround to prevent module shadowing of Python's built-in `json` library, which was identified as a blocking issue in code review.