### PR TITLE
fix(ci): Ensure Playwright screenshot is generated and fix Docker build

### DIFF
--- a/.github/workflows/test-quickstart.yml
+++ b/.github/workflows/test-quickstart.yml
@@ -120,6 +120,11 @@ jobs:
               }
           }
 
+      - name: 🔍 List files for artifact debugging
+        if: always()
+        run: ls -R
+        shell: bash
+
       - name: Upload Playwright Screenshot
         if: always()
         uses: actions/upload-artifact@v4

--- a/Dockerfile.tinyfield
+++ b/Dockerfile.tinyfield
@@ -16,19 +16,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf 
 # Copy Python packages
 COPY --from=backend-builder /root/.local /root/.local
 
-# Copy backend
-COPY web_service/backend /app/backend
-
-# Copy frontend (static HTML)
-COPY web_service/frontend/public /app/frontend/public
+# Copy application code, preserving directory structure
+COPY web_service /app/web_service
 
 # Create TinyField data directories
-RUN mkdir -p /app/backend/data /app/backend/json /app/backend/logs
+RUN mkdir -p /app/web_service/backend/data /app/web_service/backend/json /app/web_service/backend/logs
 
 # Set environment
-ENV PATH=/root/.local/bin:$PATH \
-    PYTHONPATH=/app:$PYTHONPATH \
-    PYTHONUNBUFFERED=1
+ENV PATH=/root/.local/bin:$PATH
+ENV PYTHONPATH=/app
+ENV PYTHONUNBUFFERED=1
 
 # Health check
 HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 \

--- a/e2e/jules-smoke-test.py
+++ b/e2e/jules-smoke-test.py
@@ -8,8 +8,8 @@ async def main():
         try:
             await page.goto("http://127.0.0.1:8000")
             await expect(page.get_by_test_id("main-heading")).to_be_visible()
-            await page.screenshot(path="playwright-screenshot.png")
         finally:
+            await page.screenshot(path="playwright-screenshot.png")
             await browser.close()
 
 if __name__ == "__main__":


### PR DESCRIPTION
This commit addresses two issues in the CI/CD pipeline:

1. The Playwright smoke test in 'e2e/jules-smoke-test.py' has been updated to ensure a screenshot is always captured, even if the test fails. The screenshot command is now in a 'finally' block.

2. The 'Dockerfile.tinyfield' has been refactored to correctly copy the 'web_service' directory, resolving a 'ModuleNotFoundError' that prevented the container from starting. This also simplifies the Dockerfile for better maintainability.