### PR TITLE
Fix(ci): Correct PowerShell syntax in WebSvcGPT5 workflow

### DIFF
--- a/.github/workflows/build-web-service-msi-gpt5.yml
+++ b/.github/workflows/build-web-service-msi-gpt5.yml
@@ -338,11 +338,11 @@ jobs:
             try {
               $response = Invoke-WebRequest -Uri $healthUrl -UseBasicParsing -TimeoutSec 10
               if ($response.StatusCode -eq 200) {
-                Write-Host "✅ Backend health check PASSED on attempt $i."
+                Write-Host "✅ Backend health check PASSED on attempt ${i}."
                 return
               }
             } catch {
-              Write-Warning "Attempt $i: Health check failed. Retrying in $delay seconds..."
+              Write-Warning "Attempt ${i}: Health check failed. Retrying in $delay seconds..."
             }
             Start-Sleep -Seconds $delay
           }


### PR DESCRIPTION
This commit fixes a `ParserError` in the `build-web-service-msi-gpt5.yml` workflow.

The error was caused by an incorrect variable reference in a PowerShell script within the smoke test job. The string `"Attempt $i: ..."` was being misinterpreted by the parser.

The fix encloses the variable in curly braces (`${i}`), which is the correct syntax for variable expansion in this context, resolving the parser error and allowing the workflow to execute correctly. Both the `Write-Host` and `Write-Warning` commands have been corrected.