### PR TITLE
fix(ci): Resolve Python path and PowerShell syntax errors

### DIFF
--- a/.github/workflows/build-monolith-unified.yml
+++ b/.github/workflows/build-monolith-unified.yml
@@ -105,11 +105,11 @@ jobs:
           retention-days: 30
 
       # --- TEST ---
-      - name: 🧪 Smoke Test
+      - name: Smoke Test
         shell: pwsh
         timeout-minutes: 3
         run: |
-          Write-Host "🚀 Launching fortuna-monolith.exe..."
+          Write-Host "Launching fortuna-monolith.exe..."
           $logFile = "${{ github.workspace }}/monolith-test.log"
 
           $process = Start-Process `
@@ -120,7 +120,7 @@ jobs:
             -WindowStyle Hidden
 
           $procId = $process.Id
-          Write-Host "⏳ Process started (PID: $procId), waiting 8 seconds for startup..."
+          Write-Host "Process started (PID: $procId), waiting 8 seconds for startup..."
           Start-Sleep -Seconds 8
 
           # Health check
@@ -136,12 +136,13 @@ jobs:
                 -ErrorAction Stop
 
               if ($response.StatusCode -eq 200) {
-                Write-Host "✅ Backend healthy: $($response.Content)"
+                Write-Host "Backend healthy: $($response.Content)"
                 $success = $true
                 break
               }
             } catch {
-              Write-Host "   Health check attempt $attempt/$maxAttempts: waiting..."
+              # FIXED: Use ${} to delimit variable name from the colon
+              Write-Host "   Health check attempt ${attempt}/${maxAttempts}: waiting..."
               Start-Sleep -Seconds 2
             }
           }
@@ -153,11 +154,11 @@ jobs:
           }
 
           # Show logs
-          Write-Host "`n📋 Build Log (last 50 lines):"
+          Write-Host "`nBuild Log (last 50 lines):"
           Get-Content $logFile -ErrorAction SilentlyContinue | Select-Object -Last 50
 
           if (-not $success) {
-            throw "❌ Smoke test failed - backend never became healthy"
+            throw "Smoke test failed - backend never became healthy"
           }
 
-          Write-Host "✅ Smoke test passed!"
+          Write-Host "Smoke test passed!"

--- a/.github/workflows/test-quickstart.yml
+++ b/.github/workflows/test-quickstart.yml
@@ -54,18 +54,12 @@ jobs:
       - name: 🚀 Execute Bootstrapper
         shell: pwsh
         run: |
-          # Explicitly add the Python directory to the PATH for the script's environment.
-          # This is necessary because the script may not inherit the PATH set by setup-python.
-          $pythonDir = Split-Path -Parent "${{ steps.setup-python.outputs.python-path }}"
-          $pythonScriptsDir = Join-Path $pythonDir "Scripts"
-          $env:PATH = "$pythonDir;$pythonScriptsDir;$($env:PATH)"
-          Write-Host "Ensured Python is on PATH for the script."
-
           Write-Host "Starting script in CI mode..."
+          # Pass the exact python executable path to the script to avoid PATH issues.
           # Run with -Clean to test dependency installation
           # Run with -NoFrontend to focus on Backend health first
           # *>&1 combines stdout/stderr, Tee-Object saves to file AND shows in console
-          ./scripts/fortuna-quick-start.ps1 -Clean -NoFrontend *>&1 | Tee-Object -FilePath "bootstrapper_log.txt"
+          ./scripts/fortuna-quick-start.ps1 -Clean -NoFrontend -PythonExecutable "${{ steps.setup-python.outputs.python-path }}" *>&1 | Tee-Object -FilePath "bootstrapper_log.txt"
 
       - name: 📤 Upload Debug Logs
         if: always() # CRITICAL: Run this even if the bootstrapper crashes


### PR DESCRIPTION
This commit addresses two separate issues in the GitHub Actions workflows:

1. In `test-quickstart.yml`, the `fortuna-quick-start.ps1` script failed to find the Python executable. This is fixed by passing the explicit python path from the `setup-python` action directly to the script via the `-PythonExecutable` parameter.

2. In `build-monolith-unified.yml`, a PowerShell `ParserError` occurred during the smoke test due to incorrect variable interpolation. This is resolved by wrapping the variables in curly braces (e.g., `${attempt}`) to properly delimit them.