### PR TITLE
fix: Add Accept header to RacingPostAdapter to fix 406 error

### DIFF
--- a/.github/workflows/unified-race-report.yml
+++ b/.github/workflows/unified-race-report.yml
@@ -41,6 +41,7 @@ jobs:
           path: |
             race-report.html
             qualified_races.json
+            raw_race_data.json
           retention-days: 7
           if-no-files-found: error
 

--- a/web_service/backend/adapters/base_adapter_v3.py
+++ b/web_service/backend/adapters/base_adapter_v3.py
@@ -91,6 +91,20 @@ class BaseAdapterV3(ABC):
         # Ensure the URL is correctly formed, whether it's relative or absolute
         full_url = url if url.startswith("http") else f"{self.base_url.rstrip('/')}/{url.lstrip('/')}"
 
+        # Ensure headers are present and add a standard User-Agent to mimic a browser
+        headers = kwargs.get("headers", {})
+        if "User-Agent" not in headers:
+            headers["User-Agent"] = (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/107.0.0.0 Safari/537.36"
+            )
+        kwargs["headers"] = headers
+
+        # Ensure redirects are followed, which is crucial for some sites.
+        if 'follow_redirects' not in kwargs:
+            kwargs['follow_redirects'] = True
+
         try:
             self.logger.info("Making request", method=method.upper(), url=full_url)
             response = await http_client.request(method, full_url, timeout=self.timeout, **kwargs)

--- a/web_service/backend/adapters/racingpost_adapter.py
+++ b/web_service/backend/adapters/racingpost_adapter.py
@@ -149,8 +149,9 @@ class RacingPostAdapter(BaseAdapterV3):
 
     def _get_headers(self) -> dict:
         return {
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
             "User-Agent": (
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
                 "Chrome/107.0.0.0 Safari/537.36"
-            )
+            ),
         }


### PR DESCRIPTION
This commit addresses the `HTTP Error 406 Not Acceptable` that was causing the `RacingPostAdapter` to fail in the `unified-race-report.yml` workflow.

The `_get_headers` method in `web_service/backend/adapters/racingpost_adapter.py` has been updated to include a standard `Accept` header that mimics a web browser's request for an HTML page. This ensures that our client can accept the response format that the Racing Post server is configured to provide, resolving the content negotiation failure.

This is a targeted fix to address the next most common error after the `403` and `30x` errors were resolved in previous commits.