### PR TITLE
Fix(app): Correct API import in monolith entry point

### DIFF
--- a/.github/workflows/build-web-service-msi-gpt5.yml
+++ b/.github/workflows/build-web-service-msi-gpt5.yml
@@ -338,11 +338,11 @@ jobs:
             try {
               $response = Invoke-WebRequest -Uri $healthUrl -UseBasicParsing -TimeoutSec 10
               if ($response.StatusCode -eq 200) {
-                Write-Host "✅ Backend health check PASSED on attempt $i."
+                Write-Host "✅ Backend health check PASSED on attempt ${i}."
                 return
               }
             } catch {
-              Write-Warning "Attempt $i: Health check failed. Retrying in $delay seconds..."
+              Write-Warning "Attempt ${i}: Health check failed. Retrying in $delay seconds..."
             }
             Start-Sleep -Seconds $delay
           }

--- a/web_service/backend/monolith.py
+++ b/web_service/backend/monolith.py
@@ -19,12 +19,12 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# 2. Robust Router Import
+# 2. Robust API Mounting
 try:
-    # Try to import the real API
-    from web_service.backend.api import router as api_router
-    app.include_router(api_router, prefix="/api")
-    print("[MONOLITH] Loaded API routers successfully.")
+    # Import the entire API app and mount it as a sub-application
+    from web_service.backend.api import app as api_app
+    app.mount("/api", api_app)
+    print("[MONOLITH] Mounted main API application successfully.")
 except Exception as e:
     # If it fails, DO NOT CRASH. Load a fallback route.
     print(f"[MONOLITH] WARNING: Could not load API routers: {e}")


### PR DESCRIPTION
This commit fixes a critical startup error in the monolith application (`fortuna-monolith.spec`).

The application was failing to start because the entry point (`web_service/backend/monolith.py`) was attempting to import a non-existent `router` object from the main API file (`web_service/backend/api.py`).

The fix replaces this incorrect import with the correct procedure for embedding a FastAPI application within another:
1.  It now imports the `app` object from `api.py`.
2.  It uses `app.mount()` to correctly attach the imported application as a sub-app at the `/api` prefix.

This resolves the `ImportError`, allowing the monolith's API routes to load correctly and the application to start successfully.