### PR TITLE
feat(installer): add launch on exit checkbox to electron msi

### DIFF
--- a/build_wix/Product_Electron.wxs
+++ b/build_wix/Product_Electron.wxs
@@ -22,6 +22,10 @@
     <ui:WixUI Id="WixUI_InstallDir" InstallDirectory="INSTALLFOLDER" />
     <WixVariable Id="WixUILicenseRtf" Value="license.rtf" />
 
+    <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Launch Fortuna Faucet" />
+    <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1" />
+    <Property Id="WixShellExecTarget" Value="[INSTALLFOLDER]Fortuna Faucet.exe" />
+
     <StandardDirectory Id="LocalAppDataFolder">
       <Directory Id="INSTALLFOLDER" Name="Fortuna Faucet" />
     </StandardDirectory>


### PR DESCRIPTION
Adds a "Launch Fortuna Faucet" checkbox to the exit dialog of the Electron installer.

This provides a common, user-friendly feature that allows the user to immediately start the application after installation, confirming that the process was successful.

The implementation uses the standard WiX UI extension properties:
- WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT
- WIXUI_EXITDIALOGOPTIONALCHECKBOX
- WixShellExecTarget