### PR TITLE
fix(build): Set console=False for Windows service executable

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -245,7 +245,7 @@ jobs:
 
           # 3. VERIFY: Wait for backend to be ready
           # Target /docs to ensure 200 OK (root often returns 404)
-          $url = "http://127.0.0.1:8000/docs"
+          $url = "http://localhost:8000/docs"
           Write-Host "Waiting for backend at $url..."
           $maxRetries = 20
           for ($i=1; $i -le $maxRetries; $i++) {

--- a/fortuna-unified.spec
+++ b/fortuna-unified.spec
@@ -64,7 +64,7 @@ exe = EXE(
     bootloader_ignore_signals=False,
     strip=False,
     upx=True,
-    console=True,
+    console=False,
 )
 
 # --- COLLECT Object for Directory-Based Build ---


### PR DESCRIPTION
This change modifies the PyInstaller spec file, fortuna-unified.spec, to build a windowed (non-console) executable.

Setting console=False is critical for allowing the packaged application to run as a non-interactive Windows Service. The previous setting of console=True was causing the service to fail on startup in the CI environment.