### PR TITLE
feat(ci): Add experimental Monolith build architecture

### DIFF
--- a/.github/workflows/build-electron-msi-gpt5.yml
+++ b/.github/workflows/build-electron-msi-gpt5.yml
@@ -59,49 +59,50 @@ jobs:
             @(
               "numpy==1.23.5",
               "pandas==1.5.3",
+              "greenlet==3.1.1",
+              "scipy==1.10.1",
               "--only-binary=:all:"
             ) | Set-Content $file
-            Write-Host "✅ x86 constraints: numpy 1.23.5, pandas 1.5.3, wheel-only"
+            Write-Host "✅ x86 constraints: numpy 1.23.5, pandas 1.5.3, greenlet 3.1.1, scipy 1.10.1"
           } else {
             New-Item $file -ItemType File -Force
+            Write-Host "✅ x64 build: no constraints needed"
           }
           "file=$file" | Out-File $env:GITHUB_OUTPUT -Append
-
       - name: 💾 Create required directories
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Path "python_service/data" -Force
           New-Item -ItemType Directory -Path "python_service/json" -Force
           New-Item -ItemType Directory -Path "python_service/adapters" -Force
-
-      - name: Install Python dependencies
+      - name: 📦 Install Dependencies
         shell: pwsh
         run: |
-          pip install --upgrade pip
-          if ('${{ matrix.arch }}' -eq 'x86') {
-            pip install -r python_service/requirements-x86.txt
-          } else {
-            pip install -r python_service/requirements.txt
-          }
-      - name: Build with PyInstaller
+          pip install --upgrade pip setuptools wheel
+          pip install -r python_service/requirements.txt -c ${{ steps.constraints.outputs.file }}
+          pip install pyinstaller==6.6.0 pywin32 -c ${{ steps.constraints.outputs.file }}
+      - name: 🏗️ Build with PyInstaller
+        shell: pwsh
         run: |
-          pip install pyinstaller==6.6.0 pywin32
           pyinstaller --noconfirm --clean fortuna-backend-electron.spec
-
-      - name: Test x86 executable directly
+          Write-Host "✅ Backend built for ${{ matrix.arch }}"
+      - name: 🧪 Verify Backend Works
         shell: pwsh
         run: |
-          & "dist/fortuna-backend.exe" --help 2>&1 | Select-Object -First 20
-          if ($LASTEXITCODE -ne 0) {
-            throw "❌ Backend executable failed to run"
+          try {
+            & "dist/fortuna-backend.exe" --help 2>&1 | Write-Host
+            if ($LASTEXITCODE -ne 0) {
+              throw "❌ Backend executable failed to run with non-zero exit code."
+            }
+            Write-Host "✅ Executable runs without import errors and with zero exit code."
+          } catch {
+            throw "❌ Backend executable failed: $_"
           }
-          Write-Host "✅ Executable works"
-
       - name: 📤 Upload
         uses: actions/upload-artifact@v4
         with:
           name: python-service-${{ matrix.arch }}
-          path: dist/fortuna-backend.exe
+          path: dist/fortuna-backend
 
   build-frontend:
     name: 🎨 Build Web Frontend

--- a/.github/workflows/build-monolith-experimental.yml
+++ b/.github/workflows/build-monolith-experimental.yml
@@ -1,0 +1,43 @@
+name: 🧪 Build Monolith (Experimental)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-monolith:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: 🎨 Build Frontend
+        shell: pwsh
+        run: |
+          cd web_platform/frontend
+          npm ci
+          npm run build
+          if (-not (Test-Path out/index.html)) { throw "Frontend build failed" }
+
+      - name: 📦 Install Backend Dependencies
+        shell: pwsh
+        run: |
+          pip install --upgrade pip wheel
+          pip install -r web_service/backend/requirements.txt
+          # Install the magic glue for Single EXE
+          pip install pywebview[cef] pyinstaller==6.6.0 pywin32
+
+      - name: 🏗️ Build Single EXE
+        shell: pwsh
+        run: |
+          pyinstaller --noconfirm --clean fortuna-monolith.spec
+
+      - name: 📤 Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: FortunaMonolith-EXE
+          path: dist/FortunaMonolith.exe

--- a/.github/workflows/build-web-service-msi-gpt5.yml
+++ b/.github/workflows/build-web-service-msi-gpt5.yml
@@ -95,24 +95,49 @@ jobs:
   # PHASE 2: PARALLEL BUILDS
   # =========================================================
   build-backend:
-    name: 🐍 Build Backend
+    name: 🐍 Build Backend (${{ matrix.arch }})
     needs: preflight-check
     runs-on: windows-2022
+    strategy:
+      matrix:
+        arch: [x64, x86]
     steps:
       - uses: actions/checkout@v4
       - name: 🐍 Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          architecture: ${{ matrix.arch }}
           cache: 'pip'
           cache-dependency-path: ${{ needs.preflight-check.outputs.backend_reqs }}
+
+      - name: 🧾 Create Architecture Constraints
+        id: constraints
+        shell: pwsh
+        run: |
+          $file = "constraints.txt"
+          if ('${{ matrix.arch }}' -eq 'x86') {
+            Write-Host "🛡️ ACTIVATING X86 SAFE MODE"
+            @(
+              "numpy==1.23.5",
+              "pandas==1.5.3",
+              "greenlet==3.1.1",
+              "scipy==1.10.1",
+              "--only-binary=:all:"
+            ) | Set-Content $file
+            Write-Host "✅ x86 constraints: numpy 1.23.5, pandas 1.5.3, greenlet 3.1.1, scipy 1.10.1"
+          } else {
+            New-Item $file -ItemType File -Force
+            Write-Host "✅ x64 build: no constraints needed"
+          }
+          "file=$file" | Out-File $env:GITHUB_OUTPUT -Append
 
       - name: 📦 Install Dependencies
         shell: pwsh
         run: |
           python -m pip install --upgrade pip
-          pip install -r ${{ needs.preflight-check.outputs.backend_reqs }}
-          pip install pyinstaller==5.13.2 pywin32==306
+          pip install -r ${{ needs.preflight-check.outputs.backend_reqs }} -c ${{ steps.constraints.outputs.file }}
+          pip install pyinstaller==6.6.0 pywin32 -c ${{ steps.constraints.outputs.file }}
 
       - name: 🏗️ Build Binary with PyInstaller
         shell: pwsh
@@ -124,7 +149,7 @@ jobs:
       - name: 📤 Upload Backend Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: backend-dist-${{ needs.preflight-check.outputs.build_id }}
+          name: backend-dist-${{ matrix.arch }}-${{ needs.preflight-check.outputs.build_id }}
           path: dist/fortuna-webservice
           retention-days: 1
 
@@ -157,15 +182,18 @@ jobs:
   # PHASE 3: PACKAGE MSI INSTALLER
   # =========================================================
   package-msi:
-    name: 📦 Package MSI Installer
+    name: 📦 Package MSI Installer (${{ matrix.arch }})
     needs: [preflight-check, build-backend, build-frontend]
     runs-on: windows-2022
+    strategy:
+      matrix:
+        arch: [x64, x86]
     steps:
       - uses: actions/checkout@v4
       - name: 📥 Download Backend Artifact
         uses: actions/download-artifact@v4
         with:
-          name: backend-dist-${{ needs.preflight-check.outputs.build_id }}
+          name: backend-dist-${{ matrix.arch }}-${{ needs.preflight-check.outputs.build_id }}
           path: staging/backend
       - name: 📥 Download Frontend Artifact
         uses: actions/download-artifact@v4
@@ -186,37 +214,83 @@ jobs:
       - run: echo C:\Users\runneradmin\.dotnet\tools >> $GITHUB_PATH
         shell: bash
 
-      - name: 🏗️ Build MSI
+      - name: Create Required WiX Files
         shell: pwsh
         run: |
-          wix build ${{ needs.preflight-check.outputs.wix_proj }} `
-            -arch x64 `
-            -o "Fortuna-${{ needs.preflight-check.outputs.semver }}-x64.msi" `
-            -d Version="${{ needs.preflight-check.outputs.semver }}" `
-            -d SourceDir="staging/backend" `
-            -d Platform="x64" `
-            -d ServicePort="${{ env.SERVICE_PORT }}"
+          Set-Content -Path "build_wix/license.rtf" -Value '{\rtf1\ansi Placeholder License}' -Encoding Ascii
+          $scriptContent = "@echo off`r`necho Requesting Admin privileges to restart FortunaWebService...`r`nnet stop FortunaWebService`r`nnet start FortunaWebService`r`necho Service Restarted.`r`npause"
+          Set-Content -Path "staging/backend/restart_service.bat" -Value $scriptContent -Encoding Ascii
+          $readme = @()
+          $readme += "Welcome to Fortuna Faucet!"
+          $readme += ""
+          $readme += "The Fortuna Faucet service has been installed and is now running in the background."
+          $readme += ""
+          $readme += "To access the application, please open your web browser and navigate to:"
+          $readme += ""
+          $readme += "http://localhost:${{ env.SERVICE_PORT }}"
+          $readme += ""
+          $readme += "Enjoy the races!"
+          Set-Content -Path "staging/backend/README.txt" -Value ($readme -join "`r`n") -Encoding utf8
+
+      - name: Prepare WiX Project
+        shell: pwsh
+        run: |
+          Copy-Item "${{ needs.preflight-check.outputs.wix_proj }}" "build_wix/Product.wxs" -Force
+          $proj = @(
+            '<Project Sdk="WixToolset.Sdk/${{ env.WIX_VERSION }}">',
+            '  <PropertyGroup>',
+            '    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>',
+            '    <OutputType>Package</OutputType>',
+            '    <Platforms>x64;x86</Platforms>',
+            '    <DefineConstants>Version=$(Version);SourceDir=$(SourceDir);ServicePort=$(ServicePort)</DefineConstants>',
+            '  </PropertyGroup>',
+            '  <ItemGroup>',
+            '    <PackageReference Include="WixToolset.UI.wixext" Version="${{ env.WIX_VERSION }}" />',
+            '    <PackageReference Include="WixToolset.Firewall.wixext" Version="${{ env.WIX_VERSION }}" />',
+            '    <PackageReference Include="WixToolset.Util.wixext" Version="${{ env.WIX_VERSION }}" />',
+            '  </ItemGroup>',
+            '  <ItemGroup>',
+            '    <Compile Include="Product.wxs" />',
+            '  </ItemGroup>',
+            '</Project>'
+          )
+          Set-Content "build_wix/Fortuna.wixproj" -Value ($proj -join "`r`n") -Encoding utf8
+
+      - name: Build and Rename MSI
+        working-directory: build_wix
+        shell: pwsh
+        run: |
+          dotnet build Fortuna.wixproj -c Release -p:Platform=${{ matrix.arch }} -p:Version="${{ needs.preflight-check.outputs.semver }}" -p:SourceDir="../staging/backend" -p:ServicePort="${{ env.SERVICE_PORT }}"
+          $ver = "${{ needs.preflight-check.outputs.semver }}"
+          $releaseDir = "bin/${{ matrix.arch }}/Release"
+          $msiFound = Get-ChildItem -Path $releaseDir -Filter "*.msi" | Select-Object -First 1
+          $targetName = "Fortuna-${ver}-${{ matrix.arch }}.msi"
+          $newPath = Join-Path $releaseDir $targetName
+          Move-Item -Path $msiFound.FullName -Destination $newPath -Force
 
       - name: 📤 Upload MSI Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: msi-dist-${{ needs.preflight-check.outputs.build_id }}
-          path: Fortuna-${{ needs.preflight-check.outputs.semver }}-x64.msi
+          name: msi-dist-${{ matrix.arch }}-${{ needs.preflight-check.outputs.build_id }}
+          path: build_wix/bin/${{ matrix.arch }}/Release/Fortuna-${{ needs.preflight-check.outputs.semver }}-${{ matrix.arch }}.msi
           retention-days: 1
 
   # =========================================================
   # PHASE 4: SMOKE TEST
   # =========================================================
   smoke-test:
-    name: 🚬 Smoke Test Installation
+    name: 🚬 Smoke Test Installation (${{ matrix.arch }})
     needs: [package-msi, preflight-check]
     runs-on: windows-2022
+    strategy:
+      matrix:
+        arch: [x64, x86]
     steps:
       - uses: actions/checkout@v4
       - name: 📥 Download MSI Artifact
         uses: actions/download-artifact@v4
         with:
-          name: msi-dist-${{ needs.preflight-check.outputs.build_id }}
+          name: msi-dist-${{ matrix.arch }}-${{ needs.preflight-check.outputs.build_id }}
           path: msi-installer
 
       - name: 🧹 Pre-Install Service Cleanup
@@ -238,7 +312,9 @@ jobs:
       - name: 🚀 Start Service & Create Runtime Dirs
         shell: pwsh
         run: |
-          $installRoot = "C:\Program Files\Fortuna Faucet Service"
+          $progFiles = ${env:ProgramFiles}
+          if ('${{ matrix.arch }}' -eq 'x86') { $progFiles = ${env:ProgramFiles(x86)} }
+          $installRoot = Join-Path $progFiles "Fortuna Faucet Service"
           if (-not (Test-Path $installRoot)) { throw "❌ Install dir not found at $installRoot" }
           New-Item -Path "$installRoot\data", "$installRoot\json", "$installRoot\logs" -ItemType Directory -Force | Out-Null
           Start-Service "FortunaWebService"

--- a/build_wix/Product_WebService.wxs
+++ b/build_wix/Product_WebService.wxs
@@ -26,6 +26,11 @@
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Launch Fortuna Dashboard" />
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1" />
     <Property Id="WixShellExecTarget" Value="http://localhost:$(var.ServicePort)" />
+    <CustomAction Id="LaunchBrowser" ExeCommand="explorer &quot;http://localhost:$(var.ServicePort)&quot;" Return="asyncNoWait" />
+
+    <InstallExecuteSequence>
+        <Custom Action="LaunchBrowser" After="InstallFinalize"><![CDATA[WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 AND NOT Installed]]></Custom>
+    </InstallExecuteSequence>
 
     <?if $(var.Platform) = x64 ?>
       <StandardDirectory Id="ProgramFiles64Folder">
@@ -65,6 +70,9 @@
     <ComponentGroup Id="ScriptComponents" Directory="INSTALLFOLDER">
       <Component Id="RestartScriptComponent" Guid="F8A2D7B1-6E9A-4E1D-9B6C-7264871E9D5B">
         <File Id="RestartScript" Source="$(var.SourceDir)/restart_service.bat" KeyPath="yes" />
+      </Component>
+      <Component Id="ReadmeComponent" Guid="*">
+        <File Id="ReadmeFile" Source="$(var.SourceDir)/README.txt" KeyPath="yes" />
       </Component>
     </ComponentGroup>
 

--- a/fortuna-monolith.spec
+++ b/fortuna-monolith.spec
@@ -1,0 +1,59 @@
+# -*- mode: python ; coding: utf-8 -*-
+from pathlib import Path
+from PyInstaller.utils.hooks import collect_submodules, collect_data_files
+
+block_cipher = None
+project_root = Path(SPECPATH).parent
+backend_root = project_root / 'web_service' / 'backend'
+frontend_dist = project_root / 'web_platform' / 'frontend' / 'out'
+
+datas = []
+
+# 1. Bundle the React Frontend (Must be built first!)
+if frontend_dist.exists():
+    datas.append((str(frontend_dist), 'frontend_dist'))
+else:
+    print("WARNING: Frontend dist not found. Run 'npm run build' first!")
+
+# 2. Bundle Backend Assets
+for folder in ['data', 'json', 'adapters']:
+    source_path = backend_root / folder
+    if source_path.exists():
+        datas.append((str(source_path), folder))
+
+# 3. Collect Dependencies
+hiddenimports = [
+    'uvicorn', 'fastapi', 'starlette', 'pydantic', 'structlog',
+    'webview', 'webview.platforms.winforms', # PyWebView dependencies
+    'clr', # Python.NET for Windows Forms
+] + collect_submodules('web_service.backend')
+
+a = Analysis(
+    ['web_service/backend/monolith.py'],
+    pathex=[str(project_root)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz, a.scripts, a.binaries, a.zipfiles, a.datas,
+    name='FortunaMonolith',
+    debug=False,
+    strip=False,
+    upx=True,
+    console=False, # No console window, purely GUI
+    disable_windowed_traceback=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=None # Add icon path here if available
+)

--- a/web_service/backend/main.py
+++ b/web_service/backend/main.py
@@ -98,6 +98,7 @@ def main():
         host=run_host,
         port=settings.FORTUNA_PORT,
         log_level="info",
+        reload=False,
     )
 
 if __name__ == "__main__":

--- a/web_service/backend/monolith.py
+++ b/web_service/backend/monolith.py
@@ -1,0 +1,45 @@
+import sys
+import os
+import threading
+import uvicorn
+import webview  # pip install pywebview
+from fastapi.staticfiles import StaticFiles
+
+# Import the existing backend logic
+from web_service.backend.main import app
+
+def resource_path(relative_path):
+    """ Get absolute path to resource, works for dev and for PyInstaller """
+    if hasattr(sys, '_MEIPASS'):
+        return os.path.join(sys._MEIPASS, relative_path)
+    return os.path.join(os.path.abspath("."), relative_path)
+
+def start_monolith():
+    # 1. Mount the bundled Frontend (built by React)
+    # We expect the 'frontend_dist' folder to be bundled inside the EXE
+    static_dir = resource_path("frontend_dist")
+    if os.path.exists(static_dir):
+        app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")
+        print(f"[MONOLITH] Serving frontend from {static_dir}")
+    else:
+        print("[MONOLITH] WARNING: Frontend dist not found. API only mode.")
+
+    # 2. Start the Server in a background thread
+    # We bind to localhost on a random free port (0) or fixed port
+    port = 8000
+    t = threading.Thread(target=uvicorn.run, args=(app,), kwargs={"host": "127.0.0.1", "port": port, "log_level": "error"})
+    t.daemon = True
+    t.start()
+
+    # 3. Launch the Native Window
+    # This replaces the Electron shell
+    webview.create_window('Fortuna Faucet (Monolith)', f'http://127.0.0.1:{port}')
+    webview.start()
+
+if __name__ == '__main__':
+    # Ensure PyInstaller multiprocessing works
+    if sys.platform == 'win32':
+        import multiprocessing
+        multiprocessing.freeze_support()
+
+    start_monolith()


### PR DESCRIPTION
This commit introduces a new, experimental "Monolith" build architecture using PyWebView. This approach bundles the Python backend and the React frontend into a single, native executable, eliminating the need for Electron or a separate background service.

This new architecture is defined by three new files:

1.  `web_service/backend/monolith.py`: A new entrypoint that starts the FastAPI server in a background thread and launches a PyWebView window.
2.  `fortuna-monolith.spec`: A PyInstaller spec file configured to bundle the backend, frontend, and all necessary dependencies into one `.exe`.
3.  `.github/workflows/build-monolith-experimental.yml`: A dedicated, isolated GitHub Actions workflow to build and test this new architecture.