### PR TITLE
fix(ci): Create required directories for PyInstaller build

### DIFF
--- a/.github/workflows/build-universal-monolith.yml
+++ b/.github/workflows/build-universal-monolith.yml
@@ -49,6 +49,13 @@ jobs:
           pip install pywebview[cef] pyinstaller==6.6.0 pywin32
 
       # --- PHASE 3: THE MERGE (PyInstaller) ---
+      - name: 📁 Create Required Data Dirs
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path "web_service/backend/data"
+          New-Item -ItemType Directory -Force -Path "web_service/backend/json"
+          Write-Host "✅ Ensured data directories exist for PyInstaller."
+
       - name: 🔮 Generate Spec & Build
         shell: pwsh
         run: |


### PR DESCRIPTION
Fixes a "file not found" error in the 'build-universal-monolith' workflow.

The PyInstaller build was failing because it expected the 'web_service/backend/data' and 'web_service/backend/json' directories to exist, but they were not present in the CI checkout as they are empty.

This commit adds a new step to the workflow that explicitly creates these directories before the PyInstaller process runs, ensuring the build can complete successfully.