### PR TITLE
fix(ci): correct and enhance universal monolith workflow

### DIFF
--- a/.github/workflows/build-universal-monolith.yml
+++ b/.github/workflows/build-universal-monolith.yml
@@ -289,13 +289,21 @@ jobs:
           Write-Host "   Size: $([math]::Round($fileInfo.Length / 1MB, 2)) MB"
           Write-Host "   Path: dist/FortunaApp.exe"
 
-      # --- PHASE 6: SMOKE TEST ---
+      # --- PHASE 6: ARTIFACT UPLOAD ---
+      - name: 📤 Upload The Monolith
+        uses: actions/upload-artifact@v4
+        with:
+          name: FortunaApp-Universal-x86
+          path: dist/FortunaApp.exe
+          retention-days: 30
+
+      # --- PHASE 7: SMOKE TEST ---
       - name: 🧪 Smoke Test (Launch & Kill)
         shell: pwsh
         timeout-minutes: 2
         run: |
           Write-Host "🚀 Starting FortunaApp.exe..."
-          Start-Process "dist/FortunaApp.exe"
+          Start-Process "dist/FortunaApp.exe" -PassThru
 
           Write-Host "⏳ Waiting for server..."
           $maxAttempts = 20
@@ -306,7 +314,7 @@ jobs:
             Start-Sleep -Seconds 1
             $attempt++
             try {
-              $response = Invoke-WebRequest -Uri "http://127.0.0.1:8000/health" -TimeoutSec 2 -ErrorAction Stop
+              $response = Invoke-WebRequest -Uri "http://127.0.0.1:8000/api/health" -TimeoutSec 2 -ErrorAction Stop
               if ($response.StatusCode -eq 200) {
                 $success = $true
                 Write-Host "✅ Server responded on attempt $attempt"
@@ -317,17 +325,19 @@ jobs:
           }
 
           if (-not $success) {
-            # Grab any error output before killing
-            throw "❌ Server never responded - likely missing module"
+            Write-Host "❌ Server never responded!"
+            Write-Host "--- PROCESS LIST ---"
+            Get-Process
+            Write-Host "--- BUILD DIRECTORY ---"
+            ls -Recurse dist
+            throw "Smoke test failed: Server did not respond at http://127.0.0.1:8000/api/health"
           }
 
-          Stop-Process -Name "FortunaApp" -Force
-          Write-Host "✅ Smoke test passed"
+          try {
+            Stop-Process -Name "FortunaApp" -Force -ErrorAction Stop
+            Write-Host "🛑 Stopped FortunaApp process."
+          } catch {
+            Write-Host "🤔 FortunaApp process not found, may have already terminated."
+          }
 
-      # --- PHASE 7: ARTIFACT UPLOAD ---
-      - name: 📤 Upload The Monolith
-        uses: actions/upload-artifact@v4
-        with:
-          name: FortunaApp-Universal-x86
-          path: dist/FortunaApp.exe
-          retention-days: 30
+          Write-Host "✅ Smoke test passed"


### PR DESCRIPTION
This change addresses failures in the `build-universal-monolith.yml` workflow.

- Reorders the 'Upload Artifact' step to occur before the 'Smoke Test' step. This ensures the compiled executable is always available for download, even if the smoke test fails.
- Corrects the smoke test health check URL from `/health` to the correct `/api/health` endpoint.
- Enhances the smoke test failure diagnostics by adding PowerShell commands to log the current process list and the contents of the build directory, providing more context for debugging.