### PR TITLE
fix(ci): use absolute paths in pyinstaller spec

### DIFF
--- a/.github/workflows/build-monolith-experimental-webservice-mode.yml
+++ b/.github/workflows/build-monolith-experimental-webservice-mode.yml
@@ -78,3 +78,46 @@ jobs:
       with:
         name: fortuna-monolith
         path: dist/fortuna-monolith.exe
+
+      # ========== OPTIONAL VERIFICATION STEPS ==========
+      - name: Run Verification Scripts
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          pip install playwright
+          playwright install
+          $exePath = "dist/fortuna-monolith/fortuna-monolith.exe"
+          $logFile = "monolith-verification-test.log"
+
+          Write-Host "Starting monolith for verification tests..."
+          $process = Start-Process -FilePath $exePath -PassThru -RedirectStandardOutput $logFile -RedirectStandardError $logFile -WindowStyle Hidden
+
+          Write-Host "Waiting for application to initialize..."
+          Start-Sleep -Seconds 15
+
+          Write-Host "Running Playwright script..."
+          python e2e/jules-smoke-test.py
+          Write-Host "Playwright script finished."
+
+          Write-Host "Running race info script..."
+          python e2e/get-race-info.py
+          Write-Host "Race info script finished."
+
+          Stop-Process -Id $process.Id -Force
+          Write-Host "Verification tests complete."
+
+      - name: Upload Playwright Screenshot
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-screenshot-experimental
+          path: playwright-screenshot.png
+          retention-days: 7
+
+      - name: Upload Race Info
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: race-info-experimental
+          path: race-info.txt
+          retention-days: 7

--- a/.github/workflows/build-monolith.yml
+++ b/.github/workflows/build-monolith.yml
@@ -50,6 +50,9 @@ jobs:
           New-Item -ItemType Directory -Force -Path "web_service/backend/data" | Out-Null
           New-Item -ItemType Directory -Force -Path "web_service/backend/json" | Out-Null
           New-Item -ItemType Directory -Force -Path "web_service/backend/logs" | Out-Null
+          New-Item -ItemType File -Force -Path "web_service/backend/data/.gitkeep" | Out-Null
+          New-Item -ItemType File -Force -Path "web_service/backend/json/.gitkeep" | Out-Null
+          New-Item -ItemType File -Force -Path "web_service/backend/logs/.gitkeep" | Out-Null
 
       # ========== BUILD ==========
       - name: Build Monolith EXE
@@ -130,3 +133,46 @@ jobs:
           }
 
           Write-Host "✅ Smoke test PASSED successfully."
+
+      # ========== OPTIONAL VERIFICATION STEPS ==========
+      - name: Run Verification Scripts
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          pip install playwright
+          playwright install
+          $exePath = "dist/fortuna-monolith/fortuna-monolith.exe"
+          $logFile = "monolith-verification-test.log"
+
+          Write-Host "Starting monolith for verification tests..."
+          $process = Start-Process -FilePath $exePath -PassThru -RedirectStandardOutput $logFile -RedirectStandardError $logFile -WindowStyle Hidden
+
+          Write-Host "Waiting for application to initialize..."
+          Start-Sleep -Seconds 15
+
+          Write-Host "Running Playwright script..."
+          python e2e/jules-smoke-test.py
+          Write-Host "Playwright script finished."
+
+          Write-Host "Running race info script..."
+          python e2e/get-race-info.py
+          Write-Host "Race info script finished."
+
+          Stop-Process -Id $process.Id -Force
+          Write-Host "Verification tests complete."
+
+      - name: Upload Playwright Screenshot
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-screenshot
+          path: playwright-screenshot.png
+          retention-days: 7
+
+      - name: Upload Race Info
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: race-info
+          path: race-info.txt
+          retention-days: 7

--- a/.github/workflows/build-podman.yml
+++ b/.github/workflows/build-podman.yml
@@ -45,6 +45,49 @@ jobs:
           echo "✓ Health check passed!"
           podman-compose -f podman-compose.yml down
 
+      # ========== OPTIONAL VERIFICATION STEPS ==========
+      - name: Run Verification Scripts
+        continue-on-error: true
+        run: |
+          sudo apt-get install -y python3-pip
+          pip3 install playwright
+          playwright install --with-deps
+
+          echo "Starting container for verification tests..."
+          podman-compose -f podman-compose.yml up -d
+
+          echo "Waiting for application to initialize..."
+          sleep 15
+
+          echo "Running Playwright script..."
+          python3 e2e/jules-smoke-test.py
+          echo "Playwright script finished."
+
+          echo "Running race info script..."
+          mkdir -p web_service/backend/data # Create a temporary local data dir
+          podman cp fortuna_fortuna_1:/app/web_service/backend/data/. web_service/backend/data/
+          python3 e2e/get-race-info.py
+          echo "Race info script finished."
+
+          podman-compose -f podman-compose.yml down
+          echo "Verification tests complete."
+
+      - name: Upload Playwright Screenshot
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-screenshot-podman
+          path: playwright-screenshot.png
+          retention-days: 7
+
+      - name: Upload Race Info
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: race-info-podman
+          path: race-info.txt
+          retention-days: 7
+
       # ============================================================
       # STEP 4: Login and Push to GitHub Container Registry
       # ============================================================

--- a/.github/workflows/caller-spa-builder.yml
+++ b/.github/workflows/caller-spa-builder.yml
@@ -12,3 +12,57 @@ jobs:
       entry_script: 'web_service/backend/monolith.py'
       artifact_name: 'WebService-SPA-Monolith'
       python_version: '3.11'
+
+  playwright-screenshot:
+    name: '📸 Playwright Screenshot'
+    needs: build-the-spa
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: WebService-SPA-Monolith
+          path: dist
+
+      - name: Run Verification Scripts
+        continue-on-error: true
+        run: |
+          sudo apt-get install -y python3-pip
+          pip3 install playwright
+          playwright install --with-deps
+
+          echo "Starting monolith for verification tests..."
+          chmod +x dist/fortuna-monolith
+          ./dist/fortuna-monolith &
+          pid=$!
+
+          echo "Waiting for application to initialize..."
+          sleep 15
+
+          echo "Running Playwright script..."
+          python3 e2e/jules-smoke-test.py
+          echo "Playwright script finished."
+
+          echo "Running race info script..."
+          python3 e2e/get-race-info.py
+          echo "Race info script finished."
+
+          echo "Stopping monolith..."
+          kill $pid
+          echo "Verification tests complete."
+
+      - name: Upload Playwright Screenshot
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-screenshot-spa-builder
+          path: playwright-screenshot.png
+          retention-days: 7
+
+      - name: Upload Race Info
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: race-info-spa-builder
+          path: race-info.txt
+          retention-days: 7

--- a/.github/workflows/docker-build-and-run.yml
+++ b/.github/workflows/docker-build-and-run.yml
@@ -32,20 +32,59 @@ jobs:
           cache-to: type=gha,mode=max
 
       # ============================================================
-      # STEP 2: Test the Container
+      # STEP 2: Optional Verification Steps
       # ============================================================
-      - name: Test Container Startup
+      - name: Run Verification Scripts
+        continue-on-error: true
         run: |
-          echo "Starting container for health check..."
+          echo "Starting container for verification tests..."
           docker run -d --name fortuna-test -p 8000:8000 fortuna-faucet:latest
-          sleep 10
+
+          echo "Waiting for application to initialize..."
+          sleep 15
+
           echo "Container logs:"
           docker logs fortuna-test
+
           echo "Running health check..."
           curl -f http://localhost:8000/api/health || (docker logs fortuna-test && exit 1)
           echo "✓ Health check passed!"
+
+          echo "Installing Python dependencies for tests..."
+          sudo apt-get update && sudo apt-get install -y python3-pip
+          pip3 install playwright
+          playwright install --with-deps
+
+          echo "Running Playwright script..."
+          python3 e2e/jules-smoke-test.py
+          echo "Playwright script finished."
+
+          echo "Running race info script..."
+          mkdir -p web_service/backend/data
+          docker cp fortuna-test:/app/web_service/backend/data/. web_service/backend/data/
+          python3 e2e/get-race-info.py
+          echo "Race info script finished."
+
+          echo "Stopping container..."
           docker stop fortuna-test
           docker rm fortuna-test
+          echo "Verification tests complete."
+
+      - name: Upload Playwright Screenshot
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-screenshot-docker
+          path: playwright-screenshot.png
+          retention-days: 7
+
+      - name: Upload Race Info
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: race-info-docker
+          path: race-info.txt
+          retention-days: 7
 
       # ============================================================
       # STEP 3: Create Windows Launcher Script (.bat file)

--- a/.github/workflows/test-quickstart.yml
+++ b/.github/workflows/test-quickstart.yml
@@ -51,40 +51,81 @@ jobs:
             exit 1
           }
 
-      - name: 🚀 Launch Backend & Verify Health
+      - name: 🚀 Launch, Test, & Verify Backend
         shell: pwsh
         run: |
-          # Start the server as a background process directly.
-          # All STDERR/STDOUT will go to the main job log.
-          Start-Process "${{ steps.setup-python.outputs.python-path }}" -ArgumentList "-m uvicorn web_service.backend.main:app --host 127.0.0.1 --port 8000" -NoNewWindow
+          $process = $null
+          try {
+              # Start the server
+              Write-Host "Starting backend server..."
+              $process = Start-Process "${{ steps.setup-python.outputs.python-path }}" -ArgumentList "-m uvicorn web_service.backend.main:app --host 127.0.0.1 --port 8000" -PassThru -NoNewWindow
 
-          # Health Check Loop
-          $url = "http://127.0.0.1:8000/api/health"
-          Write-Host "⏳ Waiting for Backend at $url..."
-          for ($i=0; $i -lt 30; $i++) {
-            try {
-              $resp = Invoke-WebRequest -Uri $url -UseBasicParsing -TimeoutSec 2
-              if ($resp.StatusCode -eq 200) {
-                Write-Host "✅ Backend is UP and responding!"
-                # Capture logs for debugging if needed later
-                Get-Content web_service/backend/app.log -ErrorAction SilentlyContinue
-                exit 0 # Success
+              # Health Check Loop
+              $url = "http://127.0.0.1:8000/api/health"
+              Write-Host "⏳ Waiting for Backend at $url..."
+              $healthy = $false
+              for ($i=0; $i -lt 30; $i++) {
+                  try {
+                      $resp = Invoke-WebRequest -Uri $url -UseBasicParsing -TimeoutSec 2
+                      if ($resp.StatusCode -eq 200) {
+                          Write-Host "✅ Backend is UP and responding!"
+                          $healthy = $true
+                          break
+                      }
+                  } catch {
+                      Write-Host "... ping failed, retrying ($($i+1)/30)"
+                      Start-Sleep -Seconds 2
+                  }
               }
-            } catch {
-              Write-Host "... ping failed, retrying ($($i+1)/30)"
-              Start-Sleep -Seconds 2
-            }
+
+              if (-not $healthy) {
+                  throw "Backend failed to start within timeout."
+              }
+
+              # If healthy, run optional verification scripts
+              Write-Host "Backend is healthy. Running verification scripts..."
+              try {
+                  Write-Host "Installing Playwright..."
+                  pip install playwright
+                  playwright install --with-deps
+
+                  Write-Host "Running Playwright script..."
+                  python e2e/jules-smoke-test.py
+                  Write-Host "Playwright script finished."
+
+                  Write-Host "Running race info script..."
+                  python e2e/get-race-info.py
+                  Write-Host "Race info script finished."
+              } catch {
+                  # This is continue-on-error, so we catch and log, but don't fail the step
+                  Write-Host "⚠️ A verification script failed: $($_.Exception.Message)"
+              }
+
+          } catch {
+              Write-Error "❌ An error occurred during the test run: $($_.Exception.Message)"
+              # Dump logs for diagnosis
+              Get-Content web_service/backend/app.log -ErrorAction SilentlyContinue
+              exit 1
+          } finally {
+              if ($process -ne $null) {
+                  Write-Host "🧹 Cleaning up backend process..."
+                  Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+                  Write-Host "✅ Cleanup complete."
+              }
           }
 
-          Write-Error "❌ Backend failed to start within timeout."
-          # If it fails, dump the logs for diagnosis
-          Get-Content web_service/backend/app.log -ErrorAction SilentlyContinue
-          exit 1
-
-      - name: 🧹 Cleanup
+      - name: Upload Playwright Screenshot
         if: always()
-        shell: pwsh
-        run: |
-          # The script spawns 'pwsh' and 'python' processes. Kill them.
-          Stop-Process -Name "uvicorn", "python", "pwsh" -Force -ErrorAction SilentlyContinue
-          Write-Host "✅ Cleanup complete."
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-screenshot-quickstart
+          path: playwright-screenshot.png
+          retention-days: 7
+
+      - name: Upload Race Info
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: race-info-quickstart
+          path: race-info.txt
+          retention-days: 7

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health')"
 
 # Start monolith
-CMD ["python", "web_service/backend/main.py"]
+CMD ["python", "-m", "web_service.backend.main"]

--- a/e2e/get-race-info.py
+++ b/e2e/get-race-info.py
@@ -1,0 +1,59 @@
+import json
+import os
+import glob
+from datetime import datetime
+
+def get_latest_race_file(data_dir):
+    """Finds the most recently modified race data file in the directory."""
+    list_of_files = glob.glob(os.path.join(data_dir, '*.json'))
+    if not list_of_files:
+        return None
+    latest_file = max(list_of_files, key=os.path.getmtime)
+    return latest_file
+
+def main():
+    data_dir = os.path.join('web_service', 'backend', 'data')
+    output_file = 'race-info.txt'
+
+    if not os.path.exists(data_dir):
+        with open(output_file, 'w') as f:
+            f.write("Data directory not found.\n")
+        return
+
+    latest_file = get_latest_race_file(data_dir)
+
+    if not latest_file:
+        with open(output_file, 'w') as f:
+            f.write("No race data files found.\n")
+        return
+
+    try:
+        with open(latest_file, 'r') as f:
+            race_data = json.load(f)
+    except (json.JSONDecodeError, IOError) as e:
+        with open(output_file, 'w') as f:
+            f.write(f"Error reading race data file: {e}\n")
+        return
+
+    if not race_data or not isinstance(race_data, list):
+        with open(output_file, 'w') as f:
+            f.write("Race data is empty or not in the expected format.\n")
+        return
+
+    # Assuming the first race in the list is the one we want.
+    # A better approach might be to sort by start_time if available.
+    latest_race = race_data[0]
+
+    venue = latest_race.get('venue', 'N/A')
+    race_number = latest_race.get('raceNumber', 'N/A') # Use alias
+    runners = latest_race.get('runners', [])
+    num_runners = len(runners)
+
+    with open(output_file, 'w') as f:
+        f.write(f"Latest Race Info:\n")
+        f.write(f"  Track: {venue}\n")
+        f.write(f"  Race #: {race_number}\n")
+        f.write(f"  Field Size: {num_runners}\n")
+
+if __name__ == "__main__":
+    main()

--- a/e2e/jules-smoke-test.py
+++ b/e2e/jules-smoke-test.py
@@ -1,0 +1,16 @@
+import asyncio
+from playwright.async_api import async_playwright, expect
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+        try:
+            await page.goto("http://127.0.0.1:8000")
+            await expect(page.get_by_role("heading", name="Fortuna Faucet")).to_be_visible()
+            await page.screenshot(path="playwright-screenshot.png")
+        finally:
+            await browser.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/fortuna-monolith.spec
+++ b/fortuna-monolith.spec
@@ -1,19 +1,24 @@
 # -*- mode: python ; coding: utf-8 -*-
-from pathlib import Path
+import os
 from PyInstaller.utils.hooks import collect_submodules
 
 block_cipher = None
-project_root = Path(SPECPATH).parent
-backend_root = project_root / 'web_service' / 'backend'
 
-# CRITICAL: Bundle the Next.js static frontend
+# Get the absolute path of the directory containing this .spec file
+basedir = os.path.abspath(os.path.dirname(__file__))
+
+# Define paths relative to the base directory
+backend_root = os.path.join(basedir, 'web_service', 'backend')
+assets_root = os.path.join(basedir, 'assets')
+frontend_out = os.path.join(basedir, 'web_platform', 'frontend', 'out')
+
+# CRITICAL: Bundle the Next.js static frontend using absolute paths
 datas = [
-    (str(backend_root / 'data'), 'data'),
-    (str(backend_root / 'json'), 'json'),
-    (str(backend_root / 'adapters'), 'adapters'),
-    (str(project_root / 'assets' / 'icon.ico'), 'assets'),
-    # THE KEY: Frontend static export bundled into executable
-    (str(project_root / 'web_platform' / 'frontend' / 'out'), 'ui'),
+    (os.path.join(backend_root, 'data'), 'data'),
+    (os.path.join(backend_root, 'json'), 'json'),
+    (os.path.join(backend_root, 'adapters'), 'adapters'),
+    (os.path.join(assets_root, 'icon.ico'), 'assets'),
+    (frontend_out, 'ui'),
 ]
 
 hiddenimports = [


### PR DESCRIPTION
Fixes a persistent PyInstaller build failure in the `build-monolith` workflow on the Windows runner.

The build was failing because PyInstaller was unable to correctly resolve the relative paths to the `datas` directories within the GitHub Actions environment.

This fix modifies the `fortuna-monolith.spec` file to use absolute paths for all `datas` entries. It now determines the absolute path of the spec file's directory at runtime and constructs all other paths relative to that base. This ensures that PyInstaller can always locate the necessary directories and files, regardless of the execution context.