### PR TITLE
fix(ci): Resolve Multiple CI and Application Failures

### DIFF
--- a/.github/workflows/build-monolith-unified.yml
+++ b/.github/workflows/build-monolith-unified.yml
@@ -105,22 +105,23 @@ jobs:
           retention-days: 30
 
       # --- TEST ---
-      - name: 🧪 Smoke Test
+      - name: Smoke Test
         shell: pwsh
         timeout-minutes: 3
         run: |
-          Write-Host "🚀 Launching fortuna-monolith.exe..."
-          $logFile = "${{ github.workspace }}/monolith-test.log"
+          Write-Host "Launching fortuna-monolith.exe..."
+          $stdOutLog = "${{ github.workspace }}/monolith-stdout.log"
+          $stdErrLog = "${{ github.workspace }}/monolith-stderr.log"
 
           $process = Start-Process `
             -FilePath "dist/fortuna-monolith.exe" `
             -PassThru `
-            -RedirectStandardOutput $logFile `
-            -RedirectStandardError $logFile `
+            -RedirectStandardOutput $stdOutLog `
+            -RedirectStandardError $stdErrLog `
             -WindowStyle Hidden
 
           $procId = $process.Id
-          Write-Host "⏳ Process started (PID: $procId), waiting 8 seconds for startup..."
+          Write-Host "Process started (PID: $procId), waiting 8 seconds for startup..."
           Start-Sleep -Seconds 8
 
           # Health check
@@ -136,12 +137,12 @@ jobs:
                 -ErrorAction Stop
 
               if ($response.StatusCode -eq 200) {
-                Write-Host "✅ Backend healthy: $($response.Content)"
+                Write-Host "Backend healthy: $($response.Content)"
                 $success = $true
                 break
               }
             } catch {
-              Write-Host "   Health check attempt $attempt/$maxAttempts: waiting..."
+              Write-Host "   Health check attempt ${attempt}/${maxAttempts}: waiting..."
               Start-Sleep -Seconds 2
             }
           }
@@ -153,11 +154,13 @@ jobs:
           }
 
           # Show logs
-          Write-Host "`n📋 Build Log (last 50 lines):"
-          Get-Content $logFile -ErrorAction SilentlyContinue | Select-Object -Last 50
+          Write-Host "`nStdout Log (last 50 lines):"
+          Get-Content $stdOutLog -ErrorAction SilentlyContinue | Select-Object -Last 50
+          Write-Host "`nStderr Log (last 50 lines):"
+          Get-Content $stdErrLog -ErrorAction SilentlyContinue | Select-Object -Last 50
 
           if (-not $success) {
-            throw "❌ Smoke test failed - backend never became healthy"
+            throw "Smoke test failed - backend never became healthy"
           }
 
-          Write-Host "✅ Smoke test passed!"
+          Write-Host "Smoke test passed!"

--- a/.github/workflows/test-quickstart.yml
+++ b/.github/workflows/test-quickstart.yml
@@ -54,18 +54,12 @@ jobs:
       - name: 🚀 Execute Bootstrapper
         shell: pwsh
         run: |
-          # Explicitly add the Python directory to the PATH for the script's environment.
-          # This is necessary because the script may not inherit the PATH set by setup-python.
-          $pythonDir = Split-Path -Parent "${{ steps.setup-python.outputs.python-path }}"
-          $pythonScriptsDir = Join-Path $pythonDir "Scripts"
-          $env:PATH = "$pythonDir;$pythonScriptsDir;$($env:PATH)"
-          Write-Host "Ensured Python is on PATH for the script."
-
           Write-Host "Starting script in CI mode..."
+          # Pass the exact python executable path to the script to avoid PATH issues.
           # Run with -Clean to test dependency installation
           # Run with -NoFrontend to focus on Backend health first
           # *>&1 combines stdout/stderr, Tee-Object saves to file AND shows in console
-          ./scripts/fortuna-quick-start.ps1 -Clean -NoFrontend *>&1 | Tee-Object -FilePath "bootstrapper_log.txt"
+          ./scripts/fortuna-quick-start.ps1 -Clean -NoFrontend -PythonExecutable "${{ steps.setup-python.outputs.python-path }}" *>&1 | Tee-Object -FilePath "bootstrapper_log.txt"
 
       - name: 📤 Upload Debug Logs
         if: always() # CRITICAL: Run this even if the bootstrapper crashes

--- a/scripts/fortuna-quick-start.ps1
+++ b/scripts/fortuna-quick-start.ps1
@@ -89,10 +89,10 @@ if (-not (Test-Path $BACKEND_DIR)) { Show-Fail "Backend directory not found at: 
 
 # Check for Python
 try {
-    $pyVer = & $PYTHON_CMD --version 2>&1
-    Show-Success "Found $pyVer"
+    & $PYTHON_CMD --version
+    Show-Success "Python executable found."
 } catch {
-    Show-Fail "Python not found in PATH."
+    Show-Fail "Python not found in PATH or specified executable is invalid."
 }
 
 # Upgrade Pip & Wheel

--- a/web_service/backend/monolith.py
+++ b/web_service/backend/monolith.py
@@ -337,7 +337,7 @@ def main():
         )
 
         logger.info("Starting webview event loop...")
-        webview.start(debug=False)
+        webview.start(debug=False, gui='cef')
 
         logger.info("Webview closed, exiting...")
 


### PR DESCRIPTION
This commit addresses three separate issues:

1.  **`test-quickstart.yml` - Python Path Issue:** The `fortuna-quick-start.ps1` script failed to find the Python executable. This is fixed by passing the explicit python path from the `setup-python` action directly to the script via the `-PythonExecutable` parameter.

2.  **`build-monolith-unified.yml` - PowerShell Errors:** The smoke test failed due to two PowerShell errors. This is fixed by redirecting stdout and stderr to separate log files and by wrapping interpolated variables in curly braces to prevent parsing errors.

3.  **`monolith.py` - Application Crash:** The monolith application crashed with a `KeyboardInterrupt` during webview initialization. This is resolved by switching the `pywebview` backend to the more stable 'cef' engine.