### PR TITLE
Fix(scripts): Use `py` launcher in quick-start script

### DIFF
--- a/scripts/fortuna-quick-start.ps1
+++ b/scripts/fortuna-quick-start.ps1
@@ -33,7 +33,7 @@ $ErrorActionPreference = "Stop"
 $PROJECT_ROOT = Resolve-Path "$PSScriptRoot\.."
 $BACKEND_DIR  = Join-Path $PROJECT_ROOT "web_service\backend"
 $FRONTEND_DIR = Join-Path $PROJECT_ROOT "web_platform\frontend"
-$PYTHON_CMD   = "python" # Assumes python is in PATH. Use 'py -3.11' if needed.
+$PYTHON_CMD   = "py -3.11" # Assumes python is in PATH. Use 'py -3.11' if needed.
 
 # --- Helper Functions ---
 function Show-Step($msg) { Write-Host "`n🔵 $msg" -ForegroundColor Cyan }


### PR DESCRIPTION
Updates `scripts/fortuna-quick-start.ps1` to use the `py -3.11` command instead of the ambiguous `python`.

On GitHub's Windows runners (and many local Windows environments), `python.exe` can be a placeholder that redirects to the Microsoft Store. This was causing the `test-quickstart.yml` workflow to fail because it couldn't find a valid Python interpreter.

Using the `py` Python launcher with a specific version (`-3.11`) is the standard and most robust way to ensure the correct, intended Python version is executed on Windows, resolving the CI failure.