### PR TITLE
feat(ci): refactor reusable workflow to standalone monolith

### DIFF
--- a/.github/workflows/build-universal-monolith.yml
+++ b/.github/workflows/build-universal-monolith.yml
@@ -289,13 +289,21 @@ jobs:
           Write-Host "   Size: $([math]::Round($fileInfo.Length / 1MB, 2)) MB"
           Write-Host "   Path: dist/FortunaApp.exe"
 
-      # --- PHASE 6: SMOKE TEST ---
+      # --- PHASE 6: ARTIFACT UPLOAD ---
+      - name: 📤 Upload The Monolith
+        uses: actions/upload-artifact@v4
+        with:
+          name: FortunaApp-Universal-x86
+          path: dist/FortunaApp.exe
+          retention-days: 30
+
+      # --- PHASE 7: SMOKE TEST ---
       - name: 🧪 Smoke Test (Launch & Kill)
         shell: pwsh
         timeout-minutes: 2
         run: |
           Write-Host "🚀 Starting FortunaApp.exe..."
-          Start-Process "dist/FortunaApp.exe"
+          Start-Process "dist/FortunaApp.exe" -PassThru
 
           Write-Host "⏳ Waiting for server..."
           $maxAttempts = 20
@@ -306,7 +314,7 @@ jobs:
             Start-Sleep -Seconds 1
             $attempt++
             try {
-              $response = Invoke-WebRequest -Uri "http://127.0.0.1:8000/health" -TimeoutSec 2 -ErrorAction Stop
+              $response = Invoke-WebRequest -Uri "http://127.0.0.1:8000/api/health" -TimeoutSec 2 -ErrorAction Stop
               if ($response.StatusCode -eq 200) {
                 $success = $true
                 Write-Host "✅ Server responded on attempt $attempt"
@@ -317,17 +325,19 @@ jobs:
           }
 
           if (-not $success) {
-            # Grab any error output before killing
-            throw "❌ Server never responded - likely missing module"
+            Write-Host "❌ Server never responded!"
+            Write-Host "--- PROCESS LIST ---"
+            Get-Process
+            Write-Host "--- BUILD DIRECTORY ---"
+            ls -Recurse dist
+            throw "Smoke test failed: Server did not respond at http://127.0.0.1:8000/api/health"
           }
 
-          Stop-Process -Name "FortunaApp" -Force
-          Write-Host "✅ Smoke test passed"
+          try {
+            Stop-Process -Name "FortunaApp" -Force -ErrorAction Stop
+            Write-Host "🛑 Stopped FortunaApp process."
+          } catch {
+            Write-Host "🤔 FortunaApp process not found, may have already terminated."
+          }
 
-      # --- PHASE 7: ARTIFACT UPLOAD ---
-      - name: 📤 Upload The Monolith
-        uses: actions/upload-artifact@v4
-        with:
-          name: FortunaApp-Universal-x86
-          path: dist/FortunaApp.exe
-          retention-days: 30
+          Write-Host "✅ Smoke test passed"

--- a/.github/workflows/formerly-the-core-of-reusable.yml
+++ b/.github/workflows/formerly-the-core-of-reusable.yml
@@ -1,37 +1,14 @@
-name: 🧬 Reusable Monolith SPA Builder
+name: 🧬 Standalone Monolith SPA Builder
 
 on:
-  workflow_call:
-    inputs:
-      backend_dir:
-        description: 'Path to the backend source directory (e.g., web_service/backend)'
-        required: true
-        type: string
-      entry_script:
-        description: 'Path to the main Python entry script (e.g., web_service/backend/monolith.py)'
-        required: true
-        type: string
-      artifact_name:
-        description: 'Name for the final executable artifact'
-        required: false
-        type: string
-        default: 'Fortuna-SPA-Monolith'
-      python_version:
-        description: 'Python version to use for the build'
-        required: false
-        type: string
-        default: '3.11'
-    outputs:
-      artifact_path:
-        description: "Path to the built executable artifact"
-        value: ${{ jobs.build-monolith.outputs.artifact_path }}
+  workflow_dispatch:
+  push:
+    branches: ["main"]
 
 jobs:
   build-monolith:
     name: '🗿 Build Python SPA Monolith'
     runs-on: windows-latest
-    outputs:
-      artifact_path: ${{ steps.verify.outputs.artifact_path }}
     steps:
       - uses: actions/checkout@v4
 
@@ -49,21 +26,21 @@ jobs:
       - name: 🐍 Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ inputs.python_version }}
+          python-version: '3.11'
           cache: 'pip'
 
       - name: 📦 Install Backend Dependencies
         shell: pwsh
         run: |
           pip install --upgrade pip wheel
-          pip install -r ${{ inputs.backend_dir }}/requirements.txt
+          pip install -r web_service/backend/requirements.txt
           pip install pywebview[cef] pyinstaller==6.6.0 pywin32
 
       - name: 📁 Create Required Data Dirs
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force -Path "${{ inputs.backend_dir }}/data"
-          New-Item -ItemType Directory -Force -Path "${{ inputs.backend_dir }}/json"
+          New-Item -ItemType Directory -Force -Path "web_service/backend/data"
+          New-Item -ItemType Directory -Force -Path "web_service/backend/json"
 
       # --- PyInstaller Build ---
       - name: 🔮 Generate Spec & Build
@@ -76,7 +53,7 @@ jobs:
             "datas = [('frontend_dist', 'frontend_dist')]",
             "hiddenimports = ['webview', 'webview.platforms.winforms', 'clr', 'win32timezone']",
             "a = Analysis(",
-            "    ['${{ inputs.entry_script }}'],",
+            "    ['web_service/backend/monolith.py'],",
             "    pathex=[],",
             "    binaries=[],",
             "    datas=datas,",
@@ -89,7 +66,7 @@ jobs:
             "pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)",
             "exe = EXE(",
             "    pyz, a.scripts, a.binaries, a.zipfiles, a.datas,",
-            "    name='${{ inputs.artifact_name }}',",
+            "    name='Fortuna-SPA-Monolith',",
             "    console=False,",
             "    icon='electron/assets/icon.ico'",
             ")"
@@ -97,21 +74,20 @@ jobs:
           $specContent | Set-Content -Path "generated.spec"
           pyinstaller --noconfirm --clean generated.spec
 
-      # --- Verification & Output ---
-      - name: 🔍 Verify Build and Set Output
+      # --- Verification ---
+      - name: 🔍 Verify Build
         id: verify
         shell: pwsh
         run: |
-          $exePath = "dist/${{ inputs.artifact_name }}.exe"
+          $exePath = "dist/Fortuna-SPA-Monolith.exe"
           if (-not (Test-Path $exePath)) {
             throw "PyInstaller build failed - EXE not found at $exePath"
           }
-          "artifact_path=$exePath" >> $env:GITHUB_OUTPUT
           Write-Host "✅ Monolith built successfully at $exePath"
 
       - name: 📤 Upload Monolith Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.artifact_name }}
-          path: ${{ steps.verify.outputs.artifact_path }}
+          name: Fortuna-SPA-Monolith
+          path: dist/Fortuna-SPA-Monolith.exe
           retention-days: 7

--- a/web_service/backend/monolith.py
+++ b/web_service/backend/monolith.py
@@ -141,8 +141,7 @@ def main():
         resizable=True,
         fullscreen=False,
         min_size=(800, 600),
-        background_color='#1a1a1a',
-        debug=True  # Enable dev tools
+        background_color='#1a1a1a'
     )
 
     webview.start()


### PR DESCRIPTION
Refactors the `formerly-the-core-of-reusable.yml` workflow from a reusable `workflow_call` to a standalone workflow.

- Changes the trigger to `workflow_dispatch` and `push` to the main branch, allowing it to be run directly for comparison with other monolith build workflows.
- Removes the `inputs` and `outputs` sections.
- Replaces all `inputs.*` variables with hardcoded values to build the `web_service/backend/monolith.py` entry point.
- Renames the workflow to "Standalone Monolith SPA Builder". ---
fix(ci): correct and enhance universal monolith workflow

This change addresses failures in the `build-universal-monolith.yml` workflow.

- Reorders the 'Upload Artifact' step to occur before the 'Smoke Test' step. This ensures the compiled executable is always available for download, even if the smoke test fails.
- Corrects the smoke test health check URL from `/health` to the correct `/api/health` endpoint.
- Enhances the smoke test failure diagnostics by adding PowerShell commands to log the current process list and the contents of the build directory, providing more context for debugging. ---
fix(app): resolve monolith startup crash and routing error

This commit addresses two critical errors preventing the Universal Monolith application from running successfully.

- Removes the invalid `debug=True` keyword argument from the `webview.create_window()` function call in `web_service/backend/monolith.py`. This fixes a `TypeError` that caused the application to crash on startup.
- Restores the `/api` prefix to the router in `web_service/backend/api.py`. This corrects a routing bug that caused the `/api/health` endpoint to return a 404 error.