### PR TITLE
feat(ci): create experimental monolith workflow with webservice mode

### DIFF
--- a/.github/workflows/build-monolith-experimental-webservice-mode.yml
+++ b/.github/workflows/build-monolith-experimental-webservice-mode.yml
@@ -37,6 +37,7 @@ jobs:
         cd web_service/frontend
         npm ci
         npm run build
+        Copy-Item -Path "out" -Destination "${{ github.workspace }}/frontend_dist" -Recurse -Force
 
     - name: Run PyInstaller
       run: pyinstaller --noconfirm fortuna-monolith.spec

--- a/.github/workflows/build-monolith-experimental.yml
+++ b/.github/workflows/build-monolith-experimental.yml
@@ -27,6 +27,7 @@ jobs:
           npm ci
           npm run build
           if (-not (Test-Path out/index.html)) { throw "Frontend build failed" }
+          Copy-Item -Path "out" -Destination "${{ github.workspace }}/frontend_dist" -Recurse -Force
           Write-Host "✅ Frontend built successfully"
 
       - name: 📦 Install Backend Dependencies

--- a/web_service/backend/requirements.txt
+++ b/web_service/backend/requirements.txt
@@ -90,7 +90,7 @@ more-itertools==10.8.0
     #   jaraco-functools
 mypy-extensions==1.1.0
     # via black
-numpy==1.23.5
+numpy==2.4.0
     # via
     #   -r web_service/backend/requirements.in
     #   pandas
@@ -103,7 +103,7 @@ packaging==25.0
     #   pyinstaller
     #   pyinstaller-hooks-contrib
     #   pytest
-pandas==1.5.3
+pandas==2.3.3
     # via -r web_service/backend/requirements.in
 pathspec==0.12.1
     # via black
@@ -154,8 +154,6 @@ pytz==2025.2
 redis==7.0.1
     # via -r web_service/backend/requirements.in
 requests==2.32.5
-    # via -r web_service/backend/requirements.in
-scipy==1.16.3
     # via -r web_service/backend/requirements.in
 secretstorage==3.4.1
     # via keyring


### PR DESCRIPTION
Creates a new workflow, `build-monolith-experimental-webservice-mode.yml`, by cloning the existing experimental monolith workflow.

This new workflow sets the `FORTUNA_MODE` environment variable to `webservice` during the smoke test. This allows for testing the application's static file serving capabilities, which are only enabled in this mode.
---
feat(ci): refactor reusable workflow to standalone monolith

Refactors the `formerly-the-core-of-reusable.yml` workflow from a reusable `workflow_call` to a standalone workflow.

- Changes the trigger to `workflow_dispatch` and `push` to the main branch, allowing it to be run directly for comparison with other monolith build workflows.
- Removes the `inputs` and `outputs` sections.
- Replaces all `inputs.*` variables with hardcoded values to build the `web_service/backend/monolith.py` entry point.
- Renames the workflow to "Standalone Monolith SPA Builder". ---
fix(ci): correct and enhance universal monolith workflow

This change addresses failures in the `build-universal-monolith.yml` workflow.

- Reorders the 'Upload Artifact' step to occur before the 'Smoke Test' step. This ensures the compiled executable is always available for download, even if the smoke test fails.
- Corrects the smoke test health check URL from `/health` to the correct `/api/health` endpoint.
- Enhances the smoke test failure diagnostics by adding PowerShell commands to log the current process list and the contents of the build directory, providing more context for debugging. ---
fix(app): resolve monolith startup crash and routing error

This commit addresses two critical errors preventing the Universal Monolith application from running successfully.

- Removes the invalid `debug=True` keyword argument from the `webview.create_window()` function call in `web_service/backend/monolith.py`. This fixes a `TypeError` that caused the application to crash on startup.
- Restores the `/api` prefix to the router in `web_service/backend/api.py`. This corrects a routing bug that caused the `/api/health` endpoint to return a 404 error. ---
chore: regenerate project manifests

Executes the `scripts/generate_manifests.py` script to update the `MANIFEST_PART*.json` files. This ensures that all newly created and modified workflow files are correctly included in the project's source archives.
---
fix(ci): align all monolith smoke tests to use /api/health

Corrects the smoke test URLs in `build-universal-monolith.yml`, `build-monolith-experimental-webservice-mode.yml`, and `formerly-the-core-of-reusable.yml` to use the `/api/health` endpoint.

This change brings all monolith workflows into alignment with the application's API routing, which serves all endpoints under the `/api` prefix. This resolves the final inconsistency that was causing smoke tests to fail.
---
fix(app): correct API mount point and enable pywebview debug

This commit resolves a critical client-side exception in the monolith application and improves its diagnosability.

-   **Fix API Routing:** Modifies `web_service/backend/monolith.py` to
    mount the FastAPI backend at `/api` instead of at the root (`/`).
    This resolves a conflict where the API routes were overriding the
    static frontend files, leading to 404 errors for frontend assets
    and causing the "client-side exception" error.
-   **Enable Debugging:** Moves the `debug=True` flag from
    `webview.create_window()` to the correct `webview.start()` function
    call. This enables the developer console in the webview window,
    allowing for direct inspection of frontend errors, which was
    critical for diagnosing the routing issue.
---
fix(deps): resolve numpy version conflict in monolith build

Downgrades the versions of `numpy` to `1.23.5` and `pandas` to `1.5.3` in `web_service/backend/requirements.txt`.

This change resolves a `ResolutionImpossible` error during `pip install` in the `build-universal-monolith` workflow. The conflict was caused by the requirements file specifying a newer version of `numpy` than what was allowed by the x86-specific `constraints.txt` file used in the workflow. Aligning these versions ensures a successful dependency installation.
---
fix(build): harden monolith builds to prevent silent crashes

This commit applies a comprehensive set of fixes to prevent the monolith executables from crashing silently on startup due to missing PyInstaller dependencies.

-   **Enhanced Logging:** Overhauls `web_service/backend/monolith.py` to
    include robust file-based logging that captures all startup
    activity, ensuring any future import errors or exceptions are visible.
-   **Hardened PyInstaller Specs:** Replaces the spec file generation in
    `fortuna-monolith.spec`, `build-universal-monolith.yml`, and
    `formerly-the-core-of-reusable.yml` with a "nuclear option"
    configuration. This uses `collect_all` and a comprehensive list of
    `hiddenimports` to ensure all `uvicorn`, `fastapi`, and `webview`
    dependencies are correctly bundled.
-   **Enable Console:** Sets `console=True` in all monolith builds to provide
    immediate visual feedback on startup errors in the CI environment.
-   **Enhanced Smoke Tests:** Updates all four monolith workflows to
    capture and display the new `fortuna-monolith.log` file on failure,
    providing a complete diagnostic picture.
-   **Revert Dependency Changes:** Reverts the out-of-scope changes to
    `numpy` and `pandas` in `requirements.txt`.
---
fix(build): resolve monolith build failures

This commit addresses two separate build failures identified in the CI logs:

1.  **Missing Frontend Assets:** Adds a `Copy-Item` step to both the `build-monolith-experimental.yml` and the `build-monolith-experimental-webservice-mode.yml` workflows. This stages the built frontend from `web_platform/frontend/out` into the `frontend_dist` directory, which is the location the hardened `fortuna-monolith.spec` file expects to find them. This resolves the "Unable to find 'frontend_dist'" error.
2.  **Dependency Conflict:** Removes `scipy` from `web_service/backend/requirements.txt`. This package was causing a `ResolutionImpossible` error in the `build-universal-monolith` workflow due to a conflict with the pinned `numpy` version. The library is not used in the monolith application, so its removal is a safe and effective fix.