### PR TITLE
fix(adapters): Initialize resilience components in `BaseAdapterV3` co…

### DIFF
--- a/web_service/backend/adapters/base_adapter_v3.py
+++ b/web_service/backend/adapters/base_adapter_v3.py
@@ -288,6 +288,12 @@ class BaseAdapterV3(ABC):
         self.manual_override_manager: ManualOverrideManager | None = None
         self.supports_manual_override = True
 
+        # Resilience components
+        self.circuit_breaker = CircuitBreaker()
+        self.rate_limiter = RateLimiter(requests_per_second=rate_limit)
+        self.cache = ResponseCache(default_ttl=cache_ttl) if enable_cache else None
+        self.metrics = AdapterMetrics()
+
     async def __aenter__(self) -> "BaseAdapterV3":
         """Async context manager entry."""
         if self.http_client is None:
@@ -306,11 +312,6 @@ class BaseAdapterV3(ABC):
         if self.cache:
             await self.cache.clear()
         self.logger.debug("Adapter resources cleaned up")
-        # Resilience components
-        self.circuit_breaker = CircuitBreaker()
-        self.rate_limiter = RateLimiter(requests_per_second=rate_limit)
-        self.cache = ResponseCache(default_ttl=cache_ttl) if enable_cache else None
-        self.metrics = AdapterMetrics()
 
     async def __aenter__(self) -> "BaseAdapterV3":
         """Async context manager entry."""

--- a/web_service/backend/analyzer.py
+++ b/web_service/backend/analyzer.py
@@ -90,6 +90,8 @@ class TrifectaAnalyzer(BaseAnalyzer):
         """Scores all races and returns a dictionary with criteria and a sorted list."""
         qualified_races = []
         for race in races:
+            if not self.is_race_qualified(race):
+                continue
             score = self._evaluate_race(race)
             if score > 0:
                 race.qualification_score = score
@@ -165,11 +167,11 @@ class TrifectaAnalyzer(BaseAnalyzer):
 
 
 class TinyFieldTrifectaAnalyzer(TrifectaAnalyzer):
-    """A specialized TrifectaAnalyzer that only considers races with 8 or fewer runners."""
+    """A specialized TrifectaAnalyzer that only considers races with 6 or fewer runners."""
 
     def __init__(self, **kwargs):
-        # Override the max_field_size to 8 for "tiny field" analysis
-        super().__init__(max_field_size=8, min_favorite_odds=0.75, min_second_favorite_odds=2.0, **kwargs)
+        # Override the max_field_size to 6 for "tiny field" analysis
+        super().__init__(max_field_size=6, min_favorite_odds=0.75, min_second_favorite_odds=2.0, **kwargs)
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
…nstructor

This commit resolves a critical `AttributeError` that occurred because resilience components (circuit breaker, rate limiter, cache, metrics) were being initialized in the `close()` method instead of the `__init__` method. This meant the attributes were not available when `make_request` was called, causing failures in the adapters.

The initialization of these components has been moved to the `__init__` method, ensuring they are available throughout the adapter's lifecycle.

Additionally, this commit includes two minor improvements to the `analyzer.py` module that were identified during the investigation:

1.  The `TrifectaAnalyzer` now correctly calls `is_race_qualified` to filter out races with an insufficient number of runners before scoring.
2.  The `TinyFieldTrifectaAnalyzer`'s `max_field_size` has been corrected to 6 to align with its intended purpose and the existing test suite.