### PR TITLE
fix: Add User-Agent header to bypass anti-bot measures

### DIFF
--- a/.github/workflows/unified-race-report.yml
+++ b/.github/workflows/unified-race-report.yml
@@ -41,6 +41,7 @@ jobs:
           path: |
             race-report.html
             qualified_races.json
+            raw_race_data.json
           retention-days: 7
           if-no-files-found: error
 

--- a/web_service/backend/adapters/base_adapter_v3.py
+++ b/web_service/backend/adapters/base_adapter_v3.py
@@ -91,6 +91,16 @@ class BaseAdapterV3(ABC):
         # Ensure the URL is correctly formed, whether it's relative or absolute
         full_url = url if url.startswith("http") else f"{self.base_url.rstrip('/')}/{url.lstrip('/')}"
 
+        # Ensure headers are present and add a standard User-Agent to mimic a browser
+        headers = kwargs.get("headers", {})
+        if "User-Agent" not in headers:
+            headers["User-Agent"] = (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/107.0.0.0 Safari/537.36"
+            )
+        kwargs["headers"] = headers
+
         try:
             self.logger.info("Making request", method=method.upper(), url=full_url)
             response = await http_client.request(method, full_url, timeout=self.timeout, **kwargs)


### PR DESCRIPTION
This commit addresses the root cause of the adapter failures observed in the `unified-race-report.yml` workflow.

The logs showed that all reliable, non-keyed adapters were failing with various HTTP errors, most notably `403 Forbidden`. This is a classic sign of anti-bot measures on the target websites.

To resolve this, I have modified the `make_request` method in the `BaseAdapterV3` class to include a standard, browser-like `User-Agent` header with every outgoing request. This is a common and effective technique to make the requests appear as if they are coming from a legitimate user, thereby bypassing the anti-scraping protections.

This change is implemented in the base class to ensure that all current and future adapters will benefit from this fix.