### PR TITLE
fix(ci): Guarantee Playwright screenshot on test failure

### DIFF
--- a/.github/workflows/test-quickstart.yml
+++ b/.github/workflows/test-quickstart.yml
@@ -120,6 +120,11 @@ jobs:
               }
           }
 
+      - name: 🔍 List files for artifact debugging
+        if: always()
+        run: ls -R
+        shell: bash
+
       - name: Upload Playwright Screenshot
         if: always()
         uses: actions/upload-artifact@v4

--- a/e2e/jules-smoke-test.py
+++ b/e2e/jules-smoke-test.py
@@ -8,8 +8,8 @@ async def main():
         try:
             await page.goto("http://127.0.0.1:8000")
             await expect(page.get_by_test_id("main-heading")).to_be_visible()
-            await page.screenshot(path="playwright-screenshot.png")
         finally:
+            await page.screenshot(path="playwright-screenshot.png")
             await browser.close()
 
 if __name__ == "__main__":


### PR DESCRIPTION
Moves the `page.screenshot()` call in the E2E smoke test to a `finally` block. This ensures that a screenshot is always captured for debugging, even if the assertions in the test fail.

Also adds a diagnostic `ls -R` step to the workflow to provide a file manifest for easier debugging of artifact uploads.