### PR TITLE
fix(electron): Correct backend executable path in main.js

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -100,12 +100,11 @@ class FortunaDesktopApp {
       backendCommand = path.join(__dirname, '..', '.venv', 'Scripts', 'python.exe');
       backendCwd = path.join(__dirname, '..', 'web_service', 'backend');
     } else {
-      const backendFolder = path.join(process.resourcesPath, 'fortuna-backend');
-      backendCommand = path.join(backendFolder, 'fortuna-backend.exe');
-      backendCwd = backendFolder;
+      // CORRECTED PATH: In production, the backend executable is at the root of the resources directory.
+      backendCommand = path.join(process.resourcesPath, 'fortuna-backend.exe');
+      backendCwd = process.resourcesPath;
 
       console.log(`[Backend] Looking for executable at: ${backendCommand}`);
-      console.log(`[Backend] Directory exists: ${fs.existsSync(backendFolder)}`);
       console.log(`[Backend] Executable exists: ${fs.existsSync(backendCommand)}`);
     }
 


### PR DESCRIPTION
This commit fixes a critical pathing error in the Electron main process that prevented the application from launching its backend executable in a packaged production environment.

The `main.js` file was incorrectly looking for `fortuna-backend.exe` within a `fortuna-backend` subdirectory inside the application's resources folder. The corrected path now correctly points to the root of the `resources` directory (`process.resourcesPath`), which is the standard location for extra resources in an electron-builder application.

This change is expected to resolve the smoke test failure in the `build-electron-msi-gpt5.yml` workflow, where the `fortuna-backend` process was not being found after installation.