### PR TITLE
fix(ci): Resolve Next.js build failure in monolith workflow

### DIFF
--- a/.github/workflows/build-monolith-final.yml
+++ b/.github/workflows/build-monolith-final.yml
@@ -53,7 +53,7 @@ jobs:
             "/** @type {import('next').NextConfig} */",
             "const nextConfig = {",
             "  output: 'export',",
-            "  distDir: 'public',",
+            "  distDir: 'build',",
             "  images: { unoptimized: true },",
             "  trailingSlash: true,",
             "}",
@@ -61,7 +61,7 @@ jobs:
           )
           $configContent = $configLines -join [System.Environment]::NewLine
           Set-Content -Path "next.config.js" -Value $configContent -Encoding UTF8
-          Write-Host "✅ next.config.js set for 'public' directory output"
+          Write-Host "✅ next.config.js set for 'build' directory output"
 
           Write-Host "Installing dependencies..."
           npm install --legacy-peer-deps
@@ -76,6 +76,15 @@ jobs:
             Write-Error "npm run build failed"
             exit 1
           }
+
+          Write-Host "Moving build artifacts to 'public'..."
+          New-Item -ItemType Directory -Force -Path "public" | Out-Null
+          Move-Item -Path "build/*" -Destination "public" -Force
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to move build artifacts"
+            exit 1
+          }
+          Write-Host "✅ Artifacts moved."
 
           # Verify output
           Write-Host "`nVerifying output..."


### PR DESCRIPTION
The Next.js build was failing because the output directory ('distDir') was set to 'public', which is a reserved directory name.

This change modifies the build process to:
1. Set the 'distDir' to a temporary, non-reserved directory ('build').
2. Move the build artifacts from the 'build' directory to the 'public' directory after the build is complete.

This ensures the build succeeds while still placing the final assets in the correct location for the FastAPI backend to serve.