### PR TITLE
Fix(workflows): Standardize paths, triggers, and dependencies in CI w…

### DIFF
--- a/.github/workflows/build-monolith-experimental.yml
+++ b/.github/workflows/build-monolith-experimental.yml
@@ -2,6 +2,9 @@ name: 🧪 Build Monolith (Experimental)
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   build-monolith:

--- a/.github/workflows/build-msi-hat-trick-fusion.yml
+++ b/.github/workflows/build-msi-hat-trick-fusion.yml
@@ -128,7 +128,7 @@ jobs:
           if (-not (Test-Path 'build_wix/license.rtf')) {
              Set-Content -Path 'build_wix/license.rtf' -Value '{\rtf1\ansi Placeholder License}' -Encoding Ascii
           }
-          Copy-Item "build_wix/Product_WithService.wxs" "build_wix/Product.wxs" -Force
+          Copy-Item "build_wix/Product_WebService.wxs" "build_wix/Product.wxs" -Force
           $proj = @(
             '<Project Sdk="WixToolset.Sdk/${{ env.WIX_VERSION }}">',
             '  <PropertyGroup>',

--- a/.github/workflows/build-msi-revived.yml
+++ b/.github/workflows/build-msi-revived.yml
@@ -125,7 +125,7 @@ jobs:
           if (-not (Test-Path 'build_wix/license.rtf')) {
              Set-Content -Path 'build_wix/license.rtf' -Value '{\rtf1\ansi Placeholder License}' -Encoding Ascii
           }
-          Copy-Item "build_wix/Product_WithService.wxs" "build_wix/Product.wxs" -Force
+          Copy-Item "build_wix/Product_WebService.wxs" "build_wix/Product.wxs" -Force
           $proj = @(
             '<Project Sdk="WixToolset.Sdk/${{ env.WIX_VERSION }}">',
             '  <PropertyGroup>',

--- a/.github/workflows/build-msi-supreme-combo.yml
+++ b/.github/workflows/build-msi-supreme-combo.yml
@@ -129,13 +129,13 @@ jobs:
         env:
           PYTHONUTF8: '1'
         run: |
-          pyinstaller --noconfirm --clean fortuna-webservice.spec
+          pyinstaller --noconfirm --clean fortuna-unified.spec
 
       - name: 📤 Upload Backend Artifact
         uses: actions/upload-artifact@v4
         with:
           name: backend-dist-${{ matrix.arch }}
-          path: dist/fortuna-core-service
+          path: dist/fortuna-webservice
           retention-days: 1
 
   build-frontend:

--- a/.github/workflows/build-msi-unified.yml
+++ b/.github/workflows/build-msi-unified.yml
@@ -117,7 +117,7 @@ jobs:
           if (-not (Test-Path 'build_wix/license.rtf')) {
              Set-Content -Path 'build_wix/license.rtf' -Value '{\rtf1\ansi Placeholder License}' -Encoding Ascii
           }
-          Copy-Item "build_wix/Product_WithService.wxs" "build_wix/Product.wxs" -Force
+          Copy-Item "build_wix/Product_WebService.wxs" "build_wix/Product.wxs" -Force
           $proj = @(
             '<Project Sdk="WixToolset.Sdk/${{ env.WIX_VERSION }}">',
             '  <PropertyGroup>',

--- a/.github/workflows/build-web-service-msi-gpt5.yml
+++ b/.github/workflows/build-web-service-msi-gpt5.yml
@@ -12,7 +12,7 @@ concurrency:
 
 env:
   NODE_VERSION: '20'
-  PYTHON_VERSION: '3.9'
+  PYTHON_VERSION: '3.11'
   DOTNET_VERSION: '8.0.x'
   WIX_VERSION: '4.0.5'
   SERVICE_PORT: '8100'


### PR DESCRIPTION
…orkflows

- Corrected the WiX template path from `Product_WithService.wxs` to `Product_WebService.wxs` in `build-msi-hat-trick-fusion.yml`, `build-msi-revived.yml`, and `build-msi-unified.yml`.
- Corrected the PyInstaller spec file and artifact path in `build-msi-supreme-combo.yml`.
- Added a push trigger to `build-monolith-experimental.yml`.
- Standardized the Python version to 3.11 in `build-web-service-msi-gpt5.yml`.
- Verified that the 10-second timeout in `build-electron-msi-gpt5.yml` is correctly implemented.