### PR TITLE
chore: Add debugging to scraper adapters

### DIFF
--- a/.github/workflows/unified-race-report.yml
+++ b/.github/workflows/unified-race-report.yml
@@ -117,6 +117,8 @@ jobs:
             qualified_races.json
             raw_race_data.json
             reporter_output.log
+            atr_debug.html
+            sl_debug.html
           retention-days: ${{ env.REPORT_RETENTION_DAYS }}
           if-no-files-found: warn
           compression-level: 9

--- a/new_logs.txt
+++ b/new_logs.txt
@@ -1,0 +1,841 @@
+﻿2026-01-22T23:37:20.7894655Z Current runner version: '2.331.0'
+2026-01-22T23:37:20.7929379Z ##[group]Runner Image Provisioner
+2026-01-22T23:37:20.7930680Z Hosted Compute Agent
+2026-01-22T23:37:20.7931507Z Version: 20260115.477
+2026-01-22T23:37:20.7932413Z Commit: 4b342d620503cbe250a3154040964899ea7c9b00
+2026-01-22T23:37:20.7933597Z Build Date: 2026-01-15T22:32:41Z
+2026-01-22T23:37:20.7934625Z Worker ID: {35ff6832-534e-4dac-9323-bc3b24874430}
+2026-01-22T23:37:20.7935968Z Azure Region: eastus2
+2026-01-22T23:37:20.7936914Z ##[endgroup]
+2026-01-22T23:37:20.7939161Z ##[group]Operating System
+2026-01-22T23:37:20.7940046Z Ubuntu
+2026-01-22T23:37:20.7940825Z 24.04.3
+2026-01-22T23:37:20.7941495Z LTS
+2026-01-22T23:37:20.7942196Z ##[endgroup]
+2026-01-22T23:37:20.7943624Z ##[group]Runner Image
+2026-01-22T23:37:20.7944464Z Image: ubuntu-24.04
+2026-01-22T23:37:20.7945241Z Version: 20260119.4.1
+2026-01-22T23:37:20.7947386Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260119.4/images/ubuntu/Ubuntu2404-Readme.md
+2026-01-22T23:37:20.7949807Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260119.4
+2026-01-22T23:37:20.7951433Z ##[endgroup]
+2026-01-22T23:37:20.7953127Z ##[group]GITHUB_TOKEN Permissions
+2026-01-22T23:37:20.7956222Z Actions: write
+2026-01-22T23:37:20.7957036Z Contents: read
+2026-01-22T23:37:20.7957824Z Metadata: read
+2026-01-22T23:37:20.7958637Z ##[endgroup]
+2026-01-22T23:37:20.7961495Z Secret source: Actions
+2026-01-22T23:37:20.7962831Z Prepare workflow directory
+2026-01-22T23:37:20.8514130Z Prepare all required actions
+2026-01-22T23:37:20.8570870Z Getting action download info
+2026-01-22T23:37:21.2020933Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+2026-01-22T23:37:21.3345236Z Download action repository 'actions/setup-python@v5' (SHA:a26af69be951a213d495a4c3e4e4022e16d87065)
+2026-01-22T23:37:21.4525216Z Download action repository 'actions/cache@v4' (SHA:0057852bfaa89a56745cba8c7296529d2fc39830)
+2026-01-22T23:37:21.6088345Z Download action repository 'actions/upload-artifact@v4' (SHA:ea165f8d65b6e75b540449e92b4886f43607fa02)
+2026-01-22T23:37:21.8576760Z Complete job name: generate-unified-report
+2026-01-22T23:37:21.9467982Z ##[group]Run actions/checkout@v4
+2026-01-22T23:37:21.9469338Z with:
+2026-01-22T23:37:21.9470081Z   fetch-depth: 1
+2026-01-22T23:37:21.9470898Z   repository: masonj0/fortuna
+2026-01-22T23:37:21.9472182Z   token: ***
+2026-01-22T23:37:21.9472941Z   ssh-strict: true
+2026-01-22T23:37:21.9473732Z   ssh-user: git
+2026-01-22T23:37:21.9474545Z   persist-credentials: true
+2026-01-22T23:37:21.9475609Z   clean: true
+2026-01-22T23:37:21.9476503Z   sparse-checkout-cone-mode: true
+2026-01-22T23:37:21.9477503Z   fetch-tags: false
+2026-01-22T23:37:21.9478322Z   show-progress: true
+2026-01-22T23:37:21.9479144Z   lfs: false
+2026-01-22T23:37:21.9479900Z   submodules: false
+2026-01-22T23:37:21.9480722Z   set-safe-directory: true
+2026-01-22T23:37:21.9481900Z env:
+2026-01-22T23:37:21.9482629Z   PYTHON_VERSION: 3.11
+2026-01-22T23:37:21.9483527Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:37:21.9484411Z   MAX_RETRIES: 3
+2026-01-22T23:37:21.9485183Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:37:21.9486289Z ##[endgroup]
+2026-01-22T23:37:22.0598636Z Syncing repository: masonj0/fortuna
+2026-01-22T23:37:22.0601289Z ##[group]Getting Git version info
+2026-01-22T23:37:22.0602566Z Working directory is '/home/runner/work/fortuna/fortuna'
+2026-01-22T23:37:22.0604390Z [command]/usr/bin/git version
+2026-01-22T23:37:22.0684918Z git version 2.52.0
+2026-01-22T23:37:22.0712923Z ##[endgroup]
+2026-01-22T23:37:22.0736324Z Temporarily overriding HOME='/home/runner/work/_temp/a37e3886-5636-4705-a644-2a3061f20be6' before making global git config changes
+2026-01-22T23:37:22.0739127Z Adding repository directory to the temporary git global config as a safe directory
+2026-01-22T23:37:22.0741770Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/fortuna/fortuna
+2026-01-22T23:37:22.0784758Z Deleting the contents of '/home/runner/work/fortuna/fortuna'
+2026-01-22T23:37:22.0789005Z ##[group]Initializing the repository
+2026-01-22T23:37:22.0792864Z [command]/usr/bin/git init /home/runner/work/fortuna/fortuna
+2026-01-22T23:37:22.0907108Z hint: Using 'master' as the name for the initial branch. This default branch name
+2026-01-22T23:37:22.0909559Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2026-01-22T23:37:22.0912434Z hint: to use in all of your new repositories, which will suppress this warning,
+2026-01-22T23:37:22.0914345Z hint: call:
+2026-01-22T23:37:22.0915316Z hint:
+2026-01-22T23:37:22.0917132Z hint: 	git config --global init.defaultBranch <name>
+2026-01-22T23:37:22.0918756Z hint:
+2026-01-22T23:37:22.0920238Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2026-01-22T23:37:22.0923159Z hint: 'development'. The just-created branch can be renamed via this command:
+2026-01-22T23:37:22.0925081Z hint:
+2026-01-22T23:37:22.0925998Z hint: 	git branch -m <name>
+2026-01-22T23:37:22.0926891Z hint:
+2026-01-22T23:37:22.0928128Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2026-01-22T23:37:22.0930096Z Initialized empty Git repository in /home/runner/work/fortuna/fortuna/.git/
+2026-01-22T23:37:22.0933168Z [command]/usr/bin/git remote add origin https://github.com/masonj0/fortuna
+2026-01-22T23:37:22.0961173Z ##[endgroup]
+2026-01-22T23:37:22.0962917Z ##[group]Disabling automatic garbage collection
+2026-01-22T23:37:22.0965225Z [command]/usr/bin/git config --local gc.auto 0
+2026-01-22T23:37:22.0996995Z ##[endgroup]
+2026-01-22T23:37:22.0999284Z ##[group]Setting up auth
+2026-01-22T23:37:22.1005189Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-01-22T23:37:22.1039192Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-01-22T23:37:22.1410423Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-01-22T23:37:22.1442141Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-01-22T23:37:22.1667117Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-01-22T23:37:22.1700816Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-01-22T23:37:22.1930031Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2026-01-22T23:37:22.1966934Z ##[endgroup]
+2026-01-22T23:37:22.1968358Z ##[group]Fetching the repository
+2026-01-22T23:37:22.1976388Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +6eb423d64d88a6c576091ac553bb46116d1fb085:refs/remotes/origin/main
+2026-01-22T23:37:22.5327184Z From https://github.com/masonj0/fortuna
+2026-01-22T23:37:22.5328438Z  * [new ref]         6eb423d64d88a6c576091ac553bb46116d1fb085 -> origin/main
+2026-01-22T23:37:22.5360496Z ##[endgroup]
+2026-01-22T23:37:22.5361109Z ##[group]Determining the checkout info
+2026-01-22T23:37:22.5363212Z ##[endgroup]
+2026-01-22T23:37:22.5368685Z [command]/usr/bin/git sparse-checkout disable
+2026-01-22T23:37:22.5410952Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2026-01-22T23:37:22.5436676Z ##[group]Checking out the ref
+2026-01-22T23:37:22.5440729Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+2026-01-22T23:37:22.5895927Z Switched to a new branch 'main'
+2026-01-22T23:37:22.5896723Z branch 'main' set up to track 'origin/main'.
+2026-01-22T23:37:22.5906041Z ##[endgroup]
+2026-01-22T23:37:22.5946619Z [command]/usr/bin/git log -1 --format=%H
+2026-01-22T23:37:22.5969498Z 6eb423d64d88a6c576091ac553bb46116d1fb085
+2026-01-22T23:37:22.6192073Z ##[group]Run actions/setup-python@v5
+2026-01-22T23:37:22.6192692Z with:
+2026-01-22T23:37:22.6192930Z   python-version: 3.11
+2026-01-22T23:37:22.6193193Z   cache: pip
+2026-01-22T23:37:22.6193521Z   cache-dependency-path: web_service/backend/requirements.txt
+2026-01-22T23:37:22.6193916Z   check-latest: false
+2026-01-22T23:37:22.6194305Z   token: ***
+2026-01-22T23:37:22.6194563Z   update-environment: true
+2026-01-22T23:37:22.6194858Z   allow-prereleases: false
+2026-01-22T23:37:22.6195123Z   freethreaded: false
+2026-01-22T23:37:22.6195368Z env:
+2026-01-22T23:37:22.6195881Z   PYTHON_VERSION: 3.11
+2026-01-22T23:37:22.6196154Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:37:22.6196406Z   MAX_RETRIES: 3
+2026-01-22T23:37:22.6196649Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:37:22.6196884Z ##[endgroup]
+2026-01-22T23:37:22.7967351Z ##[group]Installed versions
+2026-01-22T23:37:22.8078402Z Successfully set up CPython (3.11.14)
+2026-01-22T23:37:22.8079461Z ##[endgroup]
+2026-01-22T23:37:22.8531401Z [command]/opt/hostedtoolcache/Python/3.11.14/x64/bin/pip cache dir
+2026-01-22T23:37:24.2079696Z /home/runner/.cache/pip
+2026-01-22T23:37:24.3320038Z Cache hit for: setup-python-Linux-x64-24.04-Ubuntu-python-3.11.14-pip-9b33d885a72e4a79c39d67e0d38fd2891ce0392a75a496cd6973c98dee5ac231
+2026-01-22T23:37:25.3927881Z Received 222298112 of 474921379 (46.8%), 211.8 MBs/sec
+2026-01-22T23:37:26.3989204Z Received 448790528 of 474921379 (94.5%), 213.8 MBs/sec
+2026-01-22T23:37:26.5056505Z Received 474921379 of 474921379 (100.0%), 214.2 MBs/sec
+2026-01-22T23:37:26.5060465Z Cache Size: ~453 MB (474921379 B)
+2026-01-22T23:37:26.5290245Z [command]/usr/bin/tar -xf /home/runner/work/_temp/1144cee4-7af3-4d99-b0e6-8b40165537d3/cache.tzst -P -C /home/runner/work/fortuna/fortuna --use-compress-program unzstd
+2026-01-22T23:37:27.3942339Z Cache restored successfully
+2026-01-22T23:37:27.4848302Z Cache restored from key: setup-python-Linux-x64-24.04-Ubuntu-python-3.11.14-pip-9b33d885a72e4a79c39d67e0d38fd2891ce0392a75a496cd6973c98dee5ac231
+2026-01-22T23:37:27.5059264Z ##[group]Run python -m pip install --upgrade pip setuptools wheel
+2026-01-22T23:37:27.5059909Z [36;1mpython -m pip install --upgrade pip setuptools wheel[0m
+2026-01-22T23:37:27.5060350Z [36;1mpip install -r web_service/backend/requirements.txt[0m
+2026-01-22T23:37:27.5098727Z shell: /usr/bin/bash -e {0}
+2026-01-22T23:37:27.5099006Z env:
+2026-01-22T23:37:27.5099206Z   PYTHON_VERSION: 3.11
+2026-01-22T23:37:27.5099456Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:37:27.5099682Z   MAX_RETRIES: 3
+2026-01-22T23:37:27.5099879Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:37:27.5100157Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:27.5100587Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-22T23:37:27.5101032Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:27.5101411Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:27.5101830Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:27.5102215Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-22T23:37:27.5102539Z ##[endgroup]
+2026-01-22T23:37:28.8225119Z Requirement already satisfied: pip in /opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages (25.3)
+2026-01-22T23:37:28.9358762Z Requirement already satisfied: setuptools in /opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages (79.0.1)
+2026-01-22T23:37:29.0621743Z Collecting setuptools
+2026-01-22T23:37:29.0639039Z   Using cached setuptools-80.10.1-py3-none-any.whl.metadata (6.7 kB)
+2026-01-22T23:37:29.1036845Z Collecting wheel
+2026-01-22T23:37:29.1712125Z   Downloading wheel-0.46.3-py3-none-any.whl.metadata (2.4 kB)
+2026-01-22T23:37:29.2032620Z Collecting packaging>=24.0 (from wheel)
+2026-01-22T23:37:29.2109456Z   Downloading packaging-26.0-py3-none-any.whl.metadata (3.3 kB)
+2026-01-22T23:37:29.2162216Z Using cached setuptools-80.10.1-py3-none-any.whl (1.1 MB)
+2026-01-22T23:37:29.2254823Z Downloading wheel-0.46.3-py3-none-any.whl (30 kB)
+2026-01-22T23:37:29.2452632Z Downloading packaging-26.0-py3-none-any.whl (74 kB)
+2026-01-22T23:37:29.2899766Z Installing collected packages: setuptools, packaging, wheel
+2026-01-22T23:37:29.2905819Z   Attempting uninstall: setuptools
+2026-01-22T23:37:29.2920698Z     Found existing installation: setuptools 79.0.1
+2026-01-22T23:37:29.6734564Z     Uninstalling setuptools-79.0.1:
+2026-01-22T23:37:29.7112319Z       Successfully uninstalled setuptools-79.0.1
+2026-01-22T23:37:30.5222769Z
+2026-01-22T23:37:30.5232960Z Successfully installed packaging-26.0 setuptools-80.10.1 wheel-0.46.3
+2026-01-22T23:37:31.4956051Z Collecting fastapi==0.104.1 (from -r web_service/backend/requirements.txt (line 11))
+2026-01-22T23:37:31.4971411Z   Using cached fastapi-0.104.1-py3-none-any.whl.metadata (24 kB)
+2026-01-22T23:37:31.5282100Z Collecting uvicorn==0.24.0 (from uvicorn[standard]==0.24.0->-r web_service/backend/requirements.txt (line 12))
+2026-01-22T23:37:31.5297914Z   Using cached uvicorn-0.24.0-py3-none-any.whl.metadata (6.4 kB)
+2026-01-22T23:37:31.5607858Z Collecting starlette==0.27.0 (from -r web_service/backend/requirements.txt (line 13))
+2026-01-22T23:37:31.5622460Z   Using cached starlette-0.27.0-py3-none-any.whl.metadata (5.8 kB)
+2026-01-22T23:37:31.6756398Z Collecting pydantic==2.5.0 (from -r web_service/backend/requirements.txt (line 14))
+2026-01-22T23:37:31.6773186Z   Using cached pydantic-2.5.0-py3-none-any.whl.metadata (174 kB)
+2026-01-22T23:37:32.3266752Z Collecting pydantic-core==2.14.1 (from -r web_service/backend/requirements.txt (line 15))
+2026-01-22T23:37:32.3283522Z   Using cached pydantic_core-2.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.5 kB)
+2026-01-22T23:37:32.3450823Z Collecting pydantic-settings==2.1.0 (from -r web_service/backend/requirements.txt (line 16))
+2026-01-22T23:37:32.3466177Z   Using cached pydantic_settings-2.1.0-py3-none-any.whl.metadata (2.9 kB)
+2026-01-22T23:37:32.3685976Z Collecting anyio==3.7.1 (from -r web_service/backend/requirements.txt (line 19))
+2026-01-22T23:37:32.3700889Z   Using cached anyio-3.7.1-py3-none-any.whl.metadata (4.7 kB)
+2026-01-22T23:37:32.3857501Z Collecting h11==0.14.0 (from -r web_service/backend/requirements.txt (line 20))
+2026-01-22T23:37:32.3872224Z   Using cached h11-0.14.0-py3-none-any.whl.metadata (8.2 kB)
+2026-01-22T23:37:32.4047328Z Collecting h2==4.1.0 (from -r web_service/backend/requirements.txt (line 21))
+2026-01-22T23:37:32.4061901Z   Using cached h2-4.1.0-py3-none-any.whl.metadata (3.6 kB)
+2026-01-22T23:37:32.4188101Z Collecting hpack==4.0.0 (from -r web_service/backend/requirements.txt (line 22))
+2026-01-22T23:37:32.4202211Z   Using cached hpack-4.0.0-py3-none-any.whl.metadata (2.5 kB)
+2026-01-22T23:37:32.4685799Z Collecting httpcore==1.0.2 (from -r web_service/backend/requirements.txt (line 23))
+2026-01-22T23:37:32.4700990Z   Using cached httpcore-1.0.2-py3-none-any.whl.metadata (20 kB)
+2026-01-22T23:37:32.5025126Z Collecting httptools==0.6.1 (from -r web_service/backend/requirements.txt (line 24))
+2026-01-22T23:37:32.5041746Z   Using cached httptools-0.6.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (3.6 kB)
+2026-01-22T23:37:32.5250648Z Collecting httpx==0.25.2 (from -r web_service/backend/requirements.txt (line 25))
+2026-01-22T23:37:32.5266116Z   Using cached httpx-0.25.2-py3-none-any.whl.metadata (6.9 kB)
+2026-01-22T23:37:32.5411892Z Collecting hyperframe==6.1.0 (from -r web_service/backend/requirements.txt (line 26))
+2026-01-22T23:37:32.5426449Z   Using cached hyperframe-6.1.0-py3-none-any.whl.metadata (4.3 kB)
+2026-01-22T23:37:32.6292159Z Collecting websockets==12.0 (from -r web_service/backend/requirements.txt (line 27))
+2026-01-22T23:37:32.6308999Z   Using cached websockets-12.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.6 kB)
+2026-01-22T23:37:32.6443074Z Collecting wsproto==1.2.0 (from -r web_service/backend/requirements.txt (line 28))
+2026-01-22T23:37:32.6457553Z   Using cached wsproto-1.2.0-py3-none-any.whl.metadata (5.6 kB)
+2026-01-22T23:37:32.6720630Z Collecting requests==2.31.0 (from -r web_service/backend/requirements.txt (line 31))
+2026-01-22T23:37:32.6735325Z   Using cached requests-2.31.0-py3-none-any.whl.metadata (4.6 kB)
+2026-01-22T23:37:32.6997079Z Collecting urllib3==2.1.0 (from -r web_service/backend/requirements.txt (line 32))
+2026-01-22T23:37:32.7011746Z   Using cached urllib3-2.1.0-py3-none-any.whl.metadata (6.4 kB)
+2026-01-22T23:37:32.7214775Z Collecting certifi==2023.7.22 (from -r web_service/backend/requirements.txt (line 33))
+2026-01-22T23:37:32.7229184Z   Using cached certifi-2023.7.22-py3-none-any.whl.metadata (2.2 kB)
+2026-01-22T23:37:32.8017973Z Collecting charset-normalizer==3.3.2 (from -r web_service/backend/requirements.txt (line 34))
+2026-01-22T23:37:32.8034433Z   Using cached charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (33 kB)
+2026-01-22T23:37:32.8195719Z Collecting idna==3.6 (from -r web_service/backend/requirements.txt (line 35))
+2026-01-22T23:37:32.8210173Z   Using cached idna-3.6-py3-none-any.whl.metadata (9.9 kB)
+2026-01-22T23:37:33.1626761Z Collecting sqlalchemy==2.0.23 (from -r web_service/backend/requirements.txt (line 38))
+2026-01-22T23:37:33.1642750Z   Using cached SQLAlchemy-2.0.23-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (9.6 kB)
+2026-01-22T23:37:33.2890973Z Collecting greenlet==3.0.2 (from -r web_service/backend/requirements.txt (line 39))
+2026-01-22T23:37:33.2907418Z   Using cached greenlet-3.0.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl.metadata (3.7 kB)
+2026-01-22T23:37:33.3060646Z Collecting aiosqlite==0.19.0 (from -r web_service/backend/requirements.txt (line 40))
+2026-01-22T23:37:33.3074471Z   Using cached aiosqlite-0.19.0-py3-none-any.whl.metadata (4.3 kB)
+2026-01-22T23:37:33.3723399Z Collecting psycopg2-binary==2.9.9 (from -r web_service/backend/requirements.txt (line 41))
+2026-01-22T23:37:33.3740059Z   Using cached psycopg2_binary-2.9.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.4 kB)
+2026-01-22T23:37:33.6080692Z Collecting numpy==1.24.3 (from -r web_service/backend/requirements.txt (line 44))
+2026-01-22T23:37:33.6096367Z   Using cached numpy-1.24.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (5.6 kB)
+2026-01-22T23:37:33.7312555Z Collecting pandas==2.0.3 (from -r web_service/backend/requirements.txt (line 45))
+2026-01-22T23:37:33.7328351Z   Using cached pandas-2.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (18 kB)
+2026-01-22T23:37:33.7615083Z Collecting python-dateutil==2.8.2 (from -r web_service/backend/requirements.txt (line 46))
+2026-01-22T23:37:33.7629664Z   Using cached python_dateutil-2.8.2-py2.py3-none-any.whl.metadata (8.2 kB)
+2026-01-22T23:37:33.7994618Z Collecting pytz==2023.3.post1 (from -r web_service/backend/requirements.txt (line 47))
+2026-01-22T23:37:33.8009464Z   Using cached pytz-2023.3.post1-py2.py3-none-any.whl.metadata (22 kB)
+2026-01-22T23:37:33.8173182Z Collecting tzdata==2023.3 (from -r web_service/backend/requirements.txt (line 48))
+2026-01-22T23:37:33.8187373Z   Using cached tzdata-2023.3-py2.py3-none-any.whl.metadata (1.4 kB)
+2026-01-22T23:37:33.8324220Z Collecting six==1.16.0 (from -r web_service/backend/requirements.txt (line 49))
+2026-01-22T23:37:33.8338833Z   Using cached six-1.16.0-py2.py3-none-any.whl.metadata (1.8 kB)
+2026-01-22T23:37:33.8514807Z Collecting beautifulsoup4==4.12.2 (from -r web_service/backend/requirements.txt (line 52))
+2026-01-22T23:37:33.8529048Z   Using cached beautifulsoup4-4.12.2-py3-none-any.whl.metadata (3.6 kB)
+2026-01-22T23:37:33.8716385Z Collecting soupsieve==2.5 (from -r web_service/backend/requirements.txt (line 53))
+2026-01-22T23:37:33.8731033Z   Using cached soupsieve-2.5-py3-none-any.whl.metadata (4.7 kB)
+2026-01-22T23:37:33.9900921Z Collecting selectolax==0.3.20 (from -r web_service/backend/requirements.txt (line 54))
+2026-01-22T23:37:33.9917744Z   Using cached selectolax-0.3.20-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (5.6 kB)
+2026-01-22T23:37:34.0115167Z Collecting click==8.1.7 (from -r web_service/backend/requirements.txt (line 57))
+2026-01-22T23:37:34.0129810Z   Using cached click-8.1.7-py3-none-any.whl.metadata (3.0 kB)
+2026-01-22T23:37:34.0307160Z Collecting python-dotenv==1.0.0 (from -r web_service/backend/requirements.txt (line 58))
+2026-01-22T23:37:34.0322205Z   Using cached python_dotenv-1.0.0-py3-none-any.whl.metadata (21 kB)
+2026-01-22T23:37:34.0714661Z Collecting pyyaml==6.0.1 (from -r web_service/backend/requirements.txt (line 59))
+2026-01-22T23:37:34.0730666Z   Using cached PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.1 kB)
+2026-01-22T23:37:34.3103844Z Collecting cryptography==41.0.7 (from -r web_service/backend/requirements.txt (line 62))
+2026-01-22T23:37:34.3119942Z   Using cached cryptography-41.0.7-cp37-abi3-manylinux_2_28_x86_64.whl.metadata (5.2 kB)
+2026-01-22T23:37:34.4162174Z Collecting cffi==1.16.0 (from -r web_service/backend/requirements.txt (line 63))
+2026-01-22T23:37:34.4178573Z   Using cached cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.5 kB)
+2026-01-22T23:37:34.4318227Z Collecting pycparser==2.21 (from -r web_service/backend/requirements.txt (line 64))
+2026-01-22T23:37:34.4332327Z   Using cached pycparser-2.21-py2.py3-none-any.whl.metadata (1.1 kB)
+2026-01-22T23:37:34.4461406Z Collecting secretstorage==3.5.0 (from -r web_service/backend/requirements.txt (line 65))
+2026-01-22T23:37:34.4476286Z   Using cached secretstorage-3.5.0-py3-none-any.whl.metadata (4.0 kB)
+2026-01-22T23:37:34.4800306Z Collecting keyring==24.3.0 (from -r web_service/backend/requirements.txt (line 66))
+2026-01-22T23:37:34.4815366Z   Using cached keyring-24.3.0-py3-none-any.whl.metadata (20 kB)
+2026-01-22T23:37:34.4979603Z Collecting jeepney==0.9.0 (from -r web_service/backend/requirements.txt (line 67))
+2026-01-22T23:37:34.4993819Z   Using cached jeepney-0.9.0-py3-none-any.whl.metadata (1.2 kB)
+2026-01-22T23:37:34.5268785Z Collecting redis==5.0.1 (from -r web_service/backend/requirements.txt (line 70))
+2026-01-22T23:37:34.5282561Z   Using cached redis-5.0.1-py3-none-any.whl.metadata (8.9 kB)
+2026-01-22T23:37:34.5521183Z Collecting limits==3.7.0 (from -r web_service/backend/requirements.txt (line 71))
+2026-01-22T23:37:34.5535718Z   Using cached limits-3.7.0-py3-none-any.whl.metadata (7.3 kB)
+2026-01-22T23:37:34.5709984Z Collecting slowapi==0.1.9 (from -r web_service/backend/requirements.txt (line 72))
+2026-01-22T23:37:34.5724378Z   Using cached slowapi-0.1.9-py3-none-any.whl.metadata (3.0 kB)
+2026-01-22T23:37:34.5899966Z Collecting tenacity==8.2.3 (from -r web_service/backend/requirements.txt (line 73))
+2026-01-22T23:37:34.5914170Z   Using cached tenacity-8.2.3-py3-none-any.whl.metadata (1.0 kB)
+2026-01-22T23:37:34.6122781Z Collecting pywebview==5.4 (from -r web_service/backend/requirements.txt (line 76))
+2026-01-22T23:37:34.6137103Z   Using cached pywebview-5.4-py3-none-any.whl.metadata (4.5 kB)
+2026-01-22T23:37:34.6346559Z Collecting bottle==0.13.4 (from -r web_service/backend/requirements.txt (line 77))
+2026-01-22T23:37:34.6360912Z   Using cached bottle-0.13.4-py2.py3-none-any.whl.metadata (1.6 kB)
+2026-01-22T23:37:34.6486516Z Collecting proxy-tools==0.1.0 (from -r web_service/backend/requirements.txt (line 78))
+2026-01-22T23:37:34.6488095Z   Using cached proxy_tools-0.1.0-py3-none-any.whl
+2026-01-22T23:37:34.7219006Z Collecting psutil==5.9.6 (from -r web_service/backend/requirements.txt (line 82))
+2026-01-22T23:37:34.7235745Z   Using cached psutil-5.9.6-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (21 kB)
+2026-01-22T23:37:34.7418801Z Collecting structlog==23.2.0 (from -r web_service/backend/requirements.txt (line 85))
+2026-01-22T23:37:34.7433535Z   Using cached structlog-23.2.0-py3-none-any.whl.metadata (7.6 kB)
+2026-01-22T23:37:34.7959429Z Collecting black==23.12.0 (from -r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:37:34.7975773Z   Using cached black-23.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (68 kB)
+2026-01-22T23:37:34.8485233Z Collecting pyinstaller==6.1.0 (from -r web_service/backend/requirements.txt (line 89))
+2026-01-22T23:37:34.8501664Z   Using cached pyinstaller-6.1.0-py3-none-manylinux2014_x86_64.whl.metadata (8.2 kB)
+2026-01-22T23:37:34.8734603Z Collecting pyinstaller-hooks-contrib==2023.11 (from -r web_service/backend/requirements.txt (line 90))
+2026-01-22T23:37:34.8750361Z   Using cached pyinstaller_hooks_contrib-2023.11-py2.py3-none-any.whl.metadata (15 kB)
+2026-01-22T23:37:34.8888346Z Collecting altgraph==0.17.3 (from -r web_service/backend/requirements.txt (line 91))
+2026-01-22T23:37:34.8902368Z   Using cached altgraph-0.17.3-py2.py3-none-any.whl.metadata (7.4 kB)
+2026-01-22T23:37:34.9121594Z Collecting wheel==0.41.2 (from -r web_service/backend/requirements.txt (line 92))
+2026-01-22T23:37:34.9136073Z   Using cached wheel-0.41.2-py3-none-any.whl.metadata (2.2 kB)
+2026-01-22T23:37:34.9291374Z Collecting build==1.0.3 (from -r web_service/backend/requirements.txt (line 93))
+2026-01-22T23:37:34.9305355Z   Using cached build-1.0.3-py3-none-any.whl.metadata (4.2 kB)
+2026-01-22T23:37:34.9608024Z Collecting pip-tools==7.3.0 (from -r web_service/backend/requirements.txt (line 94))
+2026-01-22T23:37:34.9622018Z   Using cached pip_tools-7.3.0-py3-none-any.whl.metadata (23 kB)
+2026-01-22T23:37:34.9973312Z Collecting pytest==7.4.3 (from -r web_service/backend/requirements.txt (line 97))
+2026-01-22T23:37:34.9987571Z   Using cached pytest-7.4.3-py3-none-any.whl.metadata (7.9 kB)
+2026-01-22T23:37:35.0218151Z Collecting pytest-asyncio==0.21.1 (from -r web_service/backend/requirements.txt (line 98))
+2026-01-22T23:37:35.0233291Z   Using cached pytest_asyncio-0.21.1-py3-none-any.whl.metadata (4.0 kB)
+2026-01-22T23:37:35.0366059Z Collecting iniconfig==2.0.0 (from -r web_service/backend/requirements.txt (line 99))
+2026-01-22T23:37:35.0380829Z   Using cached iniconfig-2.0.0-py3-none-any.whl.metadata (2.6 kB)
+2026-01-22T23:37:35.0519826Z Collecting pluggy==1.3.0 (from -r web_service/backend/requirements.txt (line 100))
+2026-01-22T23:37:35.0533788Z   Using cached pluggy-1.3.0-py3-none-any.whl.metadata (4.3 kB)
+2026-01-22T23:37:35.0715827Z Collecting packaging==23.2 (from -r web_service/backend/requirements.txt (line 101))
+2026-01-22T23:37:35.0730469Z   Using cached packaging-23.2-py3-none-any.whl.metadata (3.2 kB)
+2026-01-22T23:37:35.0915319Z Collecting typing-extensions==4.8.0 (from -r web_service/backend/requirements.txt (line 104))
+2026-01-22T23:37:35.0930385Z   Using cached typing_extensions-4.8.0-py3-none-any.whl.metadata (3.0 kB)
+2026-01-22T23:37:35.1063271Z Collecting typing-inspect==0.9.0 (from -r web_service/backend/requirements.txt (line 105))
+2026-01-22T23:37:35.1077982Z   Using cached typing_inspect-0.9.0-py3-none-any.whl.metadata (1.5 kB)
+2026-01-22T23:37:35.1202036Z Collecting annotated-types==0.6.0 (from -r web_service/backend/requirements.txt (line 106))
+2026-01-22T23:37:35.1216160Z   Using cached annotated_types-0.6.0-py3-none-any.whl.metadata (12 kB)
+2026-01-22T23:37:35.1341397Z Collecting mypy-extensions==1.0.0 (from -r web_service/backend/requirements.txt (line 109))
+2026-01-22T23:37:35.1356749Z   Using cached mypy_extensions-1.0.0-py3-none-any.whl.metadata (1.1 kB)
+2026-01-22T23:37:35.1496679Z Collecting pathspec==0.11.2 (from -r web_service/backend/requirements.txt (line 110))
+2026-01-22T23:37:35.1510330Z   Using cached pathspec-0.11.2-py3-none-any.whl.metadata (19 kB)
+2026-01-22T23:37:35.1696909Z Collecting platformdirs==4.0.0 (from -r web_service/backend/requirements.txt (line 111))
+2026-01-22T23:37:35.1710559Z   Using cached platformdirs-4.0.0-py3-none-any.whl.metadata (11 kB)
+2026-01-22T23:37:35.1914022Z Collecting more-itertools==10.1.0 (from -r web_service/backend/requirements.txt (line 112))
+2026-01-22T23:37:35.1928550Z   Using cached more_itertools-10.1.0-py3-none-any.whl.metadata (33 kB)
+2026-01-22T23:37:35.2074838Z Collecting jaraco.classes==3.3.1 (from -r web_service/backend/requirements.txt (line 113))
+2026-01-22T23:37:35.2091880Z   Using cached jaraco.classes-3.3.1-py3-none-any.whl.metadata (2.7 kB)
+2026-01-22T23:37:35.2238225Z Collecting jaraco.context==5.3.0 (from -r web_service/backend/requirements.txt (line 114))
+2026-01-22T23:37:35.2251720Z   Using cached jaraco.context-5.3.0-py3-none-any.whl.metadata (4.0 kB)
+2026-01-22T23:37:35.2429171Z Collecting jaraco.functools==4.0.0 (from -r web_service/backend/requirements.txt (line 115))
+2026-01-22T23:37:35.2442607Z   Using cached jaraco.functools-4.0.0-py3-none-any.whl.metadata (3.1 kB)
+2026-01-22T23:37:35.2589943Z Collecting deprecated==1.2.14 (from -r web_service/backend/requirements.txt (line 116))
+2026-01-22T23:37:35.2603149Z   Using cached Deprecated-1.2.14-py2.py3-none-any.whl.metadata (5.4 kB)
+2026-01-22T23:37:35.2728237Z Collecting sniffio==1.3.0 (from -r web_service/backend/requirements.txt (line 117))
+2026-01-22T23:37:35.2742767Z   Using cached sniffio-1.3.0-py3-none-any.whl.metadata (3.6 kB)
+2026-01-22T23:37:35.4913335Z Collecting wrapt==1.16.0 (from -r web_service/backend/requirements.txt (line 118))
+2026-01-22T23:37:35.4928842Z   Using cached wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.6 kB)
+2026-01-22T23:37:35.5651976Z Collecting watchfiles==0.20.0 (from -r web_service/backend/requirements.txt (line 119))
+2026-01-22T23:37:35.5667596Z   Using cached watchfiles-0.20.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.9 kB)
+2026-01-22T23:37:35.5876721Z Collecting pygments==2.17.2 (from -r web_service/backend/requirements.txt (line 120))
+2026-01-22T23:37:35.5890834Z   Using cached pygments-2.17.2-py3-none-any.whl.metadata (2.6 kB)
+2026-01-22T23:37:35.8351483Z Collecting importlib-metadata>=4.11.4 (from keyring==24.3.0->-r web_service/backend/requirements.txt (line 66))
+2026-01-22T23:37:35.8366044Z   Using cached importlib_metadata-8.7.1-py3-none-any.whl.metadata (4.7 kB)
+2026-01-22T23:37:35.8759355Z Collecting importlib-resources>=1.3 (from limits==3.7.0->-r web_service/backend/requirements.txt (line 71))
+2026-01-22T23:37:35.8774153Z   Using cached importlib_resources-6.5.2-py3-none-any.whl.metadata (3.9 kB)
+2026-01-22T23:37:36.4842173Z Collecting aiohttp>=3.7.4 (from black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:37:36.4857884Z   Using cached aiohttp-3.13.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (8.1 kB)
+2026-01-22T23:37:36.4914406Z Requirement already satisfied: setuptools>=42.0.0 in /opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages (from pyinstaller==6.1.0->-r web_service/backend/requirements.txt (line 89)) (80.10.1)
+2026-01-22T23:37:36.5206768Z Collecting pyproject_hooks (from build==1.0.3->-r web_service/backend/requirements.txt (line 93))
+2026-01-22T23:37:36.5220623Z   Using cached pyproject_hooks-1.2.0-py3-none-any.whl.metadata (1.3 kB)
+2026-01-22T23:37:36.5262209Z Requirement already satisfied: pip>=22.2 in /opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages (from pip-tools==7.3.0->-r web_service/backend/requirements.txt (line 94)) (25.3)
+2026-01-22T23:37:36.5814660Z Collecting backports.tarfile (from jaraco.context==5.3.0->-r web_service/backend/requirements.txt (line 114))
+2026-01-22T23:37:36.5829057Z   Using cached backports.tarfile-1.2.0-py3-none-any.whl.metadata (2.0 kB)
+2026-01-22T23:37:36.6555699Z Collecting uvloop!=0.15.0,!=0.15.1,>=0.14.0 (from uvicorn[standard]==0.24.0->-r web_service/backend/requirements.txt (line 12))
+2026-01-22T23:37:36.6571645Z   Using cached uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (4.9 kB)
+2026-01-22T23:37:36.6830746Z Collecting aiohappyeyeballs>=2.5.0 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:37:36.6852036Z   Using cached aiohappyeyeballs-2.6.1-py3-none-any.whl.metadata (5.9 kB)
+2026-01-22T23:37:36.6972603Z Collecting aiosignal>=1.4.0 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:37:36.6986403Z   Using cached aiosignal-1.4.0-py3-none-any.whl.metadata (3.7 kB)
+2026-01-22T23:37:36.7153790Z Collecting attrs>=17.3.0 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:37:36.7167680Z   Using cached attrs-25.4.0-py3-none-any.whl.metadata (10 kB)
+2026-01-22T23:37:36.7840898Z Collecting frozenlist>=1.1.1 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:37:36.7856407Z   Using cached frozenlist-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl.metadata (20 kB)
+2026-01-22T23:37:37.0086352Z Collecting multidict<7.0,>=4.5 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:37:37.0102052Z   Using cached multidict-6.7.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (5.3 kB)
+2026-01-22T23:37:37.0664174Z Collecting propcache>=0.2.0 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:37:37.0679826Z   Using cached propcache-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (13 kB)
+2026-01-22T23:37:37.3118921Z Collecting yarl<2.0,>=1.17.0 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:37:37.3134381Z   Using cached yarl-1.22.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (75 kB)
+2026-01-22T23:37:37.3708500Z Collecting zipp>=3.20 (from importlib-metadata>=4.11.4->keyring==24.3.0->-r web_service/backend/requirements.txt (line 66))
+2026-01-22T23:37:37.3722848Z   Using cached zipp-3.23.0-py3-none-any.whl.metadata (3.6 kB)
+2026-01-22T23:37:37.3995382Z Using cached fastapi-0.104.1-py3-none-any.whl (92 kB)
+2026-01-22T23:37:37.4009537Z Using cached starlette-0.27.0-py3-none-any.whl (66 kB)
+2026-01-22T23:37:37.4023666Z Using cached pydantic-2.5.0-py3-none-any.whl (407 kB)
+2026-01-22T23:37:37.4039803Z Using cached anyio-3.7.1-py3-none-any.whl (80 kB)
+2026-01-22T23:37:37.4053363Z Using cached uvicorn-0.24.0-py3-none-any.whl (59 kB)
+2026-01-22T23:37:37.4067103Z Using cached pydantic_core-2.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (2.1 MB)
+2026-01-22T23:37:37.4094785Z Using cached pydantic_settings-2.1.0-py3-none-any.whl (11 kB)
+2026-01-22T23:37:37.4108193Z Using cached h11-0.14.0-py3-none-any.whl (58 kB)
+2026-01-22T23:37:37.4121453Z Using cached h2-4.1.0-py3-none-any.whl (57 kB)
+2026-01-22T23:37:37.4134655Z Using cached hpack-4.0.0-py3-none-any.whl (32 kB)
+2026-01-22T23:37:37.4147859Z Using cached hyperframe-6.1.0-py3-none-any.whl (13 kB)
+2026-01-22T23:37:37.4161237Z Using cached httpcore-1.0.2-py3-none-any.whl (76 kB)
+2026-01-22T23:37:37.4175184Z Using cached httptools-0.6.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (318 kB)
+2026-01-22T23:37:37.4190641Z Using cached httpx-0.25.2-py3-none-any.whl (74 kB)
+2026-01-22T23:37:37.4204374Z Using cached websockets-12.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (130 kB)
+2026-01-22T23:37:37.4218168Z Using cached wsproto-1.2.0-py3-none-any.whl (24 kB)
+2026-01-22T23:37:37.4231287Z Using cached requests-2.31.0-py3-none-any.whl (62 kB)
+2026-01-22T23:37:37.4244738Z Using cached urllib3-2.1.0-py3-none-any.whl (104 kB)
+2026-01-22T23:37:37.4258967Z Using cached charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (140 kB)
+2026-01-22T23:37:37.4272276Z Using cached idna-3.6-py3-none-any.whl (61 kB)
+2026-01-22T23:37:37.4285293Z Using cached certifi-2023.7.22-py3-none-any.whl (158 kB)
+2026-01-22T23:37:37.4299967Z Using cached SQLAlchemy-2.0.23-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.2 MB)
+2026-01-22T23:37:37.4336102Z Using cached greenlet-3.0.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (616 kB)
+2026-01-22T23:37:37.4352993Z Using cached aiosqlite-0.19.0-py3-none-any.whl (15 kB)
+2026-01-22T23:37:37.4366171Z Using cached psycopg2_binary-2.9.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.0 MB)
+2026-01-22T23:37:37.4400966Z Using cached numpy-1.24.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.3 MB)
+2026-01-22T23:37:37.4538158Z Using cached pandas-2.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (12.2 MB)
+2026-01-22T23:37:37.4637824Z Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
+2026-01-22T23:37:37.4652229Z Using cached pytz-2023.3.post1-py2.py3-none-any.whl (502 kB)
+2026-01-22T23:37:37.4669395Z Using cached tzdata-2023.3-py2.py3-none-any.whl (341 kB)
+2026-01-22T23:37:37.4684842Z Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
+2026-01-22T23:37:37.4697753Z Using cached beautifulsoup4-4.12.2-py3-none-any.whl (142 kB)
+2026-01-22T23:37:37.4711352Z Using cached soupsieve-2.5-py3-none-any.whl (36 kB)
+2026-01-22T23:37:37.4724734Z Using cached selectolax-0.3.20-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (6.7 MB)
+2026-01-22T23:37:37.4785781Z Using cached click-8.1.7-py3-none-any.whl (97 kB)
+2026-01-22T23:37:37.4799442Z Using cached python_dotenv-1.0.0-py3-none-any.whl (19 kB)
+2026-01-22T23:37:37.4812686Z Using cached PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (757 kB)
+2026-01-22T23:37:37.4831881Z Using cached cryptography-41.0.7-cp37-abi3-manylinux_2_28_x86_64.whl (4.4 MB)
+2026-01-22T23:37:37.4875757Z Using cached cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (464 kB)
+2026-01-22T23:37:37.4891987Z Using cached pycparser-2.21-py2.py3-none-any.whl (118 kB)
+2026-01-22T23:37:37.4905701Z Using cached secretstorage-3.5.0-py3-none-any.whl (15 kB)
+2026-01-22T23:37:37.4918843Z Using cached keyring-24.3.0-py3-none-any.whl (38 kB)
+2026-01-22T23:37:37.4932215Z Using cached jeepney-0.9.0-py3-none-any.whl (49 kB)
+2026-01-22T23:37:37.4945183Z Using cached redis-5.0.1-py3-none-any.whl (250 kB)
+2026-01-22T23:37:37.4960850Z Using cached limits-3.7.0-py3-none-any.whl (43 kB)
+2026-01-22T23:37:37.4974165Z Using cached packaging-23.2-py3-none-any.whl (53 kB)
+2026-01-22T23:37:37.4987737Z Using cached slowapi-0.1.9-py3-none-any.whl (14 kB)
+2026-01-22T23:37:37.5001002Z Using cached tenacity-8.2.3-py3-none-any.whl (24 kB)
+2026-01-22T23:37:37.5014419Z Using cached pywebview-5.4-py3-none-any.whl (475 kB)
+2026-01-22T23:37:37.5031229Z Using cached bottle-0.13.4-py2.py3-none-any.whl (103 kB)
+2026-01-22T23:37:37.5045908Z Using cached psutil-5.9.6-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (283 kB)
+2026-01-22T23:37:37.5060854Z Using cached structlog-23.2.0-py3-none-any.whl (62 kB)
+2026-01-22T23:37:37.5074772Z Using cached black-23.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.7 MB)
+2026-01-22T23:37:37.5101218Z Using cached pyinstaller-6.1.0-py3-none-manylinux2014_x86_64.whl (658 kB)
+2026-01-22T23:37:37.5119128Z Using cached pyinstaller_hooks_contrib-2023.11-py2.py3-none-any.whl (294 kB)
+2026-01-22T23:37:37.5134339Z Using cached altgraph-0.17.3-py2.py3-none-any.whl (21 kB)
+2026-01-22T23:37:37.5147890Z Using cached wheel-0.41.2-py3-none-any.whl (64 kB)
+2026-01-22T23:37:37.5161259Z Using cached build-1.0.3-py3-none-any.whl (18 kB)
+2026-01-22T23:37:37.5174319Z Using cached pip_tools-7.3.0-py3-none-any.whl (57 kB)
+2026-01-22T23:37:37.5187986Z Using cached pytest-7.4.3-py3-none-any.whl (325 kB)
+2026-01-22T23:37:37.5203278Z Using cached pluggy-1.3.0-py3-none-any.whl (18 kB)
+2026-01-22T23:37:37.5216589Z Using cached pytest_asyncio-0.21.1-py3-none-any.whl (13 kB)
+2026-01-22T23:37:37.5229896Z Using cached iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
+2026-01-22T23:37:37.5243380Z Using cached typing_extensions-4.8.0-py3-none-any.whl (31 kB)
+2026-01-22T23:37:37.5256641Z Using cached typing_inspect-0.9.0-py3-none-any.whl (8.8 kB)
+2026-01-22T23:37:37.5269954Z Using cached annotated_types-0.6.0-py3-none-any.whl (12 kB)
+2026-01-22T23:37:37.5283343Z Using cached mypy_extensions-1.0.0-py3-none-any.whl (4.7 kB)
+2026-01-22T23:37:37.5296475Z Using cached pathspec-0.11.2-py3-none-any.whl (29 kB)
+2026-01-22T23:37:37.5311174Z Using cached platformdirs-4.0.0-py3-none-any.whl (17 kB)
+2026-01-22T23:37:37.5324427Z Using cached more_itertools-10.1.0-py3-none-any.whl (55 kB)
+2026-01-22T23:37:37.5338205Z Using cached jaraco.classes-3.3.1-py3-none-any.whl (6.8 kB)
+2026-01-22T23:37:37.5351451Z Using cached jaraco.context-5.3.0-py3-none-any.whl (6.5 kB)
+2026-01-22T23:37:37.5364566Z Using cached jaraco.functools-4.0.0-py3-none-any.whl (9.8 kB)
+2026-01-22T23:37:37.5378700Z Using cached Deprecated-1.2.14-py2.py3-none-any.whl (9.6 kB)
+2026-01-22T23:37:37.5393464Z Using cached wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (80 kB)
+2026-01-22T23:37:37.5407067Z Using cached sniffio-1.3.0-py3-none-any.whl (10 kB)
+2026-01-22T23:37:37.5421199Z Using cached watchfiles-0.20.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.3 MB)
+2026-01-22T23:37:37.5443976Z Using cached pygments-2.17.2-py3-none-any.whl (1.2 MB)
+2026-01-22T23:37:37.5466300Z Using cached aiohttp-3.13.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (1.7 MB)
+2026-01-22T23:37:37.5492404Z Using cached multidict-6.7.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (246 kB)
+2026-01-22T23:37:37.5507923Z Using cached yarl-1.22.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (365 kB)
+2026-01-22T23:37:37.5523389Z Using cached aiohappyeyeballs-2.6.1-py3-none-any.whl (15 kB)
+2026-01-22T23:37:37.5536898Z Using cached aiosignal-1.4.0-py3-none-any.whl (7.5 kB)
+2026-01-22T23:37:37.5549940Z Using cached attrs-25.4.0-py3-none-any.whl (67 kB)
+2026-01-22T23:37:37.5564062Z Using cached frozenlist-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl (231 kB)
+2026-01-22T23:37:37.5578814Z Using cached importlib_metadata-8.7.1-py3-none-any.whl (27 kB)
+2026-01-22T23:37:37.5592520Z Using cached importlib_resources-6.5.2-py3-none-any.whl (37 kB)
+2026-01-22T23:37:37.5606472Z Using cached propcache-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (210 kB)
+2026-01-22T23:37:37.5621313Z Using cached uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (3.8 MB)
+2026-01-22T23:37:37.5661134Z Using cached zipp-3.23.0-py3-none-any.whl (10 kB)
+2026-01-22T23:37:37.5674382Z Using cached backports.tarfile-1.2.0-py3-none-any.whl (30 kB)
+2026-01-22T23:37:37.5688255Z Using cached pyproject_hooks-1.2.0-py3-none-any.whl (10 kB)
+2026-01-22T23:37:37.8309058Z Installing collected packages: selectolax, pytz, proxy-tools, bottle, altgraph, zipp, wrapt, wheel, websockets, uvloop, urllib3, tzdata, typing-extensions, tenacity, structlog, soupsieve, sniffio, six, redis, pyyaml, python-dotenv, pyproject_hooks, pyinstaller-hooks-contrib, pygments, pycparser, psycopg2-binary, psutil, propcache, pluggy, platformdirs, pathspec, packaging, numpy, mypy-extensions, multidict, more-itertools, jeepney, iniconfig, importlib-resources, idna, hyperframe, httptools, hpack, h11, greenlet, frozenlist, click, charset-normalizer, certifi, backports.tarfile, attrs, annotated-types, aiosqlite, aiohappyeyeballs, yarl, wsproto, uvicorn, typing-inspect, sqlalchemy, requests, pywebview, python-dateutil, pytest, pyinstaller, pydantic-core, jaraco.functools, jaraco.context, jaraco.classes, importlib-metadata, httpcore, h2, deprecated, cffi, build, beautifulsoup4, anyio, aiosignal, watchfiles, starlette, pytest-asyncio, pydantic, pip-tools, pandas, limits, httpx, cryptography, aiohttp, slowapi, secretstorage, pydantic-settings, fastapi, black, keyring
+2026-01-22T23:37:38.1287576Z   Attempting uninstall: wheel
+2026-01-22T23:37:38.1304264Z     Found existing installation: wheel 0.46.3
+2026-01-22T23:37:38.1332858Z     Uninstalling wheel-0.46.3:
+2026-01-22T23:37:38.1344447Z       Successfully uninstalled wheel-0.46.3
+2026-01-22T23:37:39.9265848Z   Attempting uninstall: packaging
+2026-01-22T23:37:39.9283689Z     Found existing installation: packaging 26.0
+2026-01-22T23:37:39.9311517Z     Uninstalling packaging-26.0:
+2026-01-22T23:37:39.9320780Z       Successfully uninstalled packaging-26.0
+2026-01-22T23:37:49.2610565Z
+2026-01-22T23:37:49.2659826Z Successfully installed aiohappyeyeballs-2.6.1 aiohttp-3.13.3 aiosignal-1.4.0 aiosqlite-0.19.0 altgraph-0.17.3 annotated-types-0.6.0 anyio-3.7.1 attrs-25.4.0 backports.tarfile-1.2.0 beautifulsoup4-4.12.2 black-23.12.0 bottle-0.13.4 build-1.0.3 certifi-2023.7.22 cffi-1.16.0 charset-normalizer-3.3.2 click-8.1.7 cryptography-41.0.7 deprecated-1.2.14 fastapi-0.104.1 frozenlist-1.8.0 greenlet-3.0.2 h11-0.14.0 h2-4.1.0 hpack-4.0.0 httpcore-1.0.2 httptools-0.6.1 httpx-0.25.2 hyperframe-6.1.0 idna-3.6 importlib-metadata-8.7.1 importlib-resources-6.5.2 iniconfig-2.0.0 jaraco.classes-3.3.1 jaraco.context-5.3.0 jaraco.functools-4.0.0 jeepney-0.9.0 keyring-24.3.0 limits-3.7.0 more-itertools-10.1.0 multidict-6.7.0 mypy-extensions-1.0.0 numpy-1.24.3 packaging-23.2 pandas-2.0.3 pathspec-0.11.2 pip-tools-7.3.0 platformdirs-4.0.0 pluggy-1.3.0 propcache-0.4.1 proxy-tools-0.1.0 psutil-5.9.6 psycopg2-binary-2.9.9 pycparser-2.21 pydantic-2.5.0 pydantic-core-2.14.1 pydantic-settings-2.1.0 pygments-2.17.2 pyinstaller-6.1.0 pyinstaller-hooks-contrib-2023.11 pyproject_hooks-1.2.0 pytest-7.4.3 pytest-asyncio-0.21.1 python-dateutil-2.8.2 python-dotenv-1.0.0 pytz-2023.3.post1 pywebview-5.4 pyyaml-6.0.1 redis-5.0.1 requests-2.31.0 secretstorage-3.5.0 selectolax-0.3.20 six-1.16.0 slowapi-0.1.9 sniffio-1.3.0 soupsieve-2.5 sqlalchemy-2.0.23 starlette-0.27.0 structlog-23.2.0 tenacity-8.2.3 typing-extensions-4.8.0 typing-inspect-0.9.0 tzdata-2023.3 urllib3-2.1.0 uvicorn-0.24.0 uvloop-0.22.1 watchfiles-0.20.0 websockets-12.0 wheel-0.41.2 wrapt-1.16.0 wsproto-1.2.0 yarl-1.22.0 zipp-3.23.0
+2026-01-22T23:37:50.1591282Z ##[group]Run mkdir -p web_service/backend/{data,json,logs}
+2026-01-22T23:37:50.1591731Z [36;1mmkdir -p web_service/backend/{data,json,logs}[0m
+2026-01-22T23:37:50.1592041Z [36;1mmkdir -p reports/archive[0m
+2026-01-22T23:37:50.1624089Z shell: /usr/bin/bash -e {0}
+2026-01-22T23:37:50.1624316Z env:
+2026-01-22T23:37:50.1624494Z   PYTHON_VERSION: 3.11
+2026-01-22T23:37:50.1624710Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:37:50.1624934Z   MAX_RETRIES: 3
+2026-01-22T23:37:50.1625112Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:37:50.1625377Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:50.1625992Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-22T23:37:50.1626404Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:50.1626763Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:50.1627128Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:50.1627530Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-22T23:37:50.1627825Z ##[endgroup]
+2026-01-22T23:37:50.1800613Z ##[group]Run actions/cache@v4
+2026-01-22T23:37:50.1800871Z with:
+2026-01-22T23:37:50.1801156Z   path: web_service/backend/data/*.cache
+web_service/backend/json/*.cache
+
+2026-01-22T23:37:50.1801539Z   key: race-data-Linux-31
+2026-01-22T23:37:50.1801761Z   restore-keys: race-data-Linux-
+
+2026-01-22T23:37:50.1802009Z   enableCrossOsArchive: false
+2026-01-22T23:37:50.1802243Z   fail-on-cache-miss: false
+2026-01-22T23:37:50.1802449Z   lookup-only: false
+2026-01-22T23:37:50.1802644Z   save-always: false
+2026-01-22T23:37:50.1802825Z env:
+2026-01-22T23:37:50.1802982Z   PYTHON_VERSION: 3.11
+2026-01-22T23:37:50.1803185Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:37:50.1803392Z   MAX_RETRIES: 3
+2026-01-22T23:37:50.1803564Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:37:50.1803825Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:50.1804231Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-22T23:37:50.1804655Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:50.1805012Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:50.1805840Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:50.1806209Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-22T23:37:50.1806513Z ##[endgroup]
+2026-01-22T23:37:50.3830412Z Cache not found for input keys: race-data-Linux-31, race-data-Linux-
+2026-01-22T23:37:50.3904657Z ##[group]Run set -o pipefail
+2026-01-22T23:37:50.3904947Z [36;1mset -o pipefail[0m
+2026-01-22T23:37:50.3905285Z [36;1mpython scripts/fortuna_reporter.py 2>&1 | tee reporter_output.log[0m
+2026-01-22T23:37:50.3906230Z [36;1m[0m
+2026-01-22T23:37:50.3906570Z [36;1m# Extract metrics from the log for outputs[0m
+2026-01-22T23:37:50.3906975Z [36;1mif [ -f "qualified_races.json" ]; then[0m
+2026-01-22T23:37:50.3907494Z [36;1m  RACE_COUNT=$(python -c "import json; print(len(json.load(open('qualified_races.json')).get('races', [])))")[0m
+2026-01-22T23:37:50.3908060Z [36;1m  echo "race_count=${RACE_COUNT}" >> $GITHUB_OUTPUT[0m
+2026-01-22T23:37:50.3908397Z [36;1m  echo "status=success" >> $GITHUB_OUTPUT[0m
+2026-01-22T23:37:50.3908682Z [36;1melse[0m
+2026-01-22T23:37:50.3908887Z [36;1m  echo "race_count=0" >> $GITHUB_OUTPUT[0m
+2026-01-22T23:37:50.3909184Z [36;1m  echo "status=failed" >> $GITHUB_OUTPUT[0m
+2026-01-22T23:37:50.3909443Z [36;1mfi[0m
+2026-01-22T23:37:50.3941342Z shell: /usr/bin/bash -e {0}
+2026-01-22T23:37:50.3941567Z env:
+2026-01-22T23:37:50.3941743Z   PYTHON_VERSION: 3.11
+2026-01-22T23:37:50.3941963Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:37:50.3942171Z   MAX_RETRIES: 3
+2026-01-22T23:37:50.3942359Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:37:50.3942622Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:50.3943035Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-22T23:37:50.3943718Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:50.3962294Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:50.3962716Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:50.3963108Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-22T23:37:50.3963436Z   ANALYZER_TYPE: tiny_field_trifecta
+2026-01-22T23:37:50.3963688Z   FORCE_REFRESH: false
+2026-01-22T23:37:50.3963890Z ##[endgroup]
+2026-01-22T23:37:51.1742726Z 2026-01-22 23:37:51 [info     ] CacheManager initialized (not connected).
+2026-01-22T23:37:51.1939986Z [2026-01-22 23:37:51] ℹ️ === Fortuna Unified Race Reporter ===
+2026-01-22T23:37:51.1940907Z [2026-01-22 23:37:51] ℹ️ Analyzer: tiny_field_trifecta
+2026-01-22T23:37:51.1941662Z [2026-01-22 23:37:51] ℹ️ Excluding 23 adapters
+2026-01-22T23:37:51.1942589Z 2026-01-22 23:37:51 [warning  ] encryption_key_not_found       file=.key recommendation=Run 'python manage_secrets.py' to generate a key.
+2026-01-22T23:37:51.1952410Z 2026-01-22 23:37:51 [info     ] Initializing FortunaEngine...
+2026-01-22T23:37:51.1953024Z 2026-01-22 23:37:51 [info     ] Configuration loaded.
+2026-01-22T23:37:51.1953594Z 2026-01-22 23:37:51 [info     ] Initializing adapters...
+2026-01-22T23:37:51.1954193Z 2026-01-22 23:37:51 [info     ] Attempting to initialize adapter: AtTheRacesAdapter
+2026-01-22T23:37:51.1955051Z 2026-01-22 23:37:51 [info     ] Successfully initialized adapter: AtTheRacesAdapter
+2026-01-22T23:37:51.1956150Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: BetfairAdapter
+2026-01-22T23:37:51.1957138Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: BetfairGreyhoundAdapter
+2026-01-22T23:37:51.1958082Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: BrisnetAdapter
+2026-01-22T23:37:51.1958996Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: EquibaseAdapter
+2026-01-22T23:37:51.1959861Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: FanDuelAdapter
+2026-01-22T23:37:51.1960569Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: GbgbApiAdapter
+2026-01-22T23:37:51.1961373Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: GreyhoundAdapter
+2026-01-22T23:37:51.1962412Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: HarnessAdapter
+2026-01-22T23:37:51.1962979Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: HorseRacingNationAdapter
+2026-01-22T23:37:51.1963760Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: NYRABetsAdapter
+2026-01-22T23:37:51.1964301Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: OddscheckerAdapter
+2026-01-22T23:37:51.1964837Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: PuntersAdapter
+2026-01-22T23:37:51.1965381Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: RacingAndSportsAdapter
+2026-01-22T23:37:51.1966609Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: RacingAndSportsGreyhoundAdapter
+2026-01-22T23:37:51.1967235Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: RacingPostAdapter
+2026-01-22T23:37:51.1967822Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: RacingTVAdapter
+2026-01-22T23:37:51.1968606Z 2026-01-22 23:37:51 [info     ] Attempting to initialize adapter: SportingLifeAdapter
+2026-01-22T23:37:51.1969429Z 2026-01-22 23:37:51 [info     ] Successfully initialized adapter: SportingLifeAdapter
+2026-01-22T23:37:51.1970183Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: TabAdapter
+2026-01-22T23:37:51.1970692Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: TheRacingApiAdapter
+2026-01-22T23:37:51.1971163Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: TimeformAdapter
+2026-01-22T23:37:51.1971623Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: TwinSpiresAdapter
+2026-01-22T23:37:51.1972075Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: TVGAdapter
+2026-01-22T23:37:51.1972495Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: XpressbetAdapter
+2026-01-22T23:37:51.1972973Z 2026-01-22 23:37:51 [info     ] Intentionally skipping adapter: PointsBetGreyhoundAdapter
+2026-01-22T23:37:51.1973428Z 2026-01-22 23:37:51 [info     ] 2 adapters initialized successfully.
+2026-01-22T23:37:51.1973790Z 2026-01-22 23:37:51 [info     ] Initializing HTTP client...
+2026-01-22T23:37:51.2187263Z 2026-01-22 23:37:51 [info     ] HTTP client initialized.
+2026-01-22T23:37:51.2188635Z 2026-01-22 23:37:51 [info     ] Concurrency semaphore initialized limit=10
+2026-01-22T23:37:51.2189344Z 2026-01-22 23:37:51 [info     ] FortunaEngine initialization complete.
+2026-01-22T23:37:51.2190306Z 2026-01-22 23:37:51 [info     ] AnalyzerEngine discovered plugins available_analyzers=['trifecta', 'tiny_field_trifecta']
+2026-01-22T23:37:51.2191528Z [2026-01-22 23:37:51] ℹ️ Healthy adapters: 2/2
+2026-01-22T23:37:51.2192245Z [2026-01-22 23:37:51] ℹ️ Fetching race data (attempt 1/3)...
+2026-01-22T23:37:51.2193296Z 2026-01-22 23:37:51 [info     ] Making request                 adapter_name=AtTheRaces method=GET url=https://www.attheraces.com/racecards/2026-01-22
+2026-01-22T23:37:51.2227074Z 2026-01-22 23:37:51 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-22
+2026-01-22T23:37:51.8838056Z 2026-01-22 23:37:51 [error    ] HTTP status error              adapter_name=AtTheRaces status_code=403 url=https://www.attheraces.com/racecards/2026-01-22
+2026-01-22T23:37:51.9007288Z 2026-01-22 23:37:51 [error    ] Critical failure during fetch from adapter. adapter=AtTheRaces error=AdapterHttpError.__init__() got an unexpected keyword argument 'message'
+2026-01-22T23:37:51.9008778Z Traceback (most recent call last):
+2026-01-22T23:37:51.9018132Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/base_adapter_v3.py", line 449, in make_request
+2026-01-22T23:37:51.9019080Z     response.raise_for_status()
+2026-01-22T23:37:51.9020076Z   File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/httpx/_models.py", line 758, in raise_for_status
+2026-01-22T23:37:51.9021314Z     raise HTTPStatusError(message, request=request, response=self)
+2026-01-22T23:37:51.9022348Z httpx.HTTPStatusError: Client error '403 Forbidden' for url 'https://www.attheraces.com/racecards/2026-01-22'
+2026-01-22T23:37:51.9023730Z For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+2026-01-22T23:37:51.9024095Z
+2026-01-22T23:37:51.9024476Z During handling of the above exception, another exception occurred:
+2026-01-22T23:37:51.9024758Z
+2026-01-22T23:37:51.9024859Z Traceback (most recent call last):
+2026-01-22T23:37:51.9025611Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/engine.py", line 232, in _time_adapter_fetch
+2026-01-22T23:37:51.9026218Z     race_data_list = await adapter.get_races(date)
+2026-01-22T23:37:51.9026520Z                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:51.9027062Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/base_adapter_v3.py", line 354, in get_races
+2026-01-22T23:37:51.9027584Z     raw_data = await self._fetch_data(date)
+2026-01-22T23:37:51.9027829Z                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:51.9028367Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/at_the_races_adapter.py", line 38, in _fetch_data
+2026-01-22T23:37:51.9028916Z     index_response = await self.make_request(
+2026-01-22T23:37:51.9029181Z                      ^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:51.9029712Z   File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/tenacity/_asyncio.py", line 88, in async_wrapped
+2026-01-22T23:37:51.9030280Z     return await fn(*args, **kwargs)
+2026-01-22T23:37:51.9030513Z            ^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:51.9031018Z   File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/tenacity/_asyncio.py", line 47, in __call__
+2026-01-22T23:37:51.9031535Z     do = self.iter(retry_state=retry_state)
+2026-01-22T23:37:51.9031789Z          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:51.9032321Z   File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/tenacity/__init__.py", line 314, in iter
+2026-01-22T23:37:51.9032828Z     return fut.result()
+2026-01-22T23:37:51.9033017Z            ^^^^^^^^^^^^
+2026-01-22T23:37:51.9033478Z   File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/concurrent/futures/_base.py", line 449, in result
+2026-01-22T23:37:51.9033976Z     return self.__get_result()
+2026-01-22T23:37:51.9034194Z            ^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:51.9034815Z   File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
+2026-01-22T23:37:51.9035586Z     raise self._exception
+2026-01-22T23:37:51.9036083Z   File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/tenacity/_asyncio.py", line 50, in __call__
+2026-01-22T23:37:51.9036602Z     result = await fn(*args, **kwargs)
+2026-01-22T23:37:51.9036834Z              ^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:51.9037335Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/base_adapter_v3.py", line 471, in make_request
+2026-01-22T23:37:51.9037858Z     raise AdapterHttpError(
+2026-01-22T23:37:51.9038076Z           ^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:51.9038425Z TypeError: AdapterHttpError.__init__() got an unexpected keyword argument 'message'
+2026-01-22T23:37:52.1247652Z 2026-01-22 23:37:52 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-25
+2026-01-22T23:37:52.1251518Z 2026-01-22 23:37:52 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/tomorrow
+2026-01-22T23:37:52.1255297Z 2026-01-22 23:37:52 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-22/huntingdon/racecard/899402/pertemps-novices-handicap-chase
+2026-01-22T23:37:52.1259200Z 2026-01-22 23:37:52 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-22/turfway-park/racecard/900024/race-3-claiming
+2026-01-22T23:37:52.1264564Z 2026-01-22 23:37:52 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-23/charles-town/racecard/899979/race-1-maiden-claiming
+2026-01-22T23:37:52.1267610Z 2026-01-22 23:37:52 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-28
+2026-01-22T23:37:52.1271935Z 2026-01-22 23:37:52 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-22/huntingdon/racecard/899405/pertemps-network-handicap-hurdle-gbb-race
+2026-01-22T23:37:52.1275060Z 2026-01-22 23:37:52 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-22/huntingdon/racecard/899404/albert-bartlett-triple-crown-series-handicap-hurdle
+2026-01-22T23:37:52.1278912Z 2026-01-22 23:37:52 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-22/huntingdon/racecard/899406/pertemps-network-mares-maiden-nh-flat-race-conditionals-and-amateurs
+2026-01-22T23:37:52.1281616Z 2026-01-22 23:37:52 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-24
+2026-01-22T23:37:52.1285880Z 2026-01-22 23:37:52 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-22/huntingdon/racecard/899401/pertemps-network-maiden-hurdle-gbb-race
+2026-01-22T23:37:52.1289538Z 2026-01-22 23:37:52 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-27
+2026-01-22T23:37:52.1293451Z 2026-01-22 23:37:52 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-22/huntingdon/racecard/899400/pertemps-network-novices-handicap-chase-gbb-race
+2026-01-22T23:37:52.1296697Z 2026-01-22 23:37:52 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-22/huntingdon/racecard/899403/pertemps-network-mares-handicap-chase-gbb-race
+2026-01-22T23:37:52.1299713Z 2026-01-22 23:37:52 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-26
+2026-01-22T23:37:53.7318131Z 2026-01-22 23:37:53 [warning  ] Error parsing a race from SportingLife, skipping race. adapter_name=SportingLife
+2026-01-22T23:37:53.7319071Z Traceback (most recent call last):
+2026-01-22T23:37:53.7320266Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/sporting_life_adapter.py", line 97, in _parse_races
+2026-01-22T23:37:53.7321616Z     header_text = clean_text(soup.select_one("h1.hr-race-header-title__text").get_text())
+2026-01-22T23:37:53.7322491Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:53.7323161Z AttributeError: 'NoneType' object has no attribute 'get_text'
+2026-01-22T23:37:53.7570461Z 2026-01-22 23:37:53 [warning  ] Error parsing a race from SportingLife, skipping race. adapter_name=SportingLife
+2026-01-22T23:37:53.7571385Z Traceback (most recent call last):
+2026-01-22T23:37:53.7572633Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/sporting_life_adapter.py", line 97, in _parse_races
+2026-01-22T23:37:53.7573895Z     header_text = clean_text(soup.select_one("h1.hr-race-header-title__text").get_text())
+2026-01-22T23:37:53.7574689Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:53.7575375Z AttributeError: 'NoneType' object has no attribute 'get_text'
+2026-01-22T23:37:53.7901086Z 2026-01-22 23:37:53 [warning  ] Error parsing a race from SportingLife, skipping race. adapter_name=SportingLife
+2026-01-22T23:37:53.7902293Z Traceback (most recent call last):
+2026-01-22T23:37:53.7903637Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/sporting_life_adapter.py", line 97, in _parse_races
+2026-01-22T23:37:53.7906059Z     header_text = clean_text(soup.select_one("h1.hr-race-header-title__text").get_text())
+2026-01-22T23:37:53.7907200Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:53.7907984Z AttributeError: 'NoneType' object has no attribute 'get_text'
+2026-01-22T23:37:53.8189092Z 2026-01-22 23:37:53 [warning  ] Error parsing a race from SportingLife, skipping race. adapter_name=SportingLife
+2026-01-22T23:37:53.8189857Z Traceback (most recent call last):
+2026-01-22T23:37:53.8191122Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/sporting_life_adapter.py", line 97, in _parse_races
+2026-01-22T23:37:53.8192878Z     header_text = clean_text(soup.select_one("h1.hr-race-header-title__text").get_text())
+2026-01-22T23:37:53.8193799Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:53.8194350Z AttributeError: 'NoneType' object has no attribute 'get_text'
+2026-01-22T23:37:53.8439942Z 2026-01-22 23:37:53 [warning  ] Error parsing a race from SportingLife, skipping race. adapter_name=SportingLife
+2026-01-22T23:37:53.8440978Z Traceback (most recent call last):
+2026-01-22T23:37:53.8442215Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/sporting_life_adapter.py", line 97, in _parse_races
+2026-01-22T23:37:53.8443814Z     header_text = clean_text(soup.select_one("h1.hr-race-header-title__text").get_text())
+2026-01-22T23:37:53.8444524Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:53.8445093Z AttributeError: 'NoneType' object has no attribute 'get_text'
+2026-01-22T23:37:53.8690832Z 2026-01-22 23:37:53 [warning  ] Error parsing a race from SportingLife, skipping race. adapter_name=SportingLife
+2026-01-22T23:37:53.8691877Z Traceback (most recent call last):
+2026-01-22T23:37:53.8692852Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/sporting_life_adapter.py", line 97, in _parse_races
+2026-01-22T23:37:53.8693991Z     header_text = clean_text(soup.select_one("h1.hr-race-header-title__text").get_text())
+2026-01-22T23:37:53.8694702Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:53.8695292Z AttributeError: 'NoneType' object has no attribute 'get_text'
+2026-01-22T23:37:53.8980774Z 2026-01-22 23:37:53 [warning  ] Error parsing a race from SportingLife, skipping race. adapter_name=SportingLife
+2026-01-22T23:37:53.8981700Z Traceback (most recent call last):
+2026-01-22T23:37:53.8982496Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/sporting_life_adapter.py", line 97, in _parse_races
+2026-01-22T23:37:53.8983381Z     header_text = clean_text(soup.select_one("h1.hr-race-header-title__text").get_text())
+2026-01-22T23:37:53.8983958Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:53.8984431Z AttributeError: 'NoneType' object has no attribute 'get_text'
+2026-01-22T23:37:53.9394577Z 2026-01-22 23:37:53 [warning  ] Error parsing a race from SportingLife, skipping race. adapter_name=SportingLife
+2026-01-22T23:37:53.9395680Z Traceback (most recent call last):
+2026-01-22T23:37:53.9396495Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/sporting_life_adapter.py", line 97, in _parse_races
+2026-01-22T23:37:53.9397419Z     header_text = clean_text(soup.select_one("h1.hr-race-header-title__text").get_text())
+2026-01-22T23:37:53.9397995Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:53.9398484Z AttributeError: 'NoneType' object has no attribute 'get_text'
+2026-01-22T23:37:53.9715955Z 2026-01-22 23:37:53 [warning  ] Error parsing a race from SportingLife, skipping race. adapter_name=SportingLife
+2026-01-22T23:37:53.9717263Z Traceback (most recent call last):
+2026-01-22T23:37:53.9718406Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/sporting_life_adapter.py", line 97, in _parse_races
+2026-01-22T23:37:53.9719553Z     header_text = clean_text(soup.select_one("h1.hr-race-header-title__text").get_text())
+2026-01-22T23:37:53.9720214Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:53.9720692Z AttributeError: 'NoneType' object has no attribute 'get_text'
+2026-01-22T23:37:53.9968777Z 2026-01-22 23:37:53 [warning  ] Error parsing a race from SportingLife, skipping race. adapter_name=SportingLife
+2026-01-22T23:37:53.9969943Z Traceback (most recent call last):
+2026-01-22T23:37:53.9971221Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/sporting_life_adapter.py", line 97, in _parse_races
+2026-01-22T23:37:53.9972364Z     header_text = clean_text(soup.select_one("h1.hr-race-header-title__text").get_text())
+2026-01-22T23:37:53.9972924Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:53.9973365Z AttributeError: 'NoneType' object has no attribute 'get_text'
+2026-01-22T23:37:54.0707732Z 2026-01-22 23:37:54 [warning  ] Error parsing a race from SportingLife, skipping race. adapter_name=SportingLife
+2026-01-22T23:37:54.0708817Z Traceback (most recent call last):
+2026-01-22T23:37:54.0710077Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/sporting_life_adapter.py", line 97, in _parse_races
+2026-01-22T23:37:54.0711414Z     header_text = clean_text(soup.select_one("h1.hr-race-header-title__text").get_text())
+2026-01-22T23:37:54.0712070Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:54.0712552Z AttributeError: 'NoneType' object has no attribute 'get_text'
+2026-01-22T23:37:54.0956425Z 2026-01-22 23:37:54 [warning  ] Error parsing a race from SportingLife, skipping race. adapter_name=SportingLife
+2026-01-22T23:37:54.0957448Z Traceback (most recent call last):
+2026-01-22T23:37:54.0958420Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/sporting_life_adapter.py", line 97, in _parse_races
+2026-01-22T23:37:54.0959561Z     header_text = clean_text(soup.select_one("h1.hr-race-header-title__text").get_text())
+2026-01-22T23:37:54.0960268Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:54.0960863Z AttributeError: 'NoneType' object has no attribute 'get_text'
+2026-01-22T23:37:54.1247164Z 2026-01-22 23:37:54 [warning  ] Error parsing a race from SportingLife, skipping race. adapter_name=SportingLife
+2026-01-22T23:37:54.1248437Z Traceback (most recent call last):
+2026-01-22T23:37:54.1249881Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/sporting_life_adapter.py", line 97, in _parse_races
+2026-01-22T23:37:54.1251408Z     header_text = clean_text(soup.select_one("h1.hr-race-header-title__text").get_text())
+2026-01-22T23:37:54.1252142Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:54.1252737Z AttributeError: 'NoneType' object has no attribute 'get_text'
+2026-01-22T23:37:54.1502502Z 2026-01-22 23:37:54 [warning  ] Error parsing a race from SportingLife, skipping race. adapter_name=SportingLife
+2026-01-22T23:37:54.1503571Z Traceback (most recent call last):
+2026-01-22T23:37:54.1504478Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/sporting_life_adapter.py", line 97, in _parse_races
+2026-01-22T23:37:54.1505807Z     header_text = clean_text(soup.select_one("h1.hr-race-header-title__text").get_text())
+2026-01-22T23:37:54.1506467Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:54.1507021Z AttributeError: 'NoneType' object has no attribute 'get_text'
+2026-01-22T23:37:54.1749104Z 2026-01-22 23:37:54 [warning  ] Error parsing a race from SportingLife, skipping race. adapter_name=SportingLife
+2026-01-22T23:37:54.1750740Z Traceback (most recent call last):
+2026-01-22T23:37:54.1752326Z   File "/home/runner/work/fortuna/fortuna/web_service/backend/adapters/sporting_life_adapter.py", line 97, in _parse_races
+2026-01-22T23:37:54.1753618Z     header_text = clean_text(soup.select_one("h1.hr-race-header-title__text").get_text())
+2026-01-22T23:37:54.1754200Z                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2026-01-22T23:37:54.1754643Z AttributeError: 'NoneType' object has no attribute 'get_text'
+2026-01-22T23:37:54.1756104Z 2026-01-22 23:37:54 [info     ] Updating stale cache           cache_type=StaleDataCache key=2026-01-22
+2026-01-22T23:37:54.1757342Z [2026-01-22 23:37:54] ✅ Saved raw race data to raw_race_data.json
+2026-01-22T23:37:54.1758268Z [2026-01-22 23:37:54] ❌ No races returned from OddsEngine. This is a critical failure.
+2026-01-22T23:37:54.1759122Z [2026-01-22 23:37:54] ℹ️ Generating Markdown summary...
+2026-01-22T23:37:54.1759911Z [2026-01-22 23:37:54] ✅ Generated Markdown summary at github_summary.md
+2026-01-22T23:37:54.1764082Z [2026-01-22 23:37:54] ℹ️ Generated 1/4 outputs
+2026-01-22T23:37:54.2529357Z ##[error]Process completed with exit code 1.
+2026-01-22T23:37:54.2594435Z ##[group]Run actions/upload-artifact@v4
+2026-01-22T23:37:54.2594722Z with:
+2026-01-22T23:37:54.2594907Z   name: race-reports-31-1
+2026-01-22T23:37:54.2595268Z   path: race-report.html
+qualified_races.json
+raw_race_data.json
+reporter_output.log
+
+2026-01-22T23:37:54.2595892Z   retention-days: 14
+2026-01-22T23:37:54.2596093Z   if-no-files-found: warn
+2026-01-22T23:37:54.2596298Z   compression-level: 9
+2026-01-22T23:37:54.2596499Z   overwrite: false
+2026-01-22T23:37:54.2596699Z   include-hidden-files: false
+2026-01-22T23:37:54.2596908Z env:
+2026-01-22T23:37:54.2597079Z   PYTHON_VERSION: 3.11
+2026-01-22T23:37:54.2597277Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:37:54.2597479Z   MAX_RETRIES: 3
+2026-01-22T23:37:54.2597683Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:37:54.2597941Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:54.2598345Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-22T23:37:54.2598768Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:54.2599119Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:54.2599475Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:54.2599839Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-22T23:37:54.2600140Z ##[endgroup]
+2026-01-22T23:37:54.4780412Z Multiple search paths detected. Calculating the least common ancestor of all paths
+2026-01-22T23:37:54.4786553Z The least common ancestor is /home/runner/work/fortuna/fortuna. This will be the root directory of the artifact
+2026-01-22T23:37:54.4787594Z With the provided path, there will be 4 files uploaded
+2026-01-22T23:37:54.4792455Z Artifact name is valid!
+2026-01-22T23:37:54.4793681Z Root directory input is valid!
+2026-01-22T23:37:54.5886038Z Beginning upload of artifact content to blob storage
+2026-01-22T23:37:54.6425254Z Uploaded bytes 10288
+2026-01-22T23:37:54.6563218Z Finished uploading artifact content to blob storage!
+2026-01-22T23:37:54.6566581Z SHA256 digest of uploaded artifact zip is e94bd32cb3cef9a5791fba712b2dd2af1193f28aa1fdad0a573b543328b8ca7a
+2026-01-22T23:37:54.6568712Z Finalizing artifact upload
+2026-01-22T23:37:54.7291438Z Artifact race-reports-31-1.zip successfully finalized. Artifact ID 5227224528
+2026-01-22T23:37:54.7292866Z Artifact race-reports-31-1 has been successfully uploaded! Final size is 10288 bytes. Artifact ID is 5227224528
+2026-01-22T23:37:54.7300170Z Artifact download URL: https://github.com/masonj0/fortuna/actions/runs/21268831912/artifacts/5227224528
+2026-01-22T23:37:54.7413007Z ##[group]Run {
+2026-01-22T23:37:54.7413426Z [36;1m{[0m
+2026-01-22T23:37:54.7413829Z [36;1m  echo "## 🐴 Fortuna Race Report Summary"[0m
+2026-01-22T23:37:54.7414624Z [36;1m  echo ""[0m
+2026-01-22T23:37:54.7415046Z [36;1m  echo "**Run:** #31 | **Status:** unknown"[0m
+2026-01-22T23:37:54.7415808Z [36;1m  echo "**Analyzer:** tiny_field_trifecta"[0m
+2026-01-22T23:37:54.7416258Z [36;1m  echo ""[0m
+2026-01-22T23:37:54.7416591Z [36;1m[0m
+2026-01-22T23:37:54.7416956Z [36;1m  if [ -f "github_summary.md" ]; then[0m
+2026-01-22T23:37:54.7417457Z [36;1m    cat github_summary.md[0m
+2026-01-22T23:37:54.7417856Z [36;1m  else[0m
+2026-01-22T23:37:54.7418252Z [36;1m    echo "### ⚠️ Detailed summary not available"[0m
+2026-01-22T23:37:54.7418749Z [36;1m    echo ""[0m
+2026-01-22T23:37:54.7419194Z [36;1m    echo "Check the artifacts for the full report."[0m
+2026-01-22T23:37:54.7419716Z [36;1m  fi[0m
+2026-01-22T23:37:54.7420029Z [36;1m[0m
+2026-01-22T23:37:54.7420361Z [36;1m  echo ""[0m
+2026-01-22T23:37:54.7420697Z [36;1m  echo "---"[0m
+2026-01-22T23:37:54.7421198Z [36;1m  echo "*Generated at $(date -u '+%Y-%m-%d %H:%M:%S UTC')*"[0m
+2026-01-22T23:37:54.7421813Z [36;1m} >> $GITHUB_STEP_SUMMARY[0m
+2026-01-22T23:37:54.7468011Z shell: /usr/bin/bash -e {0}
+2026-01-22T23:37:54.7468408Z env:
+2026-01-22T23:37:54.7468704Z   PYTHON_VERSION: 3.11
+2026-01-22T23:37:54.7469078Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:37:54.7469454Z   MAX_RETRIES: 3
+2026-01-22T23:37:54.7469778Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:37:54.7470233Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:54.7470967Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-22T23:37:54.7471702Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:54.7472363Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:54.7473042Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:54.7473734Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-22T23:37:54.7474304Z ##[endgroup]
+2026-01-22T23:37:54.7611674Z ##[group]Run echo "::warning::Report generation failed. Check logs for details."
+2026-01-22T23:37:54.7612252Z [36;1mecho "::warning::Report generation failed. Check logs for details."[0m
+2026-01-22T23:37:54.7612655Z [36;1m# Archive any partial data for debugging[0m
+2026-01-22T23:37:54.7612965Z [36;1mif ls *.json 1> /dev/null 2>&1; then[0m
+2026-01-22T23:37:54.7613327Z [36;1m  tar -czf debug-data.tar.gz *.json *.log 2>/dev/null || true[0m
+2026-01-22T23:37:54.7613650Z [36;1mfi[0m
+2026-01-22T23:37:54.7645092Z shell: /usr/bin/bash -e {0}
+2026-01-22T23:37:54.7645336Z env:
+2026-01-22T23:37:54.7645842Z   PYTHON_VERSION: 3.11
+2026-01-22T23:37:54.7646170Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:37:54.7646399Z   MAX_RETRIES: 3
+2026-01-22T23:37:54.7646680Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:37:54.7646960Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:54.7647414Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-22T23:37:54.7647858Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:54.7648377Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:54.7648746Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:37:54.7649122Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-22T23:37:54.7649434Z ##[endgroup]
+2026-01-22T23:37:54.7736670Z ##[warning]Report generation failed. Check logs for details.
+2026-01-22T23:37:54.7872227Z Post job cleanup.
+2026-01-22T23:37:54.8917892Z [command]/usr/bin/git version
+2026-01-22T23:37:54.8956091Z git version 2.52.0
+2026-01-22T23:37:54.9000180Z Temporarily overriding HOME='/home/runner/work/_temp/fc38ed04-0552-4e52-b7da-733487b2977a' before making global git config changes
+2026-01-22T23:37:54.9001498Z Adding repository directory to the temporary git global config as a safe directory
+2026-01-22T23:37:54.9013257Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/fortuna/fortuna
+2026-01-22T23:37:54.9052831Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-01-22T23:37:54.9088669Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-01-22T23:37:54.9331032Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-01-22T23:37:54.9355906Z http.https://github.com/.extraheader
+2026-01-22T23:37:54.9369954Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2026-01-22T23:37:54.9402374Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-01-22T23:37:54.9652395Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-01-22T23:37:54.9693278Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-01-22T23:37:55.0087389Z Evaluate and set job outputs
+2026-01-22T23:37:55.0093657Z Cleaning up orphan processes

--- a/new_logs_2.txt
+++ b/new_logs_2.txt
@@ -1,0 +1,693 @@
+﻿2026-01-22T23:52:18.2958151Z Current runner version: '2.331.0'
+2026-01-22T23:52:18.2982733Z ##[group]Runner Image Provisioner
+2026-01-22T23:52:18.2983599Z Hosted Compute Agent
+2026-01-22T23:52:18.2984139Z Version: 20260115.477
+2026-01-22T23:52:18.2984678Z Commit: 4b342d620503cbe250a3154040964899ea7c9b00
+2026-01-22T23:52:18.2985413Z Build Date: 2026-01-15T22:32:41Z
+2026-01-22T23:52:18.2986007Z Worker ID: {6476e5e3-ec8f-46dd-8858-0e7925d5cee1}
+2026-01-22T23:52:18.2986767Z Azure Region: northcentralus
+2026-01-22T23:52:18.2987430Z ##[endgroup]
+2026-01-22T23:52:18.2988803Z ##[group]Operating System
+2026-01-22T23:52:18.2989386Z Ubuntu
+2026-01-22T23:52:18.2989874Z 24.04.3
+2026-01-22T23:52:18.2990345Z LTS
+2026-01-22T23:52:18.2990797Z ##[endgroup]
+2026-01-22T23:52:18.2991333Z ##[group]Runner Image
+2026-01-22T23:52:18.2991874Z Image: ubuntu-24.04
+2026-01-22T23:52:18.2993675Z Version: 20260119.4.1
+2026-01-22T23:52:18.2995278Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260119.4/images/ubuntu/Ubuntu2404-Readme.md
+2026-01-22T23:52:18.2996685Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260119.4
+2026-01-22T23:52:18.2997616Z ##[endgroup]
+2026-01-22T23:52:18.2998695Z ##[group]GITHUB_TOKEN Permissions
+2026-01-22T23:52:18.3000789Z Actions: write
+2026-01-22T23:52:18.3001324Z Contents: read
+2026-01-22T23:52:18.3001861Z Metadata: read
+2026-01-22T23:52:18.3002543Z ##[endgroup]
+2026-01-22T23:52:18.3004704Z Secret source: Actions
+2026-01-22T23:52:18.3005652Z Prepare workflow directory
+2026-01-22T23:52:18.3411374Z Prepare all required actions
+2026-01-22T23:52:18.3452883Z Getting action download info
+2026-01-22T23:52:18.6767697Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+2026-01-22T23:52:18.8164400Z Download action repository 'actions/setup-python@v5' (SHA:a26af69be951a213d495a4c3e4e4022e16d87065)
+2026-01-22T23:52:18.9405515Z Download action repository 'actions/cache@v4' (SHA:0057852bfaa89a56745cba8c7296529d2fc39830)
+2026-01-22T23:52:19.1015754Z Download action repository 'actions/upload-artifact@v4' (SHA:ea165f8d65b6e75b540449e92b4886f43607fa02)
+2026-01-22T23:52:19.5589145Z Complete job name: generate-unified-report
+2026-01-22T23:52:19.6438743Z ##[group]Run actions/checkout@v4
+2026-01-22T23:52:19.6440513Z with:
+2026-01-22T23:52:19.6441467Z   fetch-depth: 1
+2026-01-22T23:52:19.6442851Z   repository: masonj0/fortuna
+2026-01-22T23:52:19.6444515Z   token: ***
+2026-01-22T23:52:19.6445503Z   ssh-strict: true
+2026-01-22T23:52:19.6446472Z   ssh-user: git
+2026-01-22T23:52:19.6447430Z   persist-credentials: true
+2026-01-22T23:52:19.6448617Z   clean: true
+2026-01-22T23:52:19.6449669Z   sparse-checkout-cone-mode: true
+2026-01-22T23:52:19.6451018Z   fetch-tags: false
+2026-01-22T23:52:19.6452169Z   show-progress: true
+2026-01-22T23:52:19.6453166Z   lfs: false
+2026-01-22T23:52:19.6454208Z   submodules: false
+2026-01-22T23:52:19.6455388Z   set-safe-directory: true
+2026-01-22T23:52:19.6456882Z env:
+2026-01-22T23:52:19.6457723Z   PYTHON_VERSION: 3.11
+2026-01-22T23:52:19.6458781Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:52:19.6459772Z   MAX_RETRIES: 3
+2026-01-22T23:52:19.6460949Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:52:19.6462135Z ##[endgroup]
+2026-01-22T23:52:19.7679293Z Syncing repository: masonj0/fortuna
+2026-01-22T23:52:19.7682195Z ##[group]Getting Git version info
+2026-01-22T23:52:19.7683471Z Working directory is '/home/runner/work/fortuna/fortuna'
+2026-01-22T23:52:19.7685491Z [command]/usr/bin/git version
+2026-01-22T23:52:19.7767668Z git version 2.52.0
+2026-01-22T23:52:19.7796336Z ##[endgroup]
+2026-01-22T23:52:19.7812667Z Temporarily overriding HOME='/home/runner/work/_temp/573a6a6f-5eee-4237-86e7-8a0b3b2ca888' before making global git config changes
+2026-01-22T23:52:19.7815442Z Adding repository directory to the temporary git global config as a safe directory
+2026-01-22T23:52:19.7826180Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/fortuna/fortuna
+2026-01-22T23:52:19.7869237Z Deleting the contents of '/home/runner/work/fortuna/fortuna'
+2026-01-22T23:52:19.7873111Z ##[group]Initializing the repository
+2026-01-22T23:52:19.7877642Z [command]/usr/bin/git init /home/runner/work/fortuna/fortuna
+2026-01-22T23:52:19.7990514Z hint: Using 'master' as the name for the initial branch. This default branch name
+2026-01-22T23:52:19.7993521Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2026-01-22T23:52:19.7996794Z hint: to use in all of your new repositories, which will suppress this warning,
+2026-01-22T23:52:19.7998510Z hint: call:
+2026-01-22T23:52:19.7999190Z hint:
+2026-01-22T23:52:19.8000153Z hint: 	git config --global init.defaultBranch <name>
+2026-01-22T23:52:19.8001310Z hint:
+2026-01-22T23:52:19.8003468Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2026-01-22T23:52:19.8005379Z hint: 'development'. The just-created branch can be renamed via this command:
+2026-01-22T23:52:19.8006736Z hint:
+2026-01-22T23:52:19.8007445Z hint: 	git branch -m <name>
+2026-01-22T23:52:19.8008692Z hint:
+2026-01-22T23:52:19.8009820Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2026-01-22T23:52:19.8011728Z Initialized empty Git repository in /home/runner/work/fortuna/fortuna/.git/
+2026-01-22T23:52:19.8015020Z [command]/usr/bin/git remote add origin https://github.com/masonj0/fortuna
+2026-01-22T23:52:19.8047678Z ##[endgroup]
+2026-01-22T23:52:19.8048947Z ##[group]Disabling automatic garbage collection
+2026-01-22T23:52:19.8051505Z [command]/usr/bin/git config --local gc.auto 0
+2026-01-22T23:52:19.8083222Z ##[endgroup]
+2026-01-22T23:52:19.8084558Z ##[group]Setting up auth
+2026-01-22T23:52:19.8091507Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-01-22T23:52:19.8128630Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-01-22T23:52:19.8503577Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-01-22T23:52:19.8539943Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-01-22T23:52:19.8770913Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-01-22T23:52:19.8803329Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-01-22T23:52:19.9039160Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2026-01-22T23:52:19.9074682Z ##[endgroup]
+2026-01-22T23:52:19.9077171Z ##[group]Fetching the repository
+2026-01-22T23:52:19.9086702Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +7103cf2d411d14f6a323c8870203fa677c27ebca:refs/remotes/origin/main
+2026-01-22T23:52:20.3136357Z From https://github.com/masonj0/fortuna
+2026-01-22T23:52:20.3137554Z  * [new ref]         7103cf2d411d14f6a323c8870203fa677c27ebca -> origin/main
+2026-01-22T23:52:20.3174947Z ##[endgroup]
+2026-01-22T23:52:20.3175865Z ##[group]Determining the checkout info
+2026-01-22T23:52:20.3177423Z ##[endgroup]
+2026-01-22T23:52:20.3183665Z [command]/usr/bin/git sparse-checkout disable
+2026-01-22T23:52:20.3228083Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2026-01-22T23:52:20.3256124Z ##[group]Checking out the ref
+2026-01-22T23:52:20.3260523Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+2026-01-22T23:52:20.3742269Z Switched to a new branch 'main'
+2026-01-22T23:52:20.3743727Z branch 'main' set up to track 'origin/main'.
+2026-01-22T23:52:20.3753589Z ##[endgroup]
+2026-01-22T23:52:20.3792854Z [command]/usr/bin/git log -1 --format=%H
+2026-01-22T23:52:20.3818462Z 7103cf2d411d14f6a323c8870203fa677c27ebca
+2026-01-22T23:52:20.4066757Z ##[group]Run actions/setup-python@v5
+2026-01-22T23:52:20.4067512Z with:
+2026-01-22T23:52:20.4067848Z   python-version: 3.11
+2026-01-22T23:52:20.4068231Z   cache: pip
+2026-01-22T23:52:20.4068692Z   cache-dependency-path: web_service/backend/requirements.txt
+2026-01-22T23:52:20.4069206Z   check-latest: false
+2026-01-22T23:52:20.4069732Z   token: ***
+2026-01-22T23:52:20.4070177Z   update-environment: true
+2026-01-22T23:52:20.4070600Z   allow-prereleases: false
+2026-01-22T23:52:20.4071008Z   freethreaded: false
+2026-01-22T23:52:20.4071360Z env:
+2026-01-22T23:52:20.4071673Z   PYTHON_VERSION: 3.11
+2026-01-22T23:52:20.4072315Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:52:20.4072683Z   MAX_RETRIES: 3
+2026-01-22T23:52:20.4073025Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:52:20.4073374Z ##[endgroup]
+2026-01-22T23:52:20.5832523Z ##[group]Installed versions
+2026-01-22T23:52:20.6369263Z Successfully set up CPython (3.11.14)
+2026-01-22T23:52:20.6370611Z ##[endgroup]
+2026-01-22T23:52:20.7146818Z [command]/opt/hostedtoolcache/Python/3.11.14/x64/bin/pip cache dir
+2026-01-22T23:52:26.5330551Z /home/runner/.cache/pip
+2026-01-22T23:52:26.7099751Z Cache hit for: setup-python-Linux-x64-24.04-Ubuntu-python-3.11.14-pip-9b33d885a72e4a79c39d67e0d38fd2891ce0392a75a496cd6973c98dee5ac231
+2026-01-22T23:52:27.8671636Z Received 134217728 of 474921379 (28.3%), 121.1 MBs/sec
+2026-01-22T23:52:28.8685772Z Received 327155712 of 474921379 (68.9%), 151.5 MBs/sec
+2026-01-22T23:52:29.6911056Z Received 474921379 of 474921379 (100.0%), 157.2 MBs/sec
+2026-01-22T23:52:29.6913309Z Cache Size: ~453 MB (474921379 B)
+2026-01-22T23:52:29.6953505Z [command]/usr/bin/tar -xf /home/runner/work/_temp/f21d549a-23fc-485d-8f46-9a5aefaa2295/cache.tzst -P -C /home/runner/work/fortuna/fortuna --use-compress-program unzstd
+2026-01-22T23:52:30.4970404Z Cache restored successfully
+2026-01-22T23:52:30.5884749Z Cache restored from key: setup-python-Linux-x64-24.04-Ubuntu-python-3.11.14-pip-9b33d885a72e4a79c39d67e0d38fd2891ce0392a75a496cd6973c98dee5ac231
+2026-01-22T23:52:30.6081769Z ##[group]Run python -m pip install --upgrade pip setuptools wheel
+2026-01-22T23:52:30.6082758Z [36;1mpython -m pip install --upgrade pip setuptools wheel[0m
+2026-01-22T23:52:30.6083193Z [36;1mpip install -r web_service/backend/requirements.txt[0m
+2026-01-22T23:52:30.6125756Z shell: /usr/bin/bash -e {0}
+2026-01-22T23:52:30.6126025Z env:
+2026-01-22T23:52:30.6126233Z   PYTHON_VERSION: 3.11
+2026-01-22T23:52:30.6126478Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:52:30.6126694Z   MAX_RETRIES: 3
+2026-01-22T23:52:30.6126879Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:52:30.6127302Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:30.6127794Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-22T23:52:30.6128218Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:30.6128592Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:30.6128986Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:30.6129365Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-22T23:52:30.6129808Z ##[endgroup]
+2026-01-22T23:52:33.3131663Z Requirement already satisfied: pip in /opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages (25.3)
+2026-01-22T23:52:33.4332312Z Requirement already satisfied: setuptools in /opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages (79.0.1)
+2026-01-22T23:52:33.5597564Z Collecting setuptools
+2026-01-22T23:52:33.5616091Z   Using cached setuptools-80.10.1-py3-none-any.whl.metadata (6.7 kB)
+2026-01-22T23:52:33.5983344Z Collecting wheel
+2026-01-22T23:52:33.6569453Z   Downloading wheel-0.46.3-py3-none-any.whl.metadata (2.4 kB)
+2026-01-22T23:52:33.6972810Z Collecting packaging>=24.0 (from wheel)
+2026-01-22T23:52:33.7031464Z   Downloading packaging-26.0-py3-none-any.whl.metadata (3.3 kB)
+2026-01-22T23:52:33.7097859Z Using cached setuptools-80.10.1-py3-none-any.whl (1.1 MB)
+2026-01-22T23:52:33.7150367Z Downloading wheel-0.46.3-py3-none-any.whl (30 kB)
+2026-01-22T23:52:33.7245331Z Downloading packaging-26.0-py3-none-any.whl (74 kB)
+2026-01-22T23:52:33.8565043Z Installing collected packages: setuptools, packaging, wheel
+2026-01-22T23:52:33.8570204Z   Attempting uninstall: setuptools
+2026-01-22T23:52:33.8586372Z     Found existing installation: setuptools 79.0.1
+2026-01-22T23:52:34.2321792Z     Uninstalling setuptools-79.0.1:
+2026-01-22T23:52:34.3286873Z       Successfully uninstalled setuptools-79.0.1
+2026-01-22T23:52:35.2716499Z
+2026-01-22T23:52:35.2725894Z Successfully installed packaging-26.0 setuptools-80.10.1 wheel-0.46.3
+2026-01-22T23:52:36.2380269Z Collecting fastapi==0.104.1 (from -r web_service/backend/requirements.txt (line 11))
+2026-01-22T23:52:36.2396636Z   Using cached fastapi-0.104.1-py3-none-any.whl.metadata (24 kB)
+2026-01-22T23:52:36.2662905Z Collecting uvicorn==0.24.0 (from uvicorn[standard]==0.24.0->-r web_service/backend/requirements.txt (line 12))
+2026-01-22T23:52:36.2685622Z   Using cached uvicorn-0.24.0-py3-none-any.whl.metadata (6.4 kB)
+2026-01-22T23:52:36.2968319Z Collecting starlette==0.27.0 (from -r web_service/backend/requirements.txt (line 13))
+2026-01-22T23:52:36.2984696Z   Using cached starlette-0.27.0-py3-none-any.whl.metadata (5.8 kB)
+2026-01-22T23:52:36.4122832Z Collecting pydantic==2.5.0 (from -r web_service/backend/requirements.txt (line 14))
+2026-01-22T23:52:36.4140406Z   Using cached pydantic-2.5.0-py3-none-any.whl.metadata (174 kB)
+2026-01-22T23:52:37.0872891Z Collecting pydantic-core==2.14.1 (from -r web_service/backend/requirements.txt (line 15))
+2026-01-22T23:52:37.0889109Z   Using cached pydantic_core-2.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.5 kB)
+2026-01-22T23:52:37.1021341Z Collecting pydantic-settings==2.1.0 (from -r web_service/backend/requirements.txt (line 16))
+2026-01-22T23:52:37.1036565Z   Using cached pydantic_settings-2.1.0-py3-none-any.whl.metadata (2.9 kB)
+2026-01-22T23:52:37.1193476Z Collecting anyio==3.7.1 (from -r web_service/backend/requirements.txt (line 19))
+2026-01-22T23:52:37.1208425Z   Using cached anyio-3.7.1-py3-none-any.whl.metadata (4.7 kB)
+2026-01-22T23:52:37.1317604Z Collecting h11==0.14.0 (from -r web_service/backend/requirements.txt (line 20))
+2026-01-22T23:52:37.1331740Z   Using cached h11-0.14.0-py3-none-any.whl.metadata (8.2 kB)
+2026-01-22T23:52:37.1468830Z Collecting h2==4.1.0 (from -r web_service/backend/requirements.txt (line 21))
+2026-01-22T23:52:37.1482469Z   Using cached h2-4.1.0-py3-none-any.whl.metadata (3.6 kB)
+2026-01-22T23:52:37.1566145Z Collecting hpack==4.0.0 (from -r web_service/backend/requirements.txt (line 22))
+2026-01-22T23:52:37.1580095Z   Using cached hpack-4.0.0-py3-none-any.whl.metadata (2.5 kB)
+2026-01-22T23:52:37.1991784Z Collecting httpcore==1.0.2 (from -r web_service/backend/requirements.txt (line 23))
+2026-01-22T23:52:37.2006453Z   Using cached httpcore-1.0.2-py3-none-any.whl.metadata (20 kB)
+2026-01-22T23:52:37.2289441Z Collecting httptools==0.6.1 (from -r web_service/backend/requirements.txt (line 24))
+2026-01-22T23:52:37.2304091Z   Using cached httptools-0.6.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (3.6 kB)
+2026-01-22T23:52:37.2472524Z Collecting httpx==0.25.2 (from -r web_service/backend/requirements.txt (line 25))
+2026-01-22T23:52:37.2485866Z   Using cached httpx-0.25.2-py3-none-any.whl.metadata (6.9 kB)
+2026-01-22T23:52:37.2612962Z Collecting hyperframe==6.1.0 (from -r web_service/backend/requirements.txt (line 26))
+2026-01-22T23:52:37.2626355Z   Using cached hyperframe-6.1.0-py3-none-any.whl.metadata (4.3 kB)
+2026-01-22T23:52:37.3455722Z Collecting websockets==12.0 (from -r web_service/backend/requirements.txt (line 27))
+2026-01-22T23:52:37.3472681Z   Using cached websockets-12.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.6 kB)
+2026-01-22T23:52:37.3574991Z Collecting wsproto==1.2.0 (from -r web_service/backend/requirements.txt (line 28))
+2026-01-22T23:52:37.3589589Z   Using cached wsproto-1.2.0-py3-none-any.whl.metadata (5.6 kB)
+2026-01-22T23:52:37.3826520Z Collecting requests==2.31.0 (from -r web_service/backend/requirements.txt (line 31))
+2026-01-22T23:52:37.3840234Z   Using cached requests-2.31.0-py3-none-any.whl.metadata (4.6 kB)
+2026-01-22T23:52:37.4057229Z Collecting urllib3==2.1.0 (from -r web_service/backend/requirements.txt (line 32))
+2026-01-22T23:52:37.4071289Z   Using cached urllib3-2.1.0-py3-none-any.whl.metadata (6.4 kB)
+2026-01-22T23:52:37.4251611Z Collecting certifi==2023.7.22 (from -r web_service/backend/requirements.txt (line 33))
+2026-01-22T23:52:37.4265395Z   Using cached certifi-2023.7.22-py3-none-any.whl.metadata (2.2 kB)
+2026-01-22T23:52:37.5013117Z Collecting charset-normalizer==3.3.2 (from -r web_service/backend/requirements.txt (line 34))
+2026-01-22T23:52:37.5029204Z   Using cached charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (33 kB)
+2026-01-22T23:52:37.5151039Z Collecting idna==3.6 (from -r web_service/backend/requirements.txt (line 35))
+2026-01-22T23:52:37.5164797Z   Using cached idna-3.6-py3-none-any.whl.metadata (9.9 kB)
+2026-01-22T23:52:37.8420625Z Collecting sqlalchemy==2.0.23 (from -r web_service/backend/requirements.txt (line 38))
+2026-01-22T23:52:37.8437797Z   Using cached SQLAlchemy-2.0.23-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (9.6 kB)
+2026-01-22T23:52:37.9635144Z Collecting greenlet==3.0.2 (from -r web_service/backend/requirements.txt (line 39))
+2026-01-22T23:52:37.9650622Z   Using cached greenlet-3.0.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl.metadata (3.7 kB)
+2026-01-22T23:52:37.9749606Z Collecting aiosqlite==0.19.0 (from -r web_service/backend/requirements.txt (line 40))
+2026-01-22T23:52:37.9763195Z   Using cached aiosqlite-0.19.0-py3-none-any.whl.metadata (4.3 kB)
+2026-01-22T23:52:38.0384943Z Collecting psycopg2-binary==2.9.9 (from -r web_service/backend/requirements.txt (line 41))
+2026-01-22T23:52:38.0401327Z   Using cached psycopg2_binary-2.9.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.4 kB)
+2026-01-22T23:52:38.2757018Z Collecting numpy==1.24.3 (from -r web_service/backend/requirements.txt (line 44))
+2026-01-22T23:52:38.2773193Z   Using cached numpy-1.24.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (5.6 kB)
+2026-01-22T23:52:38.4584322Z Collecting pandas==2.0.3 (from -r web_service/backend/requirements.txt (line 45))
+2026-01-22T23:52:38.4600069Z   Using cached pandas-2.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (18 kB)
+2026-01-22T23:52:38.4850673Z Collecting python-dateutil==2.8.2 (from -r web_service/backend/requirements.txt (line 46))
+2026-01-22T23:52:38.4865311Z   Using cached python_dateutil-2.8.2-py2.py3-none-any.whl.metadata (8.2 kB)
+2026-01-22T23:52:38.5221728Z Collecting pytz==2023.3.post1 (from -r web_service/backend/requirements.txt (line 47))
+2026-01-22T23:52:38.5237860Z   Using cached pytz-2023.3.post1-py2.py3-none-any.whl.metadata (22 kB)
+2026-01-22T23:52:38.5363254Z Collecting tzdata==2023.3 (from -r web_service/backend/requirements.txt (line 48))
+2026-01-22T23:52:38.5377677Z   Using cached tzdata-2023.3-py2.py3-none-any.whl.metadata (1.4 kB)
+2026-01-22T23:52:38.5478182Z Collecting six==1.16.0 (from -r web_service/backend/requirements.txt (line 49))
+2026-01-22T23:52:38.5492952Z   Using cached six-1.16.0-py2.py3-none-any.whl.metadata (1.8 kB)
+2026-01-22T23:52:38.5634221Z Collecting beautifulsoup4==4.12.2 (from -r web_service/backend/requirements.txt (line 52))
+2026-01-22T23:52:38.5648228Z   Using cached beautifulsoup4-4.12.2-py3-none-any.whl.metadata (3.6 kB)
+2026-01-22T23:52:38.5793859Z Collecting soupsieve==2.5 (from -r web_service/backend/requirements.txt (line 53))
+2026-01-22T23:52:38.5808367Z   Using cached soupsieve-2.5-py3-none-any.whl.metadata (4.7 kB)
+2026-01-22T23:52:38.6960303Z Collecting selectolax==0.3.20 (from -r web_service/backend/requirements.txt (line 54))
+2026-01-22T23:52:38.6977879Z   Using cached selectolax-0.3.20-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (5.6 kB)
+2026-01-22T23:52:38.7144645Z Collecting click==8.1.7 (from -r web_service/backend/requirements.txt (line 57))
+2026-01-22T23:52:38.7165306Z   Using cached click-8.1.7-py3-none-any.whl.metadata (3.0 kB)
+2026-01-22T23:52:38.7305054Z Collecting python-dotenv==1.0.0 (from -r web_service/backend/requirements.txt (line 58))
+2026-01-22T23:52:38.7320467Z   Using cached python_dotenv-1.0.0-py3-none-any.whl.metadata (21 kB)
+2026-01-22T23:52:38.7721138Z Collecting pyyaml==6.0.1 (from -r web_service/backend/requirements.txt (line 59))
+2026-01-22T23:52:38.7735869Z   Using cached PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.1 kB)
+2026-01-22T23:52:39.0095107Z Collecting cryptography==41.0.7 (from -r web_service/backend/requirements.txt (line 62))
+2026-01-22T23:52:39.0111520Z   Using cached cryptography-41.0.7-cp37-abi3-manylinux_2_28_x86_64.whl.metadata (5.2 kB)
+2026-01-22T23:52:39.1121058Z Collecting cffi==1.16.0 (from -r web_service/backend/requirements.txt (line 63))
+2026-01-22T23:52:39.1138756Z   Using cached cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.5 kB)
+2026-01-22T23:52:39.1245972Z Collecting pycparser==2.21 (from -r web_service/backend/requirements.txt (line 64))
+2026-01-22T23:52:39.1260391Z   Using cached pycparser-2.21-py2.py3-none-any.whl.metadata (1.1 kB)
+2026-01-22T23:52:39.1357671Z Collecting secretstorage==3.5.0 (from -r web_service/backend/requirements.txt (line 65))
+2026-01-22T23:52:39.1372183Z   Using cached secretstorage-3.5.0-py3-none-any.whl.metadata (4.0 kB)
+2026-01-22T23:52:39.1676071Z Collecting keyring==24.3.0 (from -r web_service/backend/requirements.txt (line 66))
+2026-01-22T23:52:39.1692211Z   Using cached keyring-24.3.0-py3-none-any.whl.metadata (20 kB)
+2026-01-22T23:52:39.1824657Z Collecting jeepney==0.9.0 (from -r web_service/backend/requirements.txt (line 67))
+2026-01-22T23:52:39.1839181Z   Using cached jeepney-0.9.0-py3-none-any.whl.metadata (1.2 kB)
+2026-01-22T23:52:39.2094324Z Collecting redis==5.0.1 (from -r web_service/backend/requirements.txt (line 70))
+2026-01-22T23:52:39.2108611Z   Using cached redis-5.0.1-py3-none-any.whl.metadata (8.9 kB)
+2026-01-22T23:52:39.2319643Z Collecting limits==3.7.0 (from -r web_service/backend/requirements.txt (line 71))
+2026-01-22T23:52:39.2334704Z   Using cached limits-3.7.0-py3-none-any.whl.metadata (7.3 kB)
+2026-01-22T23:52:39.2485635Z Collecting slowapi==0.1.9 (from -r web_service/backend/requirements.txt (line 72))
+2026-01-22T23:52:39.2499809Z   Using cached slowapi-0.1.9-py3-none-any.whl.metadata (3.0 kB)
+2026-01-22T23:52:39.2635304Z Collecting tenacity==8.2.3 (from -r web_service/backend/requirements.txt (line 73))
+2026-01-22T23:52:39.2649583Z   Using cached tenacity-8.2.3-py3-none-any.whl.metadata (1.0 kB)
+2026-01-22T23:52:39.2846762Z Collecting pywebview==5.4 (from -r web_service/backend/requirements.txt (line 76))
+2026-01-22T23:52:39.2861384Z   Using cached pywebview-5.4-py3-none-any.whl.metadata (4.5 kB)
+2026-01-22T23:52:39.3044648Z Collecting bottle==0.13.4 (from -r web_service/backend/requirements.txt (line 77))
+2026-01-22T23:52:39.3059496Z   Using cached bottle-0.13.4-py2.py3-none-any.whl.metadata (1.6 kB)
+2026-01-22T23:52:39.3154045Z Collecting proxy-tools==0.1.0 (from -r web_service/backend/requirements.txt (line 78))
+2026-01-22T23:52:39.3155714Z   Using cached proxy_tools-0.1.0-py3-none-any.whl
+2026-01-22T23:52:39.3890646Z Collecting psutil==5.9.6 (from -r web_service/backend/requirements.txt (line 82))
+2026-01-22T23:52:39.3909080Z   Using cached psutil-5.9.6-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (21 kB)
+2026-01-22T23:52:39.4056579Z Collecting structlog==23.2.0 (from -r web_service/backend/requirements.txt (line 85))
+2026-01-22T23:52:39.4071254Z   Using cached structlog-23.2.0-py3-none-any.whl.metadata (7.6 kB)
+2026-01-22T23:52:39.4701842Z Collecting black==23.12.0 (from -r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:52:39.4718306Z   Using cached black-23.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (68 kB)
+2026-01-22T23:52:39.5178510Z Collecting pyinstaller==6.1.0 (from -r web_service/backend/requirements.txt (line 89))
+2026-01-22T23:52:39.5195250Z   Using cached pyinstaller-6.1.0-py3-none-manylinux2014_x86_64.whl.metadata (8.2 kB)
+2026-01-22T23:52:39.5390000Z Collecting pyinstaller-hooks-contrib==2023.11 (from -r web_service/backend/requirements.txt (line 90))
+2026-01-22T23:52:39.5405917Z   Using cached pyinstaller_hooks_contrib-2023.11-py2.py3-none-any.whl.metadata (15 kB)
+2026-01-22T23:52:39.5509164Z Collecting altgraph==0.17.3 (from -r web_service/backend/requirements.txt (line 91))
+2026-01-22T23:52:39.5525787Z   Using cached altgraph-0.17.3-py2.py3-none-any.whl.metadata (7.4 kB)
+2026-01-22T23:52:39.5708233Z Collecting wheel==0.41.2 (from -r web_service/backend/requirements.txt (line 92))
+2026-01-22T23:52:39.5724126Z   Using cached wheel-0.41.2-py3-none-any.whl.metadata (2.2 kB)
+2026-01-22T23:52:39.5846053Z Collecting build==1.0.3 (from -r web_service/backend/requirements.txt (line 93))
+2026-01-22T23:52:39.5860453Z   Using cached build-1.0.3-py3-none-any.whl.metadata (4.2 kB)
+2026-01-22T23:52:39.6137114Z Collecting pip-tools==7.3.0 (from -r web_service/backend/requirements.txt (line 94))
+2026-01-22T23:52:39.6152206Z   Using cached pip_tools-7.3.0-py3-none-any.whl.metadata (23 kB)
+2026-01-22T23:52:39.6475699Z Collecting pytest==7.4.3 (from -r web_service/backend/requirements.txt (line 97))
+2026-01-22T23:52:39.6490705Z   Using cached pytest-7.4.3-py3-none-any.whl.metadata (7.9 kB)
+2026-01-22T23:52:39.6754307Z Collecting pytest-asyncio==0.21.1 (from -r web_service/backend/requirements.txt (line 98))
+2026-01-22T23:52:39.6768158Z   Using cached pytest_asyncio-0.21.1-py3-none-any.whl.metadata (4.0 kB)
+2026-01-22T23:52:39.6856261Z Collecting iniconfig==2.0.0 (from -r web_service/backend/requirements.txt (line 99))
+2026-01-22T23:52:39.6871730Z   Using cached iniconfig-2.0.0-py3-none-any.whl.metadata (2.6 kB)
+2026-01-22T23:52:39.6982618Z Collecting pluggy==1.3.0 (from -r web_service/backend/requirements.txt (line 100))
+2026-01-22T23:52:39.6996729Z   Using cached pluggy-1.3.0-py3-none-any.whl.metadata (4.3 kB)
+2026-01-22T23:52:39.7144610Z Collecting packaging==23.2 (from -r web_service/backend/requirements.txt (line 101))
+2026-01-22T23:52:39.7159575Z   Using cached packaging-23.2-py3-none-any.whl.metadata (3.2 kB)
+2026-01-22T23:52:39.7307778Z Collecting typing-extensions==4.8.0 (from -r web_service/backend/requirements.txt (line 104))
+2026-01-22T23:52:39.7322369Z   Using cached typing_extensions-4.8.0-py3-none-any.whl.metadata (3.0 kB)
+2026-01-22T23:52:39.7429704Z Collecting typing-inspect==0.9.0 (from -r web_service/backend/requirements.txt (line 105))
+2026-01-22T23:52:39.7444317Z   Using cached typing_inspect-0.9.0-py3-none-any.whl.metadata (1.5 kB)
+2026-01-22T23:52:39.7556920Z Collecting annotated-types==0.6.0 (from -r web_service/backend/requirements.txt (line 106))
+2026-01-22T23:52:39.7570479Z   Using cached annotated_types-0.6.0-py3-none-any.whl.metadata (12 kB)
+2026-01-22T23:52:39.7662549Z Collecting mypy-extensions==1.0.0 (from -r web_service/backend/requirements.txt (line 109))
+2026-01-22T23:52:39.7677490Z   Using cached mypy_extensions-1.0.0-py3-none-any.whl.metadata (1.1 kB)
+2026-01-22T23:52:39.7783232Z Collecting pathspec==0.11.2 (from -r web_service/backend/requirements.txt (line 110))
+2026-01-22T23:52:39.7798101Z   Using cached pathspec-0.11.2-py3-none-any.whl.metadata (19 kB)
+2026-01-22T23:52:39.7948067Z Collecting platformdirs==4.0.0 (from -r web_service/backend/requirements.txt (line 111))
+2026-01-22T23:52:39.7962445Z   Using cached platformdirs-4.0.0-py3-none-any.whl.metadata (11 kB)
+2026-01-22T23:52:39.8128404Z Collecting more-itertools==10.1.0 (from -r web_service/backend/requirements.txt (line 112))
+2026-01-22T23:52:39.8142679Z   Using cached more_itertools-10.1.0-py3-none-any.whl.metadata (33 kB)
+2026-01-22T23:52:39.8238725Z Collecting jaraco.classes==3.3.1 (from -r web_service/backend/requirements.txt (line 113))
+2026-01-22T23:52:39.8252728Z   Using cached jaraco.classes-3.3.1-py3-none-any.whl.metadata (2.7 kB)
+2026-01-22T23:52:39.8358659Z Collecting jaraco.context==5.3.0 (from -r web_service/backend/requirements.txt (line 114))
+2026-01-22T23:52:39.8373000Z   Using cached jaraco.context-5.3.0-py3-none-any.whl.metadata (4.0 kB)
+2026-01-22T23:52:39.8516386Z Collecting jaraco.functools==4.0.0 (from -r web_service/backend/requirements.txt (line 115))
+2026-01-22T23:52:39.8530251Z   Using cached jaraco.functools-4.0.0-py3-none-any.whl.metadata (3.1 kB)
+2026-01-22T23:52:39.8639184Z Collecting deprecated==1.2.14 (from -r web_service/backend/requirements.txt (line 116))
+2026-01-22T23:52:39.8653133Z   Using cached Deprecated-1.2.14-py2.py3-none-any.whl.metadata (5.4 kB)
+2026-01-22T23:52:39.8730523Z Collecting sniffio==1.3.0 (from -r web_service/backend/requirements.txt (line 117))
+2026-01-22T23:52:39.8744552Z   Using cached sniffio-1.3.0-py3-none-any.whl.metadata (3.6 kB)
+2026-01-22T23:52:40.0943782Z Collecting wrapt==1.16.0 (from -r web_service/backend/requirements.txt (line 118))
+2026-01-22T23:52:40.0961220Z   Using cached wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.6 kB)
+2026-01-22T23:52:40.1676449Z Collecting watchfiles==0.20.0 (from -r web_service/backend/requirements.txt (line 119))
+2026-01-22T23:52:40.1692479Z   Using cached watchfiles-0.20.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.9 kB)
+2026-01-22T23:52:40.1874973Z Collecting pygments==2.17.2 (from -r web_service/backend/requirements.txt (line 120))
+2026-01-22T23:52:40.1889204Z   Using cached pygments-2.17.2-py3-none-any.whl.metadata (2.6 kB)
+2026-01-22T23:52:40.4373550Z Collecting importlib-metadata>=4.11.4 (from keyring==24.3.0->-r web_service/backend/requirements.txt (line 66))
+2026-01-22T23:52:40.4388784Z   Using cached importlib_metadata-8.7.1-py3-none-any.whl.metadata (4.7 kB)
+2026-01-22T23:52:40.4735892Z Collecting importlib-resources>=1.3 (from limits==3.7.0->-r web_service/backend/requirements.txt (line 71))
+2026-01-22T23:52:40.4750154Z   Using cached importlib_resources-6.5.2-py3-none-any.whl.metadata (3.9 kB)
+2026-01-22T23:52:41.1512299Z Collecting aiohttp>=3.7.4 (from black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:52:41.1528715Z   Using cached aiohttp-3.13.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (8.1 kB)
+2026-01-22T23:52:41.1590750Z Requirement already satisfied: setuptools>=42.0.0 in /opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages (from pyinstaller==6.1.0->-r web_service/backend/requirements.txt (line 89)) (80.10.1)
+2026-01-22T23:52:41.1896738Z Collecting pyproject_hooks (from build==1.0.3->-r web_service/backend/requirements.txt (line 93))
+2026-01-22T23:52:41.1911511Z   Using cached pyproject_hooks-1.2.0-py3-none-any.whl.metadata (1.3 kB)
+2026-01-22T23:52:41.1955511Z Requirement already satisfied: pip>=22.2 in /opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages (from pip-tools==7.3.0->-r web_service/backend/requirements.txt (line 94)) (25.3)
+2026-01-22T23:52:41.2460516Z Collecting backports.tarfile (from jaraco.context==5.3.0->-r web_service/backend/requirements.txt (line 114))
+2026-01-22T23:52:41.2475244Z   Using cached backports.tarfile-1.2.0-py3-none-any.whl.metadata (2.0 kB)
+2026-01-22T23:52:41.3189338Z Collecting uvloop!=0.15.0,!=0.15.1,>=0.14.0 (from uvicorn[standard]==0.24.0->-r web_service/backend/requirements.txt (line 12))
+2026-01-22T23:52:41.3206221Z   Using cached uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (4.9 kB)
+2026-01-22T23:52:41.3436115Z Collecting aiohappyeyeballs>=2.5.0 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:52:41.3454584Z   Using cached aiohappyeyeballs-2.6.1-py3-none-any.whl.metadata (5.9 kB)
+2026-01-22T23:52:41.3552661Z Collecting aiosignal>=1.4.0 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:52:41.3567271Z   Using cached aiosignal-1.4.0-py3-none-any.whl.metadata (3.7 kB)
+2026-01-22T23:52:41.3697921Z Collecting attrs>=17.3.0 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:52:41.3712391Z   Using cached attrs-25.4.0-py3-none-any.whl.metadata (10 kB)
+2026-01-22T23:52:41.4364318Z Collecting frozenlist>=1.1.1 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:52:41.4380972Z   Using cached frozenlist-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl.metadata (20 kB)
+2026-01-22T23:52:41.6677184Z Collecting multidict<7.0,>=4.5 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:52:41.6694542Z   Using cached multidict-6.7.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (5.3 kB)
+2026-01-22T23:52:41.7237935Z Collecting propcache>=0.2.0 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:52:41.7253511Z   Using cached propcache-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (13 kB)
+2026-01-22T23:52:41.9846532Z Collecting yarl<2.0,>=1.17.0 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-22T23:52:41.9861362Z   Using cached yarl-1.22.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (75 kB)
+2026-01-22T23:52:42.0424010Z Collecting zipp>=3.20 (from importlib-metadata>=4.11.4->keyring==24.3.0->-r web_service/backend/requirements.txt (line 66))
+2026-01-22T23:52:42.0438796Z   Using cached zipp-3.23.0-py3-none-any.whl.metadata (3.6 kB)
+2026-01-22T23:52:42.0720818Z Using cached fastapi-0.104.1-py3-none-any.whl (92 kB)
+2026-01-22T23:52:42.0735834Z Using cached starlette-0.27.0-py3-none-any.whl (66 kB)
+2026-01-22T23:52:42.0750407Z Using cached pydantic-2.5.0-py3-none-any.whl (407 kB)
+2026-01-22T23:52:42.0767009Z Using cached anyio-3.7.1-py3-none-any.whl (80 kB)
+2026-01-22T23:52:42.0780754Z Using cached uvicorn-0.24.0-py3-none-any.whl (59 kB)
+2026-01-22T23:52:42.0795255Z Using cached pydantic_core-2.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (2.1 MB)
+2026-01-22T23:52:42.0823967Z Using cached pydantic_settings-2.1.0-py3-none-any.whl (11 kB)
+2026-01-22T23:52:42.0837143Z Using cached h11-0.14.0-py3-none-any.whl (58 kB)
+2026-01-22T23:52:42.0850582Z Using cached h2-4.1.0-py3-none-any.whl (57 kB)
+2026-01-22T23:52:42.0864527Z Using cached hpack-4.0.0-py3-none-any.whl (32 kB)
+2026-01-22T23:52:42.0878026Z Using cached hyperframe-6.1.0-py3-none-any.whl (13 kB)
+2026-01-22T23:52:42.0891521Z Using cached httpcore-1.0.2-py3-none-any.whl (76 kB)
+2026-01-22T23:52:42.0906194Z Using cached httptools-0.6.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (318 kB)
+2026-01-22T23:52:42.0921591Z Using cached httpx-0.25.2-py3-none-any.whl (74 kB)
+2026-01-22T23:52:42.0936435Z Using cached websockets-12.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (130 kB)
+2026-01-22T23:52:42.0950362Z Using cached wsproto-1.2.0-py3-none-any.whl (24 kB)
+2026-01-22T23:52:42.0963976Z Using cached requests-2.31.0-py3-none-any.whl (62 kB)
+2026-01-22T23:52:42.0977511Z Using cached urllib3-2.1.0-py3-none-any.whl (104 kB)
+2026-01-22T23:52:42.0992222Z Using cached charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (140 kB)
+2026-01-22T23:52:42.1006540Z Using cached idna-3.6-py3-none-any.whl (61 kB)
+2026-01-22T23:52:42.1020224Z Using cached certifi-2023.7.22-py3-none-any.whl (158 kB)
+2026-01-22T23:52:42.1035408Z Using cached SQLAlchemy-2.0.23-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.2 MB)
+2026-01-22T23:52:42.1072907Z Using cached greenlet-3.0.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (616 kB)
+2026-01-22T23:52:42.1090770Z Using cached aiosqlite-0.19.0-py3-none-any.whl (15 kB)
+2026-01-22T23:52:42.1105202Z Using cached psycopg2_binary-2.9.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.0 MB)
+2026-01-22T23:52:42.1141519Z Using cached numpy-1.24.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.3 MB)
+2026-01-22T23:52:42.1284074Z Using cached pandas-2.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (12.2 MB)
+2026-01-22T23:52:42.1388728Z Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
+2026-01-22T23:52:42.1403623Z Using cached pytz-2023.3.post1-py2.py3-none-any.whl (502 kB)
+2026-01-22T23:52:42.1420557Z Using cached tzdata-2023.3-py2.py3-none-any.whl (341 kB)
+2026-01-22T23:52:42.1436264Z Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
+2026-01-22T23:52:42.1450025Z Using cached beautifulsoup4-4.12.2-py3-none-any.whl (142 kB)
+2026-01-22T23:52:42.1464356Z Using cached soupsieve-2.5-py3-none-any.whl (36 kB)
+2026-01-22T23:52:42.1480167Z Using cached selectolax-0.3.20-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (6.7 MB)
+2026-01-22T23:52:42.1545015Z Using cached click-8.1.7-py3-none-any.whl (97 kB)
+2026-01-22T23:52:42.1560422Z Using cached python_dotenv-1.0.0-py3-none-any.whl (19 kB)
+2026-01-22T23:52:42.1575619Z Using cached PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (757 kB)
+2026-01-22T23:52:42.1596291Z Using cached cryptography-41.0.7-cp37-abi3-manylinux_2_28_x86_64.whl (4.4 MB)
+2026-01-22T23:52:42.1646275Z Using cached cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (464 kB)
+2026-01-22T23:52:42.1663766Z Using cached pycparser-2.21-py2.py3-none-any.whl (118 kB)
+2026-01-22T23:52:42.1678547Z Using cached secretstorage-3.5.0-py3-none-any.whl (15 kB)
+2026-01-22T23:52:42.1691823Z Using cached keyring-24.3.0-py3-none-any.whl (38 kB)
+2026-01-22T23:52:42.1705764Z Using cached jeepney-0.9.0-py3-none-any.whl (49 kB)
+2026-01-22T23:52:42.1719188Z Using cached redis-5.0.1-py3-none-any.whl (250 kB)
+2026-01-22T23:52:42.1734349Z Using cached limits-3.7.0-py3-none-any.whl (43 kB)
+2026-01-22T23:52:42.1747612Z Using cached packaging-23.2-py3-none-any.whl (53 kB)
+2026-01-22T23:52:42.1760738Z Using cached slowapi-0.1.9-py3-none-any.whl (14 kB)
+2026-01-22T23:52:42.1774435Z Using cached tenacity-8.2.3-py3-none-any.whl (24 kB)
+2026-01-22T23:52:42.1787373Z Using cached pywebview-5.4-py3-none-any.whl (475 kB)
+2026-01-22T23:52:42.1804799Z Using cached bottle-0.13.4-py2.py3-none-any.whl (103 kB)
+2026-01-22T23:52:42.1819315Z Using cached psutil-5.9.6-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (283 kB)
+2026-01-22T23:52:42.1834635Z Using cached structlog-23.2.0-py3-none-any.whl (62 kB)
+2026-01-22T23:52:42.1848977Z Using cached black-23.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.7 MB)
+2026-01-22T23:52:42.1874866Z Using cached pyinstaller-6.1.0-py3-none-manylinux2014_x86_64.whl (658 kB)
+2026-01-22T23:52:42.1893048Z Using cached pyinstaller_hooks_contrib-2023.11-py2.py3-none-any.whl (294 kB)
+2026-01-22T23:52:42.1908814Z Using cached altgraph-0.17.3-py2.py3-none-any.whl (21 kB)
+2026-01-22T23:52:42.1921715Z Using cached wheel-0.41.2-py3-none-any.whl (64 kB)
+2026-01-22T23:52:42.1935256Z Using cached build-1.0.3-py3-none-any.whl (18 kB)
+2026-01-22T23:52:42.1948024Z Using cached pip_tools-7.3.0-py3-none-any.whl (57 kB)
+2026-01-22T23:52:42.1961355Z Using cached pytest-7.4.3-py3-none-any.whl (325 kB)
+2026-01-22T23:52:42.1977093Z Using cached pluggy-1.3.0-py3-none-any.whl (18 kB)
+2026-01-22T23:52:42.1989818Z Using cached pytest_asyncio-0.21.1-py3-none-any.whl (13 kB)
+2026-01-22T23:52:42.2002750Z Using cached iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
+2026-01-22T23:52:42.2016219Z Using cached typing_extensions-4.8.0-py3-none-any.whl (31 kB)
+2026-01-22T23:52:42.2029016Z Using cached typing_inspect-0.9.0-py3-none-any.whl (8.8 kB)
+2026-01-22T23:52:42.2042322Z Using cached annotated_types-0.6.0-py3-none-any.whl (12 kB)
+2026-01-22T23:52:42.2056258Z Using cached mypy_extensions-1.0.0-py3-none-any.whl (4.7 kB)
+2026-01-22T23:52:42.2070227Z Using cached pathspec-0.11.2-py3-none-any.whl (29 kB)
+2026-01-22T23:52:42.2083900Z Using cached platformdirs-4.0.0-py3-none-any.whl (17 kB)
+2026-01-22T23:52:42.2096871Z Using cached more_itertools-10.1.0-py3-none-any.whl (55 kB)
+2026-01-22T23:52:42.2109870Z Using cached jaraco.classes-3.3.1-py3-none-any.whl (6.8 kB)
+2026-01-22T23:52:42.2122737Z Using cached jaraco.context-5.3.0-py3-none-any.whl (6.5 kB)
+2026-01-22T23:52:42.2135691Z Using cached jaraco.functools-4.0.0-py3-none-any.whl (9.8 kB)
+2026-01-22T23:52:42.2148564Z Using cached Deprecated-1.2.14-py2.py3-none-any.whl (9.6 kB)
+2026-01-22T23:52:42.2162519Z Using cached wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (80 kB)
+2026-01-22T23:52:42.2175691Z Using cached sniffio-1.3.0-py3-none-any.whl (10 kB)
+2026-01-22T23:52:42.2189878Z Using cached watchfiles-0.20.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.3 MB)
+2026-01-22T23:52:42.2211861Z Using cached pygments-2.17.2-py3-none-any.whl (1.2 MB)
+2026-01-22T23:52:42.2235321Z Using cached aiohttp-3.13.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (1.7 MB)
+2026-01-22T23:52:42.2260828Z Using cached multidict-6.7.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (246 kB)
+2026-01-22T23:52:42.2276907Z Using cached yarl-1.22.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (365 kB)
+2026-01-22T23:52:42.2292066Z Using cached aiohappyeyeballs-2.6.1-py3-none-any.whl (15 kB)
+2026-01-22T23:52:42.2305221Z Using cached aiosignal-1.4.0-py3-none-any.whl (7.5 kB)
+2026-01-22T23:52:42.2318309Z Using cached attrs-25.4.0-py3-none-any.whl (67 kB)
+2026-01-22T23:52:42.2333615Z Using cached frozenlist-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl (231 kB)
+2026-01-22T23:52:42.2347699Z Using cached importlib_metadata-8.7.1-py3-none-any.whl (27 kB)
+2026-01-22T23:52:42.2361400Z Using cached importlib_resources-6.5.2-py3-none-any.whl (37 kB)
+2026-01-22T23:52:42.2375292Z Using cached propcache-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (210 kB)
+2026-01-22T23:52:42.2389850Z Using cached uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (3.8 MB)
+2026-01-22T23:52:42.2430683Z Using cached zipp-3.23.0-py3-none-any.whl (10 kB)
+2026-01-22T23:52:42.2444141Z Using cached backports.tarfile-1.2.0-py3-none-any.whl (30 kB)
+2026-01-22T23:52:42.2457146Z Using cached pyproject_hooks-1.2.0-py3-none-any.whl (10 kB)
+2026-01-22T23:52:42.5136384Z Installing collected packages: selectolax, pytz, proxy-tools, bottle, altgraph, zipp, wrapt, wheel, websockets, uvloop, urllib3, tzdata, typing-extensions, tenacity, structlog, soupsieve, sniffio, six, redis, pyyaml, python-dotenv, pyproject_hooks, pyinstaller-hooks-contrib, pygments, pycparser, psycopg2-binary, psutil, propcache, pluggy, platformdirs, pathspec, packaging, numpy, mypy-extensions, multidict, more-itertools, jeepney, iniconfig, importlib-resources, idna, hyperframe, httptools, hpack, h11, greenlet, frozenlist, click, charset-normalizer, certifi, backports.tarfile, attrs, annotated-types, aiosqlite, aiohappyeyeballs, yarl, wsproto, uvicorn, typing-inspect, sqlalchemy, requests, pywebview, python-dateutil, pytest, pyinstaller, pydantic-core, jaraco.functools, jaraco.context, jaraco.classes, importlib-metadata, httpcore, h2, deprecated, cffi, build, beautifulsoup4, anyio, aiosignal, watchfiles, starlette, pytest-asyncio, pydantic, pip-tools, pandas, limits, httpx, cryptography, aiohttp, slowapi, secretstorage, pydantic-settings, fastapi, black, keyring
+2026-01-22T23:52:42.8413357Z   Attempting uninstall: wheel
+2026-01-22T23:52:42.8431312Z     Found existing installation: wheel 0.46.3
+2026-01-22T23:52:42.8461720Z     Uninstalling wheel-0.46.3:
+2026-01-22T23:52:42.8474339Z       Successfully uninstalled wheel-0.46.3
+2026-01-22T23:52:44.7915765Z   Attempting uninstall: packaging
+2026-01-22T23:52:44.7935545Z     Found existing installation: packaging 26.0
+2026-01-22T23:52:44.7965112Z     Uninstalling packaging-26.0:
+2026-01-22T23:52:44.7974922Z       Successfully uninstalled packaging-26.0
+2026-01-22T23:52:54.6807348Z
+2026-01-22T23:52:54.6859846Z Successfully installed aiohappyeyeballs-2.6.1 aiohttp-3.13.3 aiosignal-1.4.0 aiosqlite-0.19.0 altgraph-0.17.3 annotated-types-0.6.0 anyio-3.7.1 attrs-25.4.0 backports.tarfile-1.2.0 beautifulsoup4-4.12.2 black-23.12.0 bottle-0.13.4 build-1.0.3 certifi-2023.7.22 cffi-1.16.0 charset-normalizer-3.3.2 click-8.1.7 cryptography-41.0.7 deprecated-1.2.14 fastapi-0.104.1 frozenlist-1.8.0 greenlet-3.0.2 h11-0.14.0 h2-4.1.0 hpack-4.0.0 httpcore-1.0.2 httptools-0.6.1 httpx-0.25.2 hyperframe-6.1.0 idna-3.6 importlib-metadata-8.7.1 importlib-resources-6.5.2 iniconfig-2.0.0 jaraco.classes-3.3.1 jaraco.context-5.3.0 jaraco.functools-4.0.0 jeepney-0.9.0 keyring-24.3.0 limits-3.7.0 more-itertools-10.1.0 multidict-6.7.0 mypy-extensions-1.0.0 numpy-1.24.3 packaging-23.2 pandas-2.0.3 pathspec-0.11.2 pip-tools-7.3.0 platformdirs-4.0.0 pluggy-1.3.0 propcache-0.4.1 proxy-tools-0.1.0 psutil-5.9.6 psycopg2-binary-2.9.9 pycparser-2.21 pydantic-2.5.0 pydantic-core-2.14.1 pydantic-settings-2.1.0 pygments-2.17.2 pyinstaller-6.1.0 pyinstaller-hooks-contrib-2023.11 pyproject_hooks-1.2.0 pytest-7.4.3 pytest-asyncio-0.21.1 python-dateutil-2.8.2 python-dotenv-1.0.0 pytz-2023.3.post1 pywebview-5.4 pyyaml-6.0.1 redis-5.0.1 requests-2.31.0 secretstorage-3.5.0 selectolax-0.3.20 six-1.16.0 slowapi-0.1.9 sniffio-1.3.0 soupsieve-2.5 sqlalchemy-2.0.23 starlette-0.27.0 structlog-23.2.0 tenacity-8.2.3 typing-extensions-4.8.0 typing-inspect-0.9.0 tzdata-2023.3 urllib3-2.1.0 uvicorn-0.24.0 uvloop-0.22.1 watchfiles-0.20.0 websockets-12.0 wheel-0.41.2 wrapt-1.16.0 wsproto-1.2.0 yarl-1.22.0 zipp-3.23.0
+2026-01-22T23:52:55.6975374Z ##[group]Run mkdir -p web_service/backend/{data,json,logs}
+2026-01-22T23:52:55.6975811Z [36;1mmkdir -p web_service/backend/{data,json,logs}[0m
+2026-01-22T23:52:55.6976108Z [36;1mmkdir -p reports/archive[0m
+2026-01-22T23:52:55.7009500Z shell: /usr/bin/bash -e {0}
+2026-01-22T23:52:55.7009742Z env:
+2026-01-22T23:52:55.7009965Z   PYTHON_VERSION: 3.11
+2026-01-22T23:52:55.7010196Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:52:55.7010409Z   MAX_RETRIES: 3
+2026-01-22T23:52:55.7010595Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:52:55.7010869Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:55.7011296Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-22T23:52:55.7011708Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:55.7012346Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:55.7012727Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:55.7013157Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-22T23:52:55.7013466Z ##[endgroup]
+2026-01-22T23:52:55.7211286Z ##[group]Run actions/cache@v4
+2026-01-22T23:52:55.7211538Z with:
+2026-01-22T23:52:55.7211819Z   path: web_service/backend/data/*.cache
+web_service/backend/json/*.cache
+
+2026-01-22T23:52:55.7212643Z   key: race-data-Linux-32
+2026-01-22T23:52:55.7213016Z   restore-keys: race-data-Linux-
+
+2026-01-22T23:52:55.7213269Z   enableCrossOsArchive: false
+2026-01-22T23:52:55.7213489Z   fail-on-cache-miss: false
+2026-01-22T23:52:55.7213716Z   lookup-only: false
+2026-01-22T23:52:55.7213912Z   save-always: false
+2026-01-22T23:52:55.7214084Z env:
+2026-01-22T23:52:55.7214252Z   PYTHON_VERSION: 3.11
+2026-01-22T23:52:55.7214454Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:52:55.7214652Z   MAX_RETRIES: 3
+2026-01-22T23:52:55.7214833Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:52:55.7215099Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:55.7215516Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-22T23:52:55.7215940Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:55.7216288Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:55.7216905Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:55.7217265Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-22T23:52:55.7217572Z ##[endgroup]
+2026-01-22T23:52:56.0064093Z Cache not found for input keys: race-data-Linux-32, race-data-Linux-
+2026-01-22T23:52:56.0163119Z ##[group]Run set -o pipefail
+2026-01-22T23:52:56.0163425Z [36;1mset -o pipefail[0m
+2026-01-22T23:52:56.0163776Z [36;1mpython scripts/fortuna_reporter.py 2>&1 | tee reporter_output.log[0m
+2026-01-22T23:52:56.0164136Z [36;1m[0m
+2026-01-22T23:52:56.0164346Z [36;1m# Extract metrics from the log for outputs[0m
+2026-01-22T23:52:56.0164642Z [36;1mif [ -f "qualified_races.json" ]; then[0m
+2026-01-22T23:52:56.0165149Z [36;1m  RACE_COUNT=$(python -c "import json; print(len(json.load(open('qualified_races.json')).get('races', [])))")[0m
+2026-01-22T23:52:56.0165688Z [36;1m  echo "race_count=${RACE_COUNT}" >> $GITHUB_OUTPUT[0m
+2026-01-22T23:52:56.0166007Z [36;1m  echo "status=success" >> $GITHUB_OUTPUT[0m
+2026-01-22T23:52:56.0166274Z [36;1melse[0m
+2026-01-22T23:52:56.0166474Z [36;1m  echo "race_count=0" >> $GITHUB_OUTPUT[0m
+2026-01-22T23:52:56.0166756Z [36;1m  echo "status=failed" >> $GITHUB_OUTPUT[0m
+2026-01-22T23:52:56.0167000Z [36;1mfi[0m
+2026-01-22T23:52:56.0200125Z shell: /usr/bin/bash -e {0}
+2026-01-22T23:52:56.0200349Z env:
+2026-01-22T23:52:56.0200515Z   PYTHON_VERSION: 3.11
+2026-01-22T23:52:56.0200723Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:52:56.0200931Z   MAX_RETRIES: 3
+2026-01-22T23:52:56.0201105Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:52:56.0201364Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:56.0201790Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-22T23:52:56.0202458Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:56.0202833Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:56.0203184Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:56.0203547Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-22T23:52:56.0203851Z   ANALYZER_TYPE: tiny_field_trifecta
+2026-01-22T23:52:56.0204087Z   FORCE_REFRESH: false
+2026-01-22T23:52:56.0204276Z ##[endgroup]
+2026-01-22T23:52:57.1398412Z 2026-01-22 23:52:57 [info     ] CacheManager initialized (not connected).
+2026-01-22T23:52:57.1595194Z [2026-01-22 23:52:57] ℹ️ === Fortuna Unified Race Reporter ===
+2026-01-22T23:52:57.1595848Z [2026-01-22 23:52:57] ℹ️ Analyzer: tiny_field_trifecta
+2026-01-22T23:52:57.1596406Z [2026-01-22 23:52:57] ℹ️ Excluding 23 adapters
+2026-01-22T23:52:57.1597349Z 2026-01-22 23:52:57 [warning  ] encryption_key_not_found       file=.key recommendation=Run 'python manage_secrets.py' to generate a key.
+2026-01-22T23:52:57.1610632Z 2026-01-22 23:52:57 [info     ] Initializing FortunaEngine...
+2026-01-22T23:52:57.1611350Z 2026-01-22 23:52:57 [info     ] Configuration loaded.
+2026-01-22T23:52:57.1612465Z 2026-01-22 23:52:57 [info     ] Initializing adapters...
+2026-01-22T23:52:57.1613451Z 2026-01-22 23:52:57 [info     ] Attempting to initialize adapter: AtTheRacesAdapter
+2026-01-22T23:52:57.1614598Z 2026-01-22 23:52:57 [info     ] Successfully initialized adapter: AtTheRacesAdapter
+2026-01-22T23:52:57.1617067Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: BetfairAdapter
+2026-01-22T23:52:57.1618029Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: BetfairGreyhoundAdapter
+2026-01-22T23:52:57.1618992Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: BrisnetAdapter
+2026-01-22T23:52:57.1619850Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: EquibaseAdapter
+2026-01-22T23:52:57.1620682Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: FanDuelAdapter
+2026-01-22T23:52:57.1621504Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: GbgbApiAdapter
+2026-01-22T23:52:57.1622458Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: GreyhoundAdapter
+2026-01-22T23:52:57.1623645Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: HarnessAdapter
+2026-01-22T23:52:57.1624503Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: HorseRacingNationAdapter
+2026-01-22T23:52:57.1625692Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: NYRABetsAdapter
+2026-01-22T23:52:57.1626543Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: OddscheckerAdapter
+2026-01-22T23:52:57.1627210Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: PuntersAdapter
+2026-01-22T23:52:57.1627947Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: RacingAndSportsAdapter
+2026-01-22T23:52:57.1628800Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: RacingAndSportsGreyhoundAdapter
+2026-01-22T23:52:57.1629674Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: RacingPostAdapter
+2026-01-22T23:52:57.1630429Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: RacingTVAdapter
+2026-01-22T23:52:57.1631218Z 2026-01-22 23:52:57 [info     ] Attempting to initialize adapter: SportingLifeAdapter
+2026-01-22T23:52:57.1632248Z 2026-01-22 23:52:57 [info     ] Successfully initialized adapter: SportingLifeAdapter
+2026-01-22T23:52:57.1633025Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: TabAdapter
+2026-01-22T23:52:57.1633765Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: TheRacingApiAdapter
+2026-01-22T23:52:57.1634537Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: TimeformAdapter
+2026-01-22T23:52:57.1635291Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: TwinSpiresAdapter
+2026-01-22T23:52:57.1636021Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: TVGAdapter
+2026-01-22T23:52:57.1636736Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: XpressbetAdapter
+2026-01-22T23:52:57.1637560Z 2026-01-22 23:52:57 [info     ] Intentionally skipping adapter: PointsBetGreyhoundAdapter
+2026-01-22T23:52:57.1638328Z 2026-01-22 23:52:57 [info     ] 2 adapters initialized successfully.
+2026-01-22T23:52:57.1638958Z 2026-01-22 23:52:57 [info     ] Initializing HTTP client...
+2026-01-22T23:52:57.1851294Z 2026-01-22 23:52:57 [info     ] HTTP client initialized.
+2026-01-22T23:52:57.1852209Z 2026-01-22 23:52:57 [info     ] Concurrency semaphore initialized limit=10
+2026-01-22T23:52:57.1852981Z 2026-01-22 23:52:57 [info     ] FortunaEngine initialization complete.
+2026-01-22T23:52:57.1853976Z 2026-01-22 23:52:57 [info     ] AnalyzerEngine discovered plugins available_analyzers=['trifecta', 'tiny_field_trifecta']
+2026-01-22T23:52:57.1856785Z [2026-01-22 23:52:57] ℹ️ Healthy adapters: 2/2
+2026-01-22T23:52:57.1857359Z [2026-01-22 23:52:57] ℹ️ Fetching race data (attempt 1/3)...
+2026-01-22T23:52:57.1858264Z 2026-01-22 23:52:57 [info     ] Making request                 adapter_name=AtTheRaces method=GET url=https://www.attheraces.com/racecards/2026-01-22
+2026-01-22T23:52:57.1889359Z 2026-01-22 23:52:57 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-22
+2026-01-22T23:52:59.3908812Z 2026-01-22 23:52:59 [info     ] Updating stale cache           cache_type=StaleDataCache key=2026-01-22
+2026-01-22T23:52:59.3912371Z [2026-01-22 23:52:59] ✅ Saved raw race data to raw_race_data.json
+2026-01-22T23:52:59.3913126Z [2026-01-22 23:52:59] ❌ No races returned from OddsEngine. This is a critical failure.
+2026-01-22T23:52:59.3914029Z [2026-01-22 23:52:59] ℹ️ Generating Markdown summary...
+2026-01-22T23:52:59.3914707Z [2026-01-22 23:52:59] ✅ Generated Markdown summary at github_summary.md
+2026-01-22T23:52:59.3917969Z [2026-01-22 23:52:59] ℹ️ Generated 1/4 outputs
+2026-01-22T23:52:59.4836490Z ##[error]Process completed with exit code 1.
+2026-01-22T23:52:59.4901192Z ##[group]Run actions/upload-artifact@v4
+2026-01-22T23:52:59.4901468Z with:
+2026-01-22T23:52:59.4901649Z   name: race-reports-32-1
+2026-01-22T23:52:59.4902435Z   path: race-report.html
+qualified_races.json
+raw_race_data.json
+reporter_output.log
+
+2026-01-22T23:52:59.4903074Z   retention-days: 14
+2026-01-22T23:52:59.4903294Z   if-no-files-found: warn
+2026-01-22T23:52:59.4903497Z   compression-level: 9
+2026-01-22T23:52:59.4903692Z   overwrite: false
+2026-01-22T23:52:59.4903883Z   include-hidden-files: false
+2026-01-22T23:52:59.4904149Z env:
+2026-01-22T23:52:59.4904339Z   PYTHON_VERSION: 3.11
+2026-01-22T23:52:59.4904533Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:52:59.4904728Z   MAX_RETRIES: 3
+2026-01-22T23:52:59.4904923Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:52:59.4905299Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:59.4905698Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-22T23:52:59.4906119Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:59.4906468Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:59.4906815Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:52:59.4907185Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-22T23:52:59.4907492Z ##[endgroup]
+2026-01-22T23:52:59.7255992Z Multiple search paths detected. Calculating the least common ancestor of all paths
+2026-01-22T23:52:59.7263290Z The least common ancestor is /home/runner/work/fortuna/fortuna. This will be the root directory of the artifact
+2026-01-22T23:52:59.7264247Z With the provided path, there will be 4 files uploaded
+2026-01-22T23:52:59.7272211Z Artifact name is valid!
+2026-01-22T23:52:59.7274294Z Root directory input is valid!
+2026-01-22T23:52:59.8624958Z Beginning upload of artifact content to blob storage
+2026-01-22T23:52:59.9969080Z Uploaded bytes 9005
+2026-01-22T23:53:00.0330792Z Finished uploading artifact content to blob storage!
+2026-01-22T23:53:00.0333592Z SHA256 digest of uploaded artifact zip is 56be6f05f179a2f6522b3ee5f458f0e9619ffed12688d8f14189d58b17f32fca
+2026-01-22T23:53:00.0335766Z Finalizing artifact upload
+2026-01-22T23:53:00.1218936Z Artifact race-reports-32-1.zip successfully finalized. Artifact ID 5227348031
+2026-01-22T23:53:00.1220454Z Artifact race-reports-32-1 has been successfully uploaded! Final size is 9005 bytes. Artifact ID is 5227348031
+2026-01-22T23:53:00.1228270Z Artifact download URL: https://github.com/masonj0/fortuna/actions/runs/21269161950/artifacts/5227348031
+2026-01-22T23:53:00.1334676Z ##[group]Run {
+2026-01-22T23:53:00.1334951Z [36;1m{[0m
+2026-01-22T23:53:00.1335203Z [36;1m  echo "## 🐴 Fortuna Race Report Summary"[0m
+2026-01-22T23:53:00.1335519Z [36;1m  echo ""[0m
+2026-01-22T23:53:00.1335773Z [36;1m  echo "**Run:** #32 | **Status:** unknown"[0m
+2026-01-22T23:53:00.1336117Z [36;1m  echo "**Analyzer:** tiny_field_trifecta"[0m
+2026-01-22T23:53:00.1336415Z [36;1m  echo ""[0m
+2026-01-22T23:53:00.1336612Z [36;1m[0m
+2026-01-22T23:53:00.1336832Z [36;1m  if [ -f "github_summary.md" ]; then[0m
+2026-01-22T23:53:00.1337144Z [36;1m    cat github_summary.md[0m
+2026-01-22T23:53:00.1337483Z [36;1m  else[0m
+2026-01-22T23:53:00.1337735Z [36;1m    echo "### ⚠️ Detailed summary not available"[0m
+2026-01-22T23:53:00.1338117Z [36;1m    echo ""[0m
+2026-01-22T23:53:00.1338387Z [36;1m    echo "Check the artifacts for the full report."[0m
+2026-01-22T23:53:00.1338712Z [36;1m  fi[0m
+2026-01-22T23:53:00.1338919Z [36;1m[0m
+2026-01-22T23:53:00.1339172Z [36;1m  echo ""[0m
+2026-01-22T23:53:00.1339381Z [36;1m  echo "---"[0m
+2026-01-22T23:53:00.1339723Z [36;1m  echo "*Generated at $(date -u '+%Y-%m-%d %H:%M:%S UTC')*"[0m
+2026-01-22T23:53:00.1340087Z [36;1m} >> $GITHUB_STEP_SUMMARY[0m
+2026-01-22T23:53:00.1374382Z shell: /usr/bin/bash -e {0}
+2026-01-22T23:53:00.1374624Z env:
+2026-01-22T23:53:00.1374807Z   PYTHON_VERSION: 3.11
+2026-01-22T23:53:00.1375033Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:53:00.1375251Z   MAX_RETRIES: 3
+2026-01-22T23:53:00.1375445Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:53:00.1375725Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:53:00.1376208Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-22T23:53:00.1376873Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:53:00.1377268Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:53:00.1377648Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:53:00.1378043Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-22T23:53:00.1378369Z ##[endgroup]
+2026-01-22T23:53:00.1489839Z ##[group]Run echo "::warning::Report generation failed. Check logs for details."
+2026-01-22T23:53:00.1490376Z [36;1mecho "::warning::Report generation failed. Check logs for details."[0m
+2026-01-22T23:53:00.1490773Z [36;1m# Archive any partial data for debugging[0m
+2026-01-22T23:53:00.1491070Z [36;1mif ls *.json 1> /dev/null 2>&1; then[0m
+2026-01-22T23:53:00.1491418Z [36;1m  tar -czf debug-data.tar.gz *.json *.log 2>/dev/null || true[0m
+2026-01-22T23:53:00.1491732Z [36;1mfi[0m
+2026-01-22T23:53:00.1520578Z shell: /usr/bin/bash -e {0}
+2026-01-22T23:53:00.1520814Z env:
+2026-01-22T23:53:00.1521007Z   PYTHON_VERSION: 3.11
+2026-01-22T23:53:00.1521220Z   REPORT_RETENTION_DAYS: 14
+2026-01-22T23:53:00.1521438Z   MAX_RETRIES: 3
+2026-01-22T23:53:00.1521622Z   REQUEST_TIMEOUT: 30
+2026-01-22T23:53:00.1522049Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:53:00.1522505Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-22T23:53:00.1522961Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:53:00.1523346Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:53:00.1523718Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-22T23:53:00.1524090Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-22T23:53:00.1524399Z ##[endgroup]
+2026-01-22T23:53:00.1582597Z ##[warning]Report generation failed. Check logs for details.
+2026-01-22T23:53:00.1705377Z Post job cleanup.
+2026-01-22T23:53:00.2736078Z [command]/usr/bin/git version
+2026-01-22T23:53:00.2776503Z git version 2.52.0
+2026-01-22T23:53:00.2824312Z Temporarily overriding HOME='/home/runner/work/_temp/79af65e4-bf07-4954-bdb2-a854f98fb5e0' before making global git config changes
+2026-01-22T23:53:00.2825763Z Adding repository directory to the temporary git global config as a safe directory
+2026-01-22T23:53:00.2831084Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/fortuna/fortuna
+2026-01-22T23:53:00.2871080Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-01-22T23:53:00.2905459Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-01-22T23:53:00.3160231Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-01-22T23:53:00.3185617Z http.https://github.com/.extraheader
+2026-01-22T23:53:00.3199552Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2026-01-22T23:53:00.3236551Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-01-22T23:53:00.3505763Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-01-22T23:53:00.3556319Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-01-22T23:53:00.3942916Z Evaluate and set job outputs
+2026-01-22T23:53:00.3949541Z Cleaning up orphan processes

--- a/new_logs_3.txt
+++ b/new_logs_3.txt
@@ -1,0 +1,693 @@
+﻿2026-01-23T00:04:22.3242771Z Current runner version: '2.331.0'
+2026-01-23T00:04:22.3275648Z ##[group]Runner Image Provisioner
+2026-01-23T00:04:22.3276905Z Hosted Compute Agent
+2026-01-23T00:04:22.3277740Z Version: 20260115.477
+2026-01-23T00:04:22.3278609Z Commit: 4b342d620503cbe250a3154040964899ea7c9b00
+2026-01-23T00:04:22.3279818Z Build Date: 2026-01-15T22:32:41Z
+2026-01-23T00:04:22.3280874Z Worker ID: {786f5f59-95d7-4203-8ee8-d987d2448834}
+2026-01-23T00:04:22.3281898Z Azure Region: eastus2
+2026-01-23T00:04:22.3282877Z ##[endgroup]
+2026-01-23T00:04:22.3285088Z ##[group]Operating System
+2026-01-23T00:04:22.3286020Z Ubuntu
+2026-01-23T00:04:22.3286812Z 24.04.3
+2026-01-23T00:04:22.3287560Z LTS
+2026-01-23T00:04:22.3288198Z ##[endgroup]
+2026-01-23T00:04:22.3289114Z ##[group]Runner Image
+2026-01-23T00:04:22.3289977Z Image: ubuntu-24.04
+2026-01-23T00:04:22.3290711Z Version: 20260119.4.1
+2026-01-23T00:04:22.3293286Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260119.4/images/ubuntu/Ubuntu2404-Readme.md
+2026-01-23T00:04:22.3295814Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260119.4
+2026-01-23T00:04:22.3297281Z ##[endgroup]
+2026-01-23T00:04:22.3299038Z ##[group]GITHUB_TOKEN Permissions
+2026-01-23T00:04:22.3301774Z Actions: write
+2026-01-23T00:04:22.3302607Z Contents: read
+2026-01-23T00:04:22.3303520Z Metadata: read
+2026-01-23T00:04:22.3304376Z ##[endgroup]
+2026-01-23T00:04:22.3307151Z Secret source: Actions
+2026-01-23T00:04:22.3308521Z Prepare workflow directory
+2026-01-23T00:04:22.3846358Z Prepare all required actions
+2026-01-23T00:04:22.3901223Z Getting action download info
+2026-01-23T00:04:22.7204787Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+2026-01-23T00:04:22.8780772Z Download action repository 'actions/setup-python@v5' (SHA:a26af69be951a213d495a4c3e4e4022e16d87065)
+2026-01-23T00:04:22.9633573Z Download action repository 'actions/cache@v4' (SHA:0057852bfaa89a56745cba8c7296529d2fc39830)
+2026-01-23T00:04:23.0660516Z Download action repository 'actions/upload-artifact@v4' (SHA:ea165f8d65b6e75b540449e92b4886f43607fa02)
+2026-01-23T00:04:23.2862124Z Complete job name: generate-unified-report
+2026-01-23T00:04:23.3589568Z ##[group]Run actions/checkout@v4
+2026-01-23T00:04:23.3590873Z with:
+2026-01-23T00:04:23.3591323Z   fetch-depth: 1
+2026-01-23T00:04:23.3591934Z   repository: masonj0/fortuna
+2026-01-23T00:04:23.3592744Z   token: ***
+2026-01-23T00:04:23.3593633Z   ssh-strict: true
+2026-01-23T00:04:23.3594202Z   ssh-user: git
+2026-01-23T00:04:23.3594724Z   persist-credentials: true
+2026-01-23T00:04:23.3595305Z   clean: true
+2026-01-23T00:04:23.3595833Z   sparse-checkout-cone-mode: true
+2026-01-23T00:04:23.3596400Z   fetch-tags: false
+2026-01-23T00:04:23.3596950Z   show-progress: true
+2026-01-23T00:04:23.3597446Z   lfs: false
+2026-01-23T00:04:23.3597922Z   submodules: false
+2026-01-23T00:04:23.3598474Z   set-safe-directory: true
+2026-01-23T00:04:23.3599290Z env:
+2026-01-23T00:04:23.3599704Z   PYTHON_VERSION: 3.11
+2026-01-23T00:04:23.3600190Z   REPORT_RETENTION_DAYS: 14
+2026-01-23T00:04:23.3600671Z   MAX_RETRIES: 3
+2026-01-23T00:04:23.3601084Z   REQUEST_TIMEOUT: 30
+2026-01-23T00:04:23.3601565Z ##[endgroup]
+2026-01-23T00:04:23.4664034Z Syncing repository: masonj0/fortuna
+2026-01-23T00:04:23.4665802Z ##[group]Getting Git version info
+2026-01-23T00:04:23.4666528Z Working directory is '/home/runner/work/fortuna/fortuna'
+2026-01-23T00:04:23.4667505Z [command]/usr/bin/git version
+2026-01-23T00:04:23.4756093Z git version 2.52.0
+2026-01-23T00:04:23.4782484Z ##[endgroup]
+2026-01-23T00:04:23.4803883Z Temporarily overriding HOME='/home/runner/work/_temp/608eee2b-85b3-465e-a9dc-3f1a0c11f0ca' before making global git config changes
+2026-01-23T00:04:23.4805394Z Adding repository directory to the temporary git global config as a safe directory
+2026-01-23T00:04:23.4809019Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/fortuna/fortuna
+2026-01-23T00:04:23.4848232Z Deleting the contents of '/home/runner/work/fortuna/fortuna'
+2026-01-23T00:04:23.4851422Z ##[group]Initializing the repository
+2026-01-23T00:04:23.4855881Z [command]/usr/bin/git init /home/runner/work/fortuna/fortuna
+2026-01-23T00:04:23.4981519Z hint: Using 'master' as the name for the initial branch. This default branch name
+2026-01-23T00:04:23.4982587Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2026-01-23T00:04:23.4983860Z hint: to use in all of your new repositories, which will suppress this warning,
+2026-01-23T00:04:23.4984639Z hint: call:
+2026-01-23T00:04:23.4985030Z hint:
+2026-01-23T00:04:23.4985559Z hint: 	git config --global init.defaultBranch <name>
+2026-01-23T00:04:23.4986677Z hint:
+2026-01-23T00:04:23.4987423Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2026-01-23T00:04:23.4988396Z hint: 'development'. The just-created branch can be renamed via this command:
+2026-01-23T00:04:23.4989150Z hint:
+2026-01-23T00:04:23.4989560Z hint: 	git branch -m <name>
+2026-01-23T00:04:23.4990033Z hint:
+2026-01-23T00:04:23.4990678Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2026-01-23T00:04:23.4991997Z Initialized empty Git repository in /home/runner/work/fortuna/fortuna/.git/
+2026-01-23T00:04:23.4997743Z [command]/usr/bin/git remote add origin https://github.com/masonj0/fortuna
+2026-01-23T00:04:23.5030897Z ##[endgroup]
+2026-01-23T00:04:23.5031655Z ##[group]Disabling automatic garbage collection
+2026-01-23T00:04:23.5035317Z [command]/usr/bin/git config --local gc.auto 0
+2026-01-23T00:04:23.5062239Z ##[endgroup]
+2026-01-23T00:04:23.5062937Z ##[group]Setting up auth
+2026-01-23T00:04:23.5069529Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-01-23T00:04:23.5099113Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-01-23T00:04:23.5462037Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-01-23T00:04:23.5492290Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-01-23T00:04:23.5706704Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-01-23T00:04:23.5739752Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-01-23T00:04:23.5961239Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2026-01-23T00:04:23.5994536Z ##[endgroup]
+2026-01-23T00:04:23.6002837Z ##[group]Fetching the repository
+2026-01-23T00:04:23.6004788Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +f7805d0ce98c6e113b1bd5d2bc949caba1371d68:refs/remotes/origin/main
+2026-01-23T00:04:23.9328765Z From https://github.com/masonj0/fortuna
+2026-01-23T00:04:23.9330351Z  * [new ref]         f7805d0ce98c6e113b1bd5d2bc949caba1371d68 -> origin/main
+2026-01-23T00:04:23.9360947Z ##[endgroup]
+2026-01-23T00:04:23.9361954Z ##[group]Determining the checkout info
+2026-01-23T00:04:23.9363691Z ##[endgroup]
+2026-01-23T00:04:23.9368484Z [command]/usr/bin/git sparse-checkout disable
+2026-01-23T00:04:23.9408925Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2026-01-23T00:04:23.9434015Z ##[group]Checking out the ref
+2026-01-23T00:04:23.9437465Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+2026-01-23T00:04:23.9890612Z Switched to a new branch 'main'
+2026-01-23T00:04:23.9893932Z branch 'main' set up to track 'origin/main'.
+2026-01-23T00:04:23.9903842Z ##[endgroup]
+2026-01-23T00:04:23.9936038Z [command]/usr/bin/git log -1 --format=%H
+2026-01-23T00:04:23.9957517Z f7805d0ce98c6e113b1bd5d2bc949caba1371d68
+2026-01-23T00:04:24.0252564Z ##[group]Run actions/setup-python@v5
+2026-01-23T00:04:24.0253983Z with:
+2026-01-23T00:04:24.0254684Z   python-version: 3.11
+2026-01-23T00:04:24.0255519Z   cache: pip
+2026-01-23T00:04:24.0256583Z   cache-dependency-path: web_service/backend/requirements.txt
+2026-01-23T00:04:24.0257993Z   check-latest: false
+2026-01-23T00:04:24.0259066Z   token: ***
+2026-01-23T00:04:24.0259843Z   update-environment: true
+2026-01-23T00:04:24.0260816Z   allow-prereleases: false
+2026-01-23T00:04:24.0261732Z   freethreaded: false
+2026-01-23T00:04:24.0262535Z env:
+2026-01-23T00:04:24.0263384Z   PYTHON_VERSION: 3.11
+2026-01-23T00:04:24.0264247Z   REPORT_RETENTION_DAYS: 14
+2026-01-23T00:04:24.0265143Z   MAX_RETRIES: 3
+2026-01-23T00:04:24.0265905Z   REQUEST_TIMEOUT: 30
+2026-01-23T00:04:24.0266704Z ##[endgroup]
+2026-01-23T00:04:24.1925061Z ##[group]Installed versions
+2026-01-23T00:04:24.2054664Z Successfully set up CPython (3.11.14)
+2026-01-23T00:04:24.2056790Z ##[endgroup]
+2026-01-23T00:04:24.2466584Z [command]/opt/hostedtoolcache/Python/3.11.14/x64/bin/pip cache dir
+2026-01-23T00:04:25.6627833Z /home/runner/.cache/pip
+2026-01-23T00:04:25.7752984Z Cache hit for: setup-python-Linux-x64-24.04-Ubuntu-python-3.11.14-pip-9b33d885a72e4a79c39d67e0d38fd2891ce0392a75a496cd6973c98dee5ac231
+2026-01-23T00:04:26.8355006Z Received 218103808 of 474921379 (45.9%), 207.8 MBs/sec
+2026-01-23T00:04:27.8414950Z Received 448790528 of 474921379 (94.5%), 213.7 MBs/sec
+2026-01-23T00:04:27.9297411Z Received 474921379 of 474921379 (100.0%), 216.2 MBs/sec
+2026-01-23T00:04:27.9299818Z Cache Size: ~453 MB (474921379 B)
+2026-01-23T00:04:27.9484005Z [command]/usr/bin/tar -xf /home/runner/work/_temp/7c1e6cae-4248-4073-8f69-2a3eb04e7a5a/cache.tzst -P -C /home/runner/work/fortuna/fortuna --use-compress-program unzstd
+2026-01-23T00:04:28.7649002Z Cache restored successfully
+2026-01-23T00:04:28.8539442Z Cache restored from key: setup-python-Linux-x64-24.04-Ubuntu-python-3.11.14-pip-9b33d885a72e4a79c39d67e0d38fd2891ce0392a75a496cd6973c98dee5ac231
+2026-01-23T00:04:28.8729877Z ##[group]Run python -m pip install --upgrade pip setuptools wheel
+2026-01-23T00:04:28.8730515Z [36;1mpython -m pip install --upgrade pip setuptools wheel[0m
+2026-01-23T00:04:28.8730972Z [36;1mpip install -r web_service/backend/requirements.txt[0m
+2026-01-23T00:04:28.8770530Z shell: /usr/bin/bash -e {0}
+2026-01-23T00:04:28.8770805Z env:
+2026-01-23T00:04:28.8771003Z   PYTHON_VERSION: 3.11
+2026-01-23T00:04:28.8771256Z   REPORT_RETENTION_DAYS: 14
+2026-01-23T00:04:28.8771486Z   MAX_RETRIES: 3
+2026-01-23T00:04:28.8771683Z   REQUEST_TIMEOUT: 30
+2026-01-23T00:04:28.8771973Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:28.8772428Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-23T00:04:28.8772863Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:28.8773522Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:28.8773970Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:28.8774371Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-23T00:04:28.8774705Z ##[endgroup]
+2026-01-23T00:04:29.8268287Z Requirement already satisfied: pip in /opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages (25.3)
+2026-01-23T00:04:29.9378433Z Requirement already satisfied: setuptools in /opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages (79.0.1)
+2026-01-23T00:04:30.0619595Z Collecting setuptools
+2026-01-23T00:04:30.0644980Z   Using cached setuptools-80.10.1-py3-none-any.whl.metadata (6.7 kB)
+2026-01-23T00:04:30.1101706Z Collecting wheel
+2026-01-23T00:04:30.1940011Z   Downloading wheel-0.46.3-py3-none-any.whl.metadata (2.4 kB)
+2026-01-23T00:04:30.2256677Z Collecting packaging>=24.0 (from wheel)
+2026-01-23T00:04:30.2331527Z   Downloading packaging-26.0-py3-none-any.whl.metadata (3.3 kB)
+2026-01-23T00:04:30.2380921Z Using cached setuptools-80.10.1-py3-none-any.whl (1.1 MB)
+2026-01-23T00:04:30.2462734Z Downloading wheel-0.46.3-py3-none-any.whl (30 kB)
+2026-01-23T00:04:30.2644421Z Downloading packaging-26.0-py3-none-any.whl (74 kB)
+2026-01-23T00:04:30.3065843Z Installing collected packages: setuptools, packaging, wheel
+2026-01-23T00:04:30.3071160Z   Attempting uninstall: setuptools
+2026-01-23T00:04:30.3085664Z     Found existing installation: setuptools 79.0.1
+2026-01-23T00:04:30.5908448Z     Uninstalling setuptools-79.0.1:
+2026-01-23T00:04:30.6374382Z       Successfully uninstalled setuptools-79.0.1
+2026-01-23T00:04:31.3320737Z
+2026-01-23T00:04:31.3329446Z Successfully installed packaging-26.0 setuptools-80.10.1 wheel-0.46.3
+2026-01-23T00:04:31.8289626Z Collecting fastapi==0.104.1 (from -r web_service/backend/requirements.txt (line 11))
+2026-01-23T00:04:31.8303755Z   Using cached fastapi-0.104.1-py3-none-any.whl.metadata (24 kB)
+2026-01-23T00:04:31.8610849Z Collecting uvicorn==0.24.0 (from uvicorn[standard]==0.24.0->-r web_service/backend/requirements.txt (line 12))
+2026-01-23T00:04:31.8624949Z   Using cached uvicorn-0.24.0-py3-none-any.whl.metadata (6.4 kB)
+2026-01-23T00:04:31.8913925Z Collecting starlette==0.27.0 (from -r web_service/backend/requirements.txt (line 13))
+2026-01-23T00:04:31.8927019Z   Using cached starlette-0.27.0-py3-none-any.whl.metadata (5.8 kB)
+2026-01-23T00:04:32.0027966Z Collecting pydantic==2.5.0 (from -r web_service/backend/requirements.txt (line 14))
+2026-01-23T00:04:32.0042064Z   Using cached pydantic-2.5.0-py3-none-any.whl.metadata (174 kB)
+2026-01-23T00:04:32.6354374Z Collecting pydantic-core==2.14.1 (from -r web_service/backend/requirements.txt (line 15))
+2026-01-23T00:04:32.6370240Z   Using cached pydantic_core-2.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.5 kB)
+2026-01-23T00:04:32.6540181Z Collecting pydantic-settings==2.1.0 (from -r web_service/backend/requirements.txt (line 16))
+2026-01-23T00:04:32.6554460Z   Using cached pydantic_settings-2.1.0-py3-none-any.whl.metadata (2.9 kB)
+2026-01-23T00:04:32.6745515Z Collecting anyio==3.7.1 (from -r web_service/backend/requirements.txt (line 19))
+2026-01-23T00:04:32.6760443Z   Using cached anyio-3.7.1-py3-none-any.whl.metadata (4.7 kB)
+2026-01-23T00:04:32.6907324Z Collecting h11==0.14.0 (from -r web_service/backend/requirements.txt (line 20))
+2026-01-23T00:04:32.6920666Z   Using cached h11-0.14.0-py3-none-any.whl.metadata (8.2 kB)
+2026-01-23T00:04:32.7084348Z Collecting h2==4.1.0 (from -r web_service/backend/requirements.txt (line 21))
+2026-01-23T00:04:32.7097011Z   Using cached h2-4.1.0-py3-none-any.whl.metadata (3.6 kB)
+2026-01-23T00:04:32.7245021Z Collecting hpack==4.0.0 (from -r web_service/backend/requirements.txt (line 22))
+2026-01-23T00:04:32.7257724Z   Using cached hpack-4.0.0-py3-none-any.whl.metadata (2.5 kB)
+2026-01-23T00:04:32.7674941Z Collecting httpcore==1.0.2 (from -r web_service/backend/requirements.txt (line 23))
+2026-01-23T00:04:32.7688491Z   Using cached httpcore-1.0.2-py3-none-any.whl.metadata (20 kB)
+2026-01-23T00:04:32.8011702Z Collecting httptools==0.6.1 (from -r web_service/backend/requirements.txt (line 24))
+2026-01-23T00:04:32.8026946Z   Using cached httptools-0.6.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (3.6 kB)
+2026-01-23T00:04:32.8238219Z Collecting httpx==0.25.2 (from -r web_service/backend/requirements.txt (line 25))
+2026-01-23T00:04:32.8251921Z   Using cached httpx-0.25.2-py3-none-any.whl.metadata (6.9 kB)
+2026-01-23T00:04:32.8414718Z Collecting hyperframe==6.1.0 (from -r web_service/backend/requirements.txt (line 26))
+2026-01-23T00:04:32.8432028Z   Using cached hyperframe-6.1.0-py3-none-any.whl.metadata (4.3 kB)
+2026-01-23T00:04:32.9293689Z Collecting websockets==12.0 (from -r web_service/backend/requirements.txt (line 27))
+2026-01-23T00:04:32.9308692Z   Using cached websockets-12.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.6 kB)
+2026-01-23T00:04:32.9441242Z Collecting wsproto==1.2.0 (from -r web_service/backend/requirements.txt (line 28))
+2026-01-23T00:04:32.9454907Z   Using cached wsproto-1.2.0-py3-none-any.whl.metadata (5.6 kB)
+2026-01-23T00:04:32.9716230Z Collecting requests==2.31.0 (from -r web_service/backend/requirements.txt (line 31))
+2026-01-23T00:04:32.9735592Z   Using cached requests-2.31.0-py3-none-any.whl.metadata (4.6 kB)
+2026-01-23T00:04:32.9986954Z Collecting urllib3==2.1.0 (from -r web_service/backend/requirements.txt (line 32))
+2026-01-23T00:04:32.9999984Z   Using cached urllib3-2.1.0-py3-none-any.whl.metadata (6.4 kB)
+2026-01-23T00:04:33.0203544Z Collecting certifi==2023.7.22 (from -r web_service/backend/requirements.txt (line 33))
+2026-01-23T00:04:33.0216212Z   Using cached certifi-2023.7.22-py3-none-any.whl.metadata (2.2 kB)
+2026-01-23T00:04:33.0998940Z Collecting charset-normalizer==3.3.2 (from -r web_service/backend/requirements.txt (line 34))
+2026-01-23T00:04:33.1013370Z   Using cached charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (33 kB)
+2026-01-23T00:04:33.1182314Z Collecting idna==3.6 (from -r web_service/backend/requirements.txt (line 35))
+2026-01-23T00:04:33.1195354Z   Using cached idna-3.6-py3-none-any.whl.metadata (9.9 kB)
+2026-01-23T00:04:33.4519382Z Collecting sqlalchemy==2.0.23 (from -r web_service/backend/requirements.txt (line 38))
+2026-01-23T00:04:33.4535384Z   Using cached SQLAlchemy-2.0.23-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (9.6 kB)
+2026-01-23T00:04:33.5791856Z Collecting greenlet==3.0.2 (from -r web_service/backend/requirements.txt (line 39))
+2026-01-23T00:04:33.5806053Z   Using cached greenlet-3.0.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl.metadata (3.7 kB)
+2026-01-23T00:04:33.5946272Z Collecting aiosqlite==0.19.0 (from -r web_service/backend/requirements.txt (line 40))
+2026-01-23T00:04:33.5959155Z   Using cached aiosqlite-0.19.0-py3-none-any.whl.metadata (4.3 kB)
+2026-01-23T00:04:33.6586305Z Collecting psycopg2-binary==2.9.9 (from -r web_service/backend/requirements.txt (line 41))
+2026-01-23T00:04:33.6605049Z   Using cached psycopg2_binary-2.9.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.4 kB)
+2026-01-23T00:04:33.8783520Z Collecting numpy==1.24.3 (from -r web_service/backend/requirements.txt (line 44))
+2026-01-23T00:04:33.8798749Z   Using cached numpy-1.24.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (5.6 kB)
+2026-01-23T00:04:33.9977618Z Collecting pandas==2.0.3 (from -r web_service/backend/requirements.txt (line 45))
+2026-01-23T00:04:33.9991575Z   Using cached pandas-2.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (18 kB)
+2026-01-23T00:04:34.0269060Z Collecting python-dateutil==2.8.2 (from -r web_service/backend/requirements.txt (line 46))
+2026-01-23T00:04:34.0281709Z   Using cached python_dateutil-2.8.2-py2.py3-none-any.whl.metadata (8.2 kB)
+2026-01-23T00:04:34.0651737Z Collecting pytz==2023.3.post1 (from -r web_service/backend/requirements.txt (line 47))
+2026-01-23T00:04:34.0665627Z   Using cached pytz-2023.3.post1-py2.py3-none-any.whl.metadata (22 kB)
+2026-01-23T00:04:34.0828566Z Collecting tzdata==2023.3 (from -r web_service/backend/requirements.txt (line 48))
+2026-01-23T00:04:34.0842104Z   Using cached tzdata-2023.3-py2.py3-none-any.whl.metadata (1.4 kB)
+2026-01-23T00:04:34.0977731Z Collecting six==1.16.0 (from -r web_service/backend/requirements.txt (line 49))
+2026-01-23T00:04:34.0991397Z   Using cached six-1.16.0-py2.py3-none-any.whl.metadata (1.8 kB)
+2026-01-23T00:04:34.1161837Z Collecting beautifulsoup4==4.12.2 (from -r web_service/backend/requirements.txt (line 52))
+2026-01-23T00:04:34.1175351Z   Using cached beautifulsoup4-4.12.2-py3-none-any.whl.metadata (3.6 kB)
+2026-01-23T00:04:34.1351328Z Collecting soupsieve==2.5 (from -r web_service/backend/requirements.txt (line 53))
+2026-01-23T00:04:34.1364890Z   Using cached soupsieve-2.5-py3-none-any.whl.metadata (4.7 kB)
+2026-01-23T00:04:34.2485114Z Collecting selectolax==0.3.20 (from -r web_service/backend/requirements.txt (line 54))
+2026-01-23T00:04:34.2498917Z   Using cached selectolax-0.3.20-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (5.6 kB)
+2026-01-23T00:04:34.2686674Z Collecting click==8.1.7 (from -r web_service/backend/requirements.txt (line 57))
+2026-01-23T00:04:34.2699400Z   Using cached click-8.1.7-py3-none-any.whl.metadata (3.0 kB)
+2026-01-23T00:04:34.2880979Z Collecting python-dotenv==1.0.0 (from -r web_service/backend/requirements.txt (line 58))
+2026-01-23T00:04:34.2893786Z   Using cached python_dotenv-1.0.0-py3-none-any.whl.metadata (21 kB)
+2026-01-23T00:04:34.3269637Z Collecting pyyaml==6.0.1 (from -r web_service/backend/requirements.txt (line 59))
+2026-01-23T00:04:34.3283778Z   Using cached PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.1 kB)
+2026-01-23T00:04:34.5461223Z Collecting cryptography==41.0.7 (from -r web_service/backend/requirements.txt (line 62))
+2026-01-23T00:04:34.5476449Z   Using cached cryptography-41.0.7-cp37-abi3-manylinux_2_28_x86_64.whl.metadata (5.2 kB)
+2026-01-23T00:04:34.6473890Z Collecting cffi==1.16.0 (from -r web_service/backend/requirements.txt (line 63))
+2026-01-23T00:04:34.6488729Z   Using cached cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.5 kB)
+2026-01-23T00:04:34.6621203Z Collecting pycparser==2.21 (from -r web_service/backend/requirements.txt (line 64))
+2026-01-23T00:04:34.6634891Z   Using cached pycparser-2.21-py2.py3-none-any.whl.metadata (1.1 kB)
+2026-01-23T00:04:34.6763449Z Collecting secretstorage==3.5.0 (from -r web_service/backend/requirements.txt (line 65))
+2026-01-23T00:04:34.6776702Z   Using cached secretstorage-3.5.0-py3-none-any.whl.metadata (4.0 kB)
+2026-01-23T00:04:34.7091186Z Collecting keyring==24.3.0 (from -r web_service/backend/requirements.txt (line 66))
+2026-01-23T00:04:34.7104647Z   Using cached keyring-24.3.0-py3-none-any.whl.metadata (20 kB)
+2026-01-23T00:04:34.7267794Z Collecting jeepney==0.9.0 (from -r web_service/backend/requirements.txt (line 67))
+2026-01-23T00:04:34.7281341Z   Using cached jeepney-0.9.0-py3-none-any.whl.metadata (1.2 kB)
+2026-01-23T00:04:34.7555392Z Collecting redis==5.0.1 (from -r web_service/backend/requirements.txt (line 70))
+2026-01-23T00:04:34.7567851Z   Using cached redis-5.0.1-py3-none-any.whl.metadata (8.9 kB)
+2026-01-23T00:04:34.7802655Z Collecting limits==3.7.0 (from -r web_service/backend/requirements.txt (line 71))
+2026-01-23T00:04:34.7815765Z   Using cached limits-3.7.0-py3-none-any.whl.metadata (7.3 kB)
+2026-01-23T00:04:34.8006608Z Collecting slowapi==0.1.9 (from -r web_service/backend/requirements.txt (line 72))
+2026-01-23T00:04:34.8019814Z   Using cached slowapi-0.1.9-py3-none-any.whl.metadata (3.0 kB)
+2026-01-23T00:04:34.8193877Z Collecting tenacity==8.2.3 (from -r web_service/backend/requirements.txt (line 73))
+2026-01-23T00:04:34.8207071Z   Using cached tenacity-8.2.3-py3-none-any.whl.metadata (1.0 kB)
+2026-01-23T00:04:34.8430659Z Collecting pywebview==5.4 (from -r web_service/backend/requirements.txt (line 76))
+2026-01-23T00:04:34.8443950Z   Using cached pywebview-5.4-py3-none-any.whl.metadata (4.5 kB)
+2026-01-23T00:04:34.8644011Z Collecting bottle==0.13.4 (from -r web_service/backend/requirements.txt (line 77))
+2026-01-23T00:04:34.8656657Z   Using cached bottle-0.13.4-py2.py3-none-any.whl.metadata (1.6 kB)
+2026-01-23T00:04:34.8780577Z Collecting proxy-tools==0.1.0 (from -r web_service/backend/requirements.txt (line 78))
+2026-01-23T00:04:34.8782261Z   Using cached proxy_tools-0.1.0-py3-none-any.whl
+2026-01-23T00:04:34.9485211Z Collecting psutil==5.9.6 (from -r web_service/backend/requirements.txt (line 82))
+2026-01-23T00:04:34.9499155Z   Using cached psutil-5.9.6-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (21 kB)
+2026-01-23T00:04:34.9674376Z Collecting structlog==23.2.0 (from -r web_service/backend/requirements.txt (line 85))
+2026-01-23T00:04:34.9687033Z   Using cached structlog-23.2.0-py3-none-any.whl.metadata (7.6 kB)
+2026-01-23T00:04:35.0185177Z Collecting black==23.12.0 (from -r web_service/backend/requirements.txt (line 88))
+2026-01-23T00:04:35.0199311Z   Using cached black-23.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (68 kB)
+2026-01-23T00:04:35.0713417Z Collecting pyinstaller==6.1.0 (from -r web_service/backend/requirements.txt (line 89))
+2026-01-23T00:04:35.0727348Z   Using cached pyinstaller-6.1.0-py3-none-manylinux2014_x86_64.whl.metadata (8.2 kB)
+2026-01-23T00:04:35.0940530Z Collecting pyinstaller-hooks-contrib==2023.11 (from -r web_service/backend/requirements.txt (line 90))
+2026-01-23T00:04:35.0954289Z   Using cached pyinstaller_hooks_contrib-2023.11-py2.py3-none-any.whl.metadata (15 kB)
+2026-01-23T00:04:35.1088611Z Collecting altgraph==0.17.3 (from -r web_service/backend/requirements.txt (line 91))
+2026-01-23T00:04:35.1101576Z   Using cached altgraph-0.17.3-py2.py3-none-any.whl.metadata (7.4 kB)
+2026-01-23T00:04:35.1309428Z Collecting wheel==0.41.2 (from -r web_service/backend/requirements.txt (line 92))
+2026-01-23T00:04:35.1322339Z   Using cached wheel-0.41.2-py3-none-any.whl.metadata (2.2 kB)
+2026-01-23T00:04:35.1476452Z Collecting build==1.0.3 (from -r web_service/backend/requirements.txt (line 93))
+2026-01-23T00:04:35.1489209Z   Using cached build-1.0.3-py3-none-any.whl.metadata (4.2 kB)
+2026-01-23T00:04:35.1803765Z Collecting pip-tools==7.3.0 (from -r web_service/backend/requirements.txt (line 94))
+2026-01-23T00:04:35.1816733Z   Using cached pip_tools-7.3.0-py3-none-any.whl.metadata (23 kB)
+2026-01-23T00:04:35.2182419Z Collecting pytest==7.4.3 (from -r web_service/backend/requirements.txt (line 97))
+2026-01-23T00:04:35.2196878Z   Using cached pytest-7.4.3-py3-none-any.whl.metadata (7.9 kB)
+2026-01-23T00:04:35.2421148Z Collecting pytest-asyncio==0.21.1 (from -r web_service/backend/requirements.txt (line 98))
+2026-01-23T00:04:35.2434922Z   Using cached pytest_asyncio-0.21.1-py3-none-any.whl.metadata (4.0 kB)
+2026-01-23T00:04:35.2568042Z Collecting iniconfig==2.0.0 (from -r web_service/backend/requirements.txt (line 99))
+2026-01-23T00:04:35.2581368Z   Using cached iniconfig-2.0.0-py3-none-any.whl.metadata (2.6 kB)
+2026-01-23T00:04:35.2720696Z Collecting pluggy==1.3.0 (from -r web_service/backend/requirements.txt (line 100))
+2026-01-23T00:04:35.2733422Z   Using cached pluggy-1.3.0-py3-none-any.whl.metadata (4.3 kB)
+2026-01-23T00:04:35.2915778Z Collecting packaging==23.2 (from -r web_service/backend/requirements.txt (line 101))
+2026-01-23T00:04:35.2929206Z   Using cached packaging-23.2-py3-none-any.whl.metadata (3.2 kB)
+2026-01-23T00:04:35.3105268Z Collecting typing-extensions==4.8.0 (from -r web_service/backend/requirements.txt (line 104))
+2026-01-23T00:04:35.3118422Z   Using cached typing_extensions-4.8.0-py3-none-any.whl.metadata (3.0 kB)
+2026-01-23T00:04:35.3244911Z Collecting typing-inspect==0.9.0 (from -r web_service/backend/requirements.txt (line 105))
+2026-01-23T00:04:35.3257717Z   Using cached typing_inspect-0.9.0-py3-none-any.whl.metadata (1.5 kB)
+2026-01-23T00:04:35.3383226Z Collecting annotated-types==0.6.0 (from -r web_service/backend/requirements.txt (line 106))
+2026-01-23T00:04:35.3396250Z   Using cached annotated_types-0.6.0-py3-none-any.whl.metadata (12 kB)
+2026-01-23T00:04:35.3516105Z Collecting mypy-extensions==1.0.0 (from -r web_service/backend/requirements.txt (line 109))
+2026-01-23T00:04:35.3530121Z   Using cached mypy_extensions-1.0.0-py3-none-any.whl.metadata (1.1 kB)
+2026-01-23T00:04:35.3667941Z Collecting pathspec==0.11.2 (from -r web_service/backend/requirements.txt (line 110))
+2026-01-23T00:04:35.3680622Z   Using cached pathspec-0.11.2-py3-none-any.whl.metadata (19 kB)
+2026-01-23T00:04:35.3861975Z Collecting platformdirs==4.0.0 (from -r web_service/backend/requirements.txt (line 111))
+2026-01-23T00:04:35.3875387Z   Using cached platformdirs-4.0.0-py3-none-any.whl.metadata (11 kB)
+2026-01-23T00:04:35.4072181Z Collecting more-itertools==10.1.0 (from -r web_service/backend/requirements.txt (line 112))
+2026-01-23T00:04:35.4085291Z   Using cached more_itertools-10.1.0-py3-none-any.whl.metadata (33 kB)
+2026-01-23T00:04:35.4220234Z Collecting jaraco.classes==3.3.1 (from -r web_service/backend/requirements.txt (line 113))
+2026-01-23T00:04:35.4232840Z   Using cached jaraco.classes-3.3.1-py3-none-any.whl.metadata (2.7 kB)
+2026-01-23T00:04:35.4372548Z Collecting jaraco.context==5.3.0 (from -r web_service/backend/requirements.txt (line 114))
+2026-01-23T00:04:35.4385720Z   Using cached jaraco.context-5.3.0-py3-none-any.whl.metadata (4.0 kB)
+2026-01-23T00:04:35.4557319Z Collecting jaraco.functools==4.0.0 (from -r web_service/backend/requirements.txt (line 115))
+2026-01-23T00:04:35.4574276Z   Using cached jaraco.functools-4.0.0-py3-none-any.whl.metadata (3.1 kB)
+2026-01-23T00:04:35.4731046Z Collecting deprecated==1.2.14 (from -r web_service/backend/requirements.txt (line 116))
+2026-01-23T00:04:35.4743920Z   Using cached Deprecated-1.2.14-py2.py3-none-any.whl.metadata (5.4 kB)
+2026-01-23T00:04:35.4900429Z Collecting sniffio==1.3.0 (from -r web_service/backend/requirements.txt (line 117))
+2026-01-23T00:04:35.4914272Z   Using cached sniffio-1.3.0-py3-none-any.whl.metadata (3.6 kB)
+2026-01-23T00:04:35.6957001Z Collecting wrapt==1.16.0 (from -r web_service/backend/requirements.txt (line 118))
+2026-01-23T00:04:35.6972521Z   Using cached wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.6 kB)
+2026-01-23T00:04:35.7688685Z Collecting watchfiles==0.20.0 (from -r web_service/backend/requirements.txt (line 119))
+2026-01-23T00:04:35.7703309Z   Using cached watchfiles-0.20.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.9 kB)
+2026-01-23T00:04:35.7908191Z Collecting pygments==2.17.2 (from -r web_service/backend/requirements.txt (line 120))
+2026-01-23T00:04:35.7921195Z   Using cached pygments-2.17.2-py3-none-any.whl.metadata (2.6 kB)
+2026-01-23T00:04:36.0516350Z Collecting importlib-metadata>=4.11.4 (from keyring==24.3.0->-r web_service/backend/requirements.txt (line 66))
+2026-01-23T00:04:36.0529997Z   Using cached importlib_metadata-8.7.1-py3-none-any.whl.metadata (4.7 kB)
+2026-01-23T00:04:36.0902259Z Collecting importlib-resources>=1.3 (from limits==3.7.0->-r web_service/backend/requirements.txt (line 71))
+2026-01-23T00:04:36.0916524Z   Using cached importlib_resources-6.5.2-py3-none-any.whl.metadata (3.9 kB)
+2026-01-23T00:04:36.6853917Z Collecting aiohttp>=3.7.4 (from black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-23T00:04:36.6869014Z   Using cached aiohttp-3.13.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (8.1 kB)
+2026-01-23T00:04:36.6925317Z Requirement already satisfied: setuptools>=42.0.0 in /opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages (from pyinstaller==6.1.0->-r web_service/backend/requirements.txt (line 89)) (80.10.1)
+2026-01-23T00:04:36.7228543Z Collecting pyproject_hooks (from build==1.0.3->-r web_service/backend/requirements.txt (line 93))
+2026-01-23T00:04:36.7241623Z   Using cached pyproject_hooks-1.2.0-py3-none-any.whl.metadata (1.3 kB)
+2026-01-23T00:04:36.7282586Z Requirement already satisfied: pip>=22.2 in /opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages (from pip-tools==7.3.0->-r web_service/backend/requirements.txt (line 94)) (25.3)
+2026-01-23T00:04:36.7828374Z Collecting backports.tarfile (from jaraco.context==5.3.0->-r web_service/backend/requirements.txt (line 114))
+2026-01-23T00:04:36.7841260Z   Using cached backports.tarfile-1.2.0-py3-none-any.whl.metadata (2.0 kB)
+2026-01-23T00:04:36.8531243Z Collecting uvloop!=0.15.0,!=0.15.1,>=0.14.0 (from uvicorn[standard]==0.24.0->-r web_service/backend/requirements.txt (line 12))
+2026-01-23T00:04:36.8544860Z   Using cached uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (4.9 kB)
+2026-01-23T00:04:36.8789582Z Collecting aiohappyeyeballs>=2.5.0 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-23T00:04:36.8802673Z   Using cached aiohappyeyeballs-2.6.1-py3-none-any.whl.metadata (5.9 kB)
+2026-01-23T00:04:36.8927752Z Collecting aiosignal>=1.4.0 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-23T00:04:36.8940741Z   Using cached aiosignal-1.4.0-py3-none-any.whl.metadata (3.7 kB)
+2026-01-23T00:04:36.9106948Z Collecting attrs>=17.3.0 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-23T00:04:36.9119825Z   Using cached attrs-25.4.0-py3-none-any.whl.metadata (10 kB)
+2026-01-23T00:04:36.9782947Z Collecting frozenlist>=1.1.1 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-23T00:04:36.9798600Z   Using cached frozenlist-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl.metadata (20 kB)
+2026-01-23T00:04:37.2011514Z Collecting multidict<7.0,>=4.5 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-23T00:04:37.2028140Z   Using cached multidict-6.7.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (5.3 kB)
+2026-01-23T00:04:37.2582385Z Collecting propcache>=0.2.0 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-23T00:04:37.2598652Z   Using cached propcache-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (13 kB)
+2026-01-23T00:04:37.5053371Z Collecting yarl<2.0,>=1.17.0 (from aiohttp>=3.7.4->black==23.12.0->-r web_service/backend/requirements.txt (line 88))
+2026-01-23T00:04:37.5069694Z   Using cached yarl-1.22.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (75 kB)
+2026-01-23T00:04:37.5630979Z Collecting zipp>=3.20 (from importlib-metadata>=4.11.4->keyring==24.3.0->-r web_service/backend/requirements.txt (line 66))
+2026-01-23T00:04:37.5644813Z   Using cached zipp-3.23.0-py3-none-any.whl.metadata (3.6 kB)
+2026-01-23T00:04:37.5912260Z Using cached fastapi-0.104.1-py3-none-any.whl (92 kB)
+2026-01-23T00:04:37.5926244Z Using cached starlette-0.27.0-py3-none-any.whl (66 kB)
+2026-01-23T00:04:37.5940085Z Using cached pydantic-2.5.0-py3-none-any.whl (407 kB)
+2026-01-23T00:04:37.5955944Z Using cached anyio-3.7.1-py3-none-any.whl (80 kB)
+2026-01-23T00:04:37.5969634Z Using cached uvicorn-0.24.0-py3-none-any.whl (59 kB)
+2026-01-23T00:04:37.5983581Z Using cached pydantic_core-2.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (2.1 MB)
+2026-01-23T00:04:37.6010839Z Using cached pydantic_settings-2.1.0-py3-none-any.whl (11 kB)
+2026-01-23T00:04:37.6023911Z Using cached h11-0.14.0-py3-none-any.whl (58 kB)
+2026-01-23T00:04:37.6037549Z Using cached h2-4.1.0-py3-none-any.whl (57 kB)
+2026-01-23T00:04:37.6051131Z Using cached hpack-4.0.0-py3-none-any.whl (32 kB)
+2026-01-23T00:04:37.6064572Z Using cached hyperframe-6.1.0-py3-none-any.whl (13 kB)
+2026-01-23T00:04:37.6077772Z Using cached httpcore-1.0.2-py3-none-any.whl (76 kB)
+2026-01-23T00:04:37.6091965Z Using cached httptools-0.6.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (318 kB)
+2026-01-23T00:04:37.6107096Z Using cached httpx-0.25.2-py3-none-any.whl (74 kB)
+2026-01-23T00:04:37.6121184Z Using cached websockets-12.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (130 kB)
+2026-01-23T00:04:37.6135030Z Using cached wsproto-1.2.0-py3-none-any.whl (24 kB)
+2026-01-23T00:04:37.6148170Z Using cached requests-2.31.0-py3-none-any.whl (62 kB)
+2026-01-23T00:04:37.6161559Z Using cached urllib3-2.1.0-py3-none-any.whl (104 kB)
+2026-01-23T00:04:37.6175746Z Using cached charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (140 kB)
+2026-01-23T00:04:37.6189343Z Using cached idna-3.6-py3-none-any.whl (61 kB)
+2026-01-23T00:04:37.6202818Z Using cached certifi-2023.7.22-py3-none-any.whl (158 kB)
+2026-01-23T00:04:37.6217612Z Using cached SQLAlchemy-2.0.23-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.2 MB)
+2026-01-23T00:04:37.6253233Z Using cached greenlet-3.0.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (616 kB)
+2026-01-23T00:04:37.6270567Z Using cached aiosqlite-0.19.0-py3-none-any.whl (15 kB)
+2026-01-23T00:04:37.6284189Z Using cached psycopg2_binary-2.9.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.0 MB)
+2026-01-23T00:04:37.6318710Z Using cached numpy-1.24.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.3 MB)
+2026-01-23T00:04:37.6451525Z Using cached pandas-2.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (12.2 MB)
+2026-01-23T00:04:37.6549156Z Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
+2026-01-23T00:04:37.6563374Z Using cached pytz-2023.3.post1-py2.py3-none-any.whl (502 kB)
+2026-01-23T00:04:37.6579403Z Using cached tzdata-2023.3-py2.py3-none-any.whl (341 kB)
+2026-01-23T00:04:37.6594315Z Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
+2026-01-23T00:04:37.6607047Z Using cached beautifulsoup4-4.12.2-py3-none-any.whl (142 kB)
+2026-01-23T00:04:37.6620297Z Using cached soupsieve-2.5-py3-none-any.whl (36 kB)
+2026-01-23T00:04:37.6633549Z Using cached selectolax-0.3.20-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (6.7 MB)
+2026-01-23T00:04:37.6692514Z Using cached click-8.1.7-py3-none-any.whl (97 kB)
+2026-01-23T00:04:37.6706000Z Using cached python_dotenv-1.0.0-py3-none-any.whl (19 kB)
+2026-01-23T00:04:37.6718934Z Using cached PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (757 kB)
+2026-01-23T00:04:37.6736918Z Using cached cryptography-41.0.7-cp37-abi3-manylinux_2_28_x86_64.whl (4.4 MB)
+2026-01-23T00:04:37.6780150Z Using cached cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (464 kB)
+2026-01-23T00:04:37.6795707Z Using cached pycparser-2.21-py2.py3-none-any.whl (118 kB)
+2026-01-23T00:04:37.6809118Z Using cached secretstorage-3.5.0-py3-none-any.whl (15 kB)
+2026-01-23T00:04:37.6821940Z Using cached keyring-24.3.0-py3-none-any.whl (38 kB)
+2026-01-23T00:04:37.6835040Z Using cached jeepney-0.9.0-py3-none-any.whl (49 kB)
+2026-01-23T00:04:37.6847702Z Using cached redis-5.0.1-py3-none-any.whl (250 kB)
+2026-01-23T00:04:37.6861958Z Using cached limits-3.7.0-py3-none-any.whl (43 kB)
+2026-01-23T00:04:37.6874826Z Using cached packaging-23.2-py3-none-any.whl (53 kB)
+2026-01-23T00:04:37.6887473Z Using cached slowapi-0.1.9-py3-none-any.whl (14 kB)
+2026-01-23T00:04:37.6900069Z Using cached tenacity-8.2.3-py3-none-any.whl (24 kB)
+2026-01-23T00:04:37.6912562Z Using cached pywebview-5.4-py3-none-any.whl (475 kB)
+2026-01-23T00:04:37.6928543Z Using cached bottle-0.13.4-py2.py3-none-any.whl (103 kB)
+2026-01-23T00:04:37.6942482Z Using cached psutil-5.9.6-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (283 kB)
+2026-01-23T00:04:37.6956637Z Using cached structlog-23.2.0-py3-none-any.whl (62 kB)
+2026-01-23T00:04:37.6970041Z Using cached black-23.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.7 MB)
+2026-01-23T00:04:37.6994421Z Using cached pyinstaller-6.1.0-py3-none-manylinux2014_x86_64.whl (658 kB)
+2026-01-23T00:04:37.7011536Z Using cached pyinstaller_hooks_contrib-2023.11-py2.py3-none-any.whl (294 kB)
+2026-01-23T00:04:37.7025988Z Using cached altgraph-0.17.3-py2.py3-none-any.whl (21 kB)
+2026-01-23T00:04:37.7038521Z Using cached wheel-0.41.2-py3-none-any.whl (64 kB)
+2026-01-23T00:04:37.7051340Z Using cached build-1.0.3-py3-none-any.whl (18 kB)
+2026-01-23T00:04:37.7064222Z Using cached pip_tools-7.3.0-py3-none-any.whl (57 kB)
+2026-01-23T00:04:37.7076970Z Using cached pytest-7.4.3-py3-none-any.whl (325 kB)
+2026-01-23T00:04:37.7091753Z Using cached pluggy-1.3.0-py3-none-any.whl (18 kB)
+2026-01-23T00:04:37.7104690Z Using cached pytest_asyncio-0.21.1-py3-none-any.whl (13 kB)
+2026-01-23T00:04:37.7117201Z Using cached iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
+2026-01-23T00:04:37.7130074Z Using cached typing_extensions-4.8.0-py3-none-any.whl (31 kB)
+2026-01-23T00:04:37.7142539Z Using cached typing_inspect-0.9.0-py3-none-any.whl (8.8 kB)
+2026-01-23T00:04:37.7155499Z Using cached annotated_types-0.6.0-py3-none-any.whl (12 kB)
+2026-01-23T00:04:37.7168207Z Using cached mypy_extensions-1.0.0-py3-none-any.whl (4.7 kB)
+2026-01-23T00:04:37.7180834Z Using cached pathspec-0.11.2-py3-none-any.whl (29 kB)
+2026-01-23T00:04:37.7193817Z Using cached platformdirs-4.0.0-py3-none-any.whl (17 kB)
+2026-01-23T00:04:37.7206641Z Using cached more_itertools-10.1.0-py3-none-any.whl (55 kB)
+2026-01-23T00:04:37.7219456Z Using cached jaraco.classes-3.3.1-py3-none-any.whl (6.8 kB)
+2026-01-23T00:04:37.7231979Z Using cached jaraco.context-5.3.0-py3-none-any.whl (6.5 kB)
+2026-01-23T00:04:37.7244666Z Using cached jaraco.functools-4.0.0-py3-none-any.whl (9.8 kB)
+2026-01-23T00:04:37.7257174Z Using cached Deprecated-1.2.14-py2.py3-none-any.whl (9.6 kB)
+2026-01-23T00:04:37.7270423Z Using cached wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (80 kB)
+2026-01-23T00:04:37.7283002Z Using cached sniffio-1.3.0-py3-none-any.whl (10 kB)
+2026-01-23T00:04:37.7297115Z Using cached watchfiles-0.20.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.3 MB)
+2026-01-23T00:04:37.7318664Z Using cached pygments-2.17.2-py3-none-any.whl (1.2 MB)
+2026-01-23T00:04:37.7340707Z Using cached aiohttp-3.13.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (1.7 MB)
+2026-01-23T00:04:37.7366462Z Using cached multidict-6.7.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (246 kB)
+2026-01-23T00:04:37.7382039Z Using cached yarl-1.22.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (365 kB)
+2026-01-23T00:04:37.7397033Z Using cached aiohappyeyeballs-2.6.1-py3-none-any.whl (15 kB)
+2026-01-23T00:04:37.7409654Z Using cached aiosignal-1.4.0-py3-none-any.whl (7.5 kB)
+2026-01-23T00:04:37.7422288Z Using cached attrs-25.4.0-py3-none-any.whl (67 kB)
+2026-01-23T00:04:37.7436108Z Using cached frozenlist-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl (231 kB)
+2026-01-23T00:04:37.7449860Z Using cached importlib_metadata-8.7.1-py3-none-any.whl (27 kB)
+2026-01-23T00:04:37.7463355Z Using cached importlib_resources-6.5.2-py3-none-any.whl (37 kB)
+2026-01-23T00:04:37.7477552Z Using cached propcache-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (210 kB)
+2026-01-23T00:04:37.7491643Z Using cached uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (3.8 MB)
+2026-01-23T00:04:37.7530224Z Using cached zipp-3.23.0-py3-none-any.whl (10 kB)
+2026-01-23T00:04:37.7542910Z Using cached backports.tarfile-1.2.0-py3-none-any.whl (30 kB)
+2026-01-23T00:04:37.7555985Z Using cached pyproject_hooks-1.2.0-py3-none-any.whl (10 kB)
+2026-01-23T00:04:38.0198877Z Installing collected packages: selectolax, pytz, proxy-tools, bottle, altgraph, zipp, wrapt, wheel, websockets, uvloop, urllib3, tzdata, typing-extensions, tenacity, structlog, soupsieve, sniffio, six, redis, pyyaml, python-dotenv, pyproject_hooks, pyinstaller-hooks-contrib, pygments, pycparser, psycopg2-binary, psutil, propcache, pluggy, platformdirs, pathspec, packaging, numpy, mypy-extensions, multidict, more-itertools, jeepney, iniconfig, importlib-resources, idna, hyperframe, httptools, hpack, h11, greenlet, frozenlist, click, charset-normalizer, certifi, backports.tarfile, attrs, annotated-types, aiosqlite, aiohappyeyeballs, yarl, wsproto, uvicorn, typing-inspect, sqlalchemy, requests, pywebview, python-dateutil, pytest, pyinstaller, pydantic-core, jaraco.functools, jaraco.context, jaraco.classes, importlib-metadata, httpcore, h2, deprecated, cffi, build, beautifulsoup4, anyio, aiosignal, watchfiles, starlette, pytest-asyncio, pydantic, pip-tools, pandas, limits, httpx, cryptography, aiohttp, slowapi, secretstorage, pydantic-settings, fastapi, black, keyring
+2026-01-23T00:04:38.3166683Z   Attempting uninstall: wheel
+2026-01-23T00:04:38.3182934Z     Found existing installation: wheel 0.46.3
+2026-01-23T00:04:38.3211406Z     Uninstalling wheel-0.46.3:
+2026-01-23T00:04:38.3224174Z       Successfully uninstalled wheel-0.46.3
+2026-01-23T00:04:40.0756680Z   Attempting uninstall: packaging
+2026-01-23T00:04:40.0774161Z     Found existing installation: packaging 26.0
+2026-01-23T00:04:40.0801479Z     Uninstalling packaging-26.0:
+2026-01-23T00:04:40.0810068Z       Successfully uninstalled packaging-26.0
+2026-01-23T00:04:49.1582395Z
+2026-01-23T00:04:49.1633413Z Successfully installed aiohappyeyeballs-2.6.1 aiohttp-3.13.3 aiosignal-1.4.0 aiosqlite-0.19.0 altgraph-0.17.3 annotated-types-0.6.0 anyio-3.7.1 attrs-25.4.0 backports.tarfile-1.2.0 beautifulsoup4-4.12.2 black-23.12.0 bottle-0.13.4 build-1.0.3 certifi-2023.7.22 cffi-1.16.0 charset-normalizer-3.3.2 click-8.1.7 cryptography-41.0.7 deprecated-1.2.14 fastapi-0.104.1 frozenlist-1.8.0 greenlet-3.0.2 h11-0.14.0 h2-4.1.0 hpack-4.0.0 httpcore-1.0.2 httptools-0.6.1 httpx-0.25.2 hyperframe-6.1.0 idna-3.6 importlib-metadata-8.7.1 importlib-resources-6.5.2 iniconfig-2.0.0 jaraco.classes-3.3.1 jaraco.context-5.3.0 jaraco.functools-4.0.0 jeepney-0.9.0 keyring-24.3.0 limits-3.7.0 more-itertools-10.1.0 multidict-6.7.0 mypy-extensions-1.0.0 numpy-1.24.3 packaging-23.2 pandas-2.0.3 pathspec-0.11.2 pip-tools-7.3.0 platformdirs-4.0.0 pluggy-1.3.0 propcache-0.4.1 proxy-tools-0.1.0 psutil-5.9.6 psycopg2-binary-2.9.9 pycparser-2.21 pydantic-2.5.0 pydantic-core-2.14.1 pydantic-settings-2.1.0 pygments-2.17.2 pyinstaller-6.1.0 pyinstaller-hooks-contrib-2023.11 pyproject_hooks-1.2.0 pytest-7.4.3 pytest-asyncio-0.21.1 python-dateutil-2.8.2 python-dotenv-1.0.0 pytz-2023.3.post1 pywebview-5.4 pyyaml-6.0.1 redis-5.0.1 requests-2.31.0 secretstorage-3.5.0 selectolax-0.3.20 six-1.16.0 slowapi-0.1.9 sniffio-1.3.0 soupsieve-2.5 sqlalchemy-2.0.23 starlette-0.27.0 structlog-23.2.0 tenacity-8.2.3 typing-extensions-4.8.0 typing-inspect-0.9.0 tzdata-2023.3 urllib3-2.1.0 uvicorn-0.24.0 uvloop-0.22.1 watchfiles-0.20.0 websockets-12.0 wheel-0.41.2 wrapt-1.16.0 wsproto-1.2.0 yarl-1.22.0 zipp-3.23.0
+2026-01-23T00:04:50.0093513Z ##[group]Run mkdir -p web_service/backend/{data,json,logs}
+2026-01-23T00:04:50.0094018Z [36;1mmkdir -p web_service/backend/{data,json,logs}[0m
+2026-01-23T00:04:50.0094332Z [36;1mmkdir -p reports/archive[0m
+2026-01-23T00:04:50.0126234Z shell: /usr/bin/bash -e {0}
+2026-01-23T00:04:50.0126469Z env:
+2026-01-23T00:04:50.0126644Z   PYTHON_VERSION: 3.11
+2026-01-23T00:04:50.0126863Z   REPORT_RETENTION_DAYS: 14
+2026-01-23T00:04:50.0127085Z   MAX_RETRIES: 3
+2026-01-23T00:04:50.0127273Z   REQUEST_TIMEOUT: 30
+2026-01-23T00:04:50.0127534Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:50.0127964Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-23T00:04:50.0128378Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:50.0128740Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:50.0129107Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:50.0129513Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-23T00:04:50.0129814Z ##[endgroup]
+2026-01-23T00:04:50.0301466Z ##[group]Run actions/cache@v4
+2026-01-23T00:04:50.0301713Z with:
+2026-01-23T00:04:50.0302002Z   path: web_service/backend/data/*.cache
+web_service/backend/json/*.cache
+
+2026-01-23T00:04:50.0302381Z   key: race-data-Linux-33
+2026-01-23T00:04:50.0302611Z   restore-keys: race-data-Linux-
+
+2026-01-23T00:04:50.0302855Z   enableCrossOsArchive: false
+2026-01-23T00:04:50.0303320Z   fail-on-cache-miss: false
+2026-01-23T00:04:50.0303541Z   lookup-only: false
+2026-01-23T00:04:50.0303730Z   save-always: false
+2026-01-23T00:04:50.0303900Z env:
+2026-01-23T00:04:50.0304063Z   PYTHON_VERSION: 3.11
+2026-01-23T00:04:50.0304260Z   REPORT_RETENTION_DAYS: 14
+2026-01-23T00:04:50.0304455Z   MAX_RETRIES: 3
+2026-01-23T00:04:50.0304633Z   REQUEST_TIMEOUT: 30
+2026-01-23T00:04:50.0304891Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:50.0305290Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-23T00:04:50.0305724Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:50.0306075Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:50.0306642Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:50.0307011Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-23T00:04:50.0307310Z ##[endgroup]
+2026-01-23T00:04:50.2396279Z Cache not found for input keys: race-data-Linux-33, race-data-Linux-
+2026-01-23T00:04:50.2469092Z ##[group]Run set -o pipefail
+2026-01-23T00:04:50.2469390Z [36;1mset -o pipefail[0m
+2026-01-23T00:04:50.2469731Z [36;1mpython scripts/fortuna_reporter.py 2>&1 | tee reporter_output.log[0m
+2026-01-23T00:04:50.2470081Z [36;1m[0m
+2026-01-23T00:04:50.2470294Z [36;1m# Extract metrics from the log for outputs[0m
+2026-01-23T00:04:50.2470606Z [36;1mif [ -f "qualified_races.json" ]; then[0m
+2026-01-23T00:04:50.2471112Z [36;1m  RACE_COUNT=$(python -c "import json; print(len(json.load(open('qualified_races.json')).get('races', [])))")[0m
+2026-01-23T00:04:50.2471665Z [36;1m  echo "race_count=${RACE_COUNT}" >> $GITHUB_OUTPUT[0m
+2026-01-23T00:04:50.2471994Z [36;1m  echo "status=success" >> $GITHUB_OUTPUT[0m
+2026-01-23T00:04:50.2472276Z [36;1melse[0m
+2026-01-23T00:04:50.2472473Z [36;1m  echo "race_count=0" >> $GITHUB_OUTPUT[0m
+2026-01-23T00:04:50.2472769Z [36;1m  echo "status=failed" >> $GITHUB_OUTPUT[0m
+2026-01-23T00:04:50.2473394Z [36;1mfi[0m
+2026-01-23T00:04:50.2504836Z shell: /usr/bin/bash -e {0}
+2026-01-23T00:04:50.2505058Z env:
+2026-01-23T00:04:50.2505233Z   PYTHON_VERSION: 3.11
+2026-01-23T00:04:50.2505444Z   REPORT_RETENTION_DAYS: 14
+2026-01-23T00:04:50.2505650Z   MAX_RETRIES: 3
+2026-01-23T00:04:50.2505831Z   REQUEST_TIMEOUT: 30
+2026-01-23T00:04:50.2506091Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:50.2506507Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-23T00:04:50.2506913Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:50.2507272Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:50.2507676Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:50.2508047Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-23T00:04:50.2508363Z   ANALYZER_TYPE: tiny_field_trifecta
+2026-01-23T00:04:50.2508602Z   FORCE_REFRESH: false
+2026-01-23T00:04:50.2508794Z ##[endgroup]
+2026-01-23T00:04:50.8240297Z 2026-01-23 00:04:50 [info     ] CacheManager initialized (not connected).
+2026-01-23T00:04:50.8431207Z [2026-01-23 00:04:50] ℹ️ === Fortuna Unified Race Reporter ===
+2026-01-23T00:04:50.8432008Z [2026-01-23 00:04:50] ℹ️ Analyzer: tiny_field_trifecta
+2026-01-23T00:04:50.8432714Z [2026-01-23 00:04:50] ℹ️ Excluding 23 adapters
+2026-01-23T00:04:50.8433990Z 2026-01-23 00:04:50 [warning  ] encryption_key_not_found       file=.key recommendation=Run 'python manage_secrets.py' to generate a key.
+2026-01-23T00:04:50.8443525Z 2026-01-23 00:04:50 [info     ] Initializing FortunaEngine...
+2026-01-23T00:04:50.8444786Z 2026-01-23 00:04:50 [info     ] Configuration loaded.
+2026-01-23T00:04:50.8445390Z 2026-01-23 00:04:50 [info     ] Initializing adapters...
+2026-01-23T00:04:50.8446152Z 2026-01-23 00:04:50 [info     ] Attempting to initialize adapter: AtTheRacesAdapter
+2026-01-23T00:04:50.8447017Z 2026-01-23 00:04:50 [info     ] Successfully initialized adapter: AtTheRacesAdapter
+2026-01-23T00:04:50.8447865Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: BetfairAdapter
+2026-01-23T00:04:50.8448804Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: BetfairGreyhoundAdapter
+2026-01-23T00:04:50.8449708Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: BrisnetAdapter
+2026-01-23T00:04:50.8450559Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: EquibaseAdapter
+2026-01-23T00:04:50.8451366Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: FanDuelAdapter
+2026-01-23T00:04:50.8452171Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: GbgbApiAdapter
+2026-01-23T00:04:50.8452994Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: GreyhoundAdapter
+2026-01-23T00:04:50.8454345Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: HarnessAdapter
+2026-01-23T00:04:50.8455213Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: HorseRacingNationAdapter
+2026-01-23T00:04:50.8456408Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: NYRABetsAdapter
+2026-01-23T00:04:50.8457309Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: OddscheckerAdapter
+2026-01-23T00:04:50.8458198Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: PuntersAdapter
+2026-01-23T00:04:50.8459106Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: RacingAndSportsAdapter
+2026-01-23T00:04:50.8460130Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: RacingAndSportsGreyhoundAdapter
+2026-01-23T00:04:50.8461118Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: RacingPostAdapter
+2026-01-23T00:04:50.8461964Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: RacingTVAdapter
+2026-01-23T00:04:50.8462833Z 2026-01-23 00:04:50 [info     ] Attempting to initialize adapter: SportingLifeAdapter
+2026-01-23T00:04:50.8463993Z 2026-01-23 00:04:50 [info     ] Successfully initialized adapter: SportingLifeAdapter
+2026-01-23T00:04:50.8464861Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: TabAdapter
+2026-01-23T00:04:50.8465675Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: TheRacingApiAdapter
+2026-01-23T00:04:50.8466530Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: TimeformAdapter
+2026-01-23T00:04:50.8467360Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: TwinSpiresAdapter
+2026-01-23T00:04:50.8468157Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: TVGAdapter
+2026-01-23T00:04:50.8468963Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: XpressbetAdapter
+2026-01-23T00:04:50.8469854Z 2026-01-23 00:04:50 [info     ] Intentionally skipping adapter: PointsBetGreyhoundAdapter
+2026-01-23T00:04:50.8470667Z 2026-01-23 00:04:50 [info     ] 2 adapters initialized successfully.
+2026-01-23T00:04:50.8471363Z 2026-01-23 00:04:50 [info     ] Initializing HTTP client...
+2026-01-23T00:04:50.8676105Z 2026-01-23 00:04:50 [info     ] HTTP client initialized.
+2026-01-23T00:04:50.8677648Z 2026-01-23 00:04:50 [info     ] Concurrency semaphore initialized limit=10
+2026-01-23T00:04:50.8678410Z 2026-01-23 00:04:50 [info     ] FortunaEngine initialization complete.
+2026-01-23T00:04:50.8679405Z 2026-01-23 00:04:50 [info     ] AnalyzerEngine discovered plugins available_analyzers=['trifecta', 'tiny_field_trifecta']
+2026-01-23T00:04:50.8680583Z [2026-01-23 00:04:50] ℹ️ Healthy adapters: 2/2
+2026-01-23T00:04:50.8681279Z [2026-01-23 00:04:50] ℹ️ Fetching race data (attempt 1/3)...
+2026-01-23T00:04:50.8682406Z 2026-01-23 00:04:50 [info     ] Making request                 adapter_name=AtTheRaces method=GET url=https://www.attheraces.com/racecards/2026-01-23
+2026-01-23T00:04:50.8713467Z 2026-01-23 00:04:50 [info     ] Making request                 adapter_name=SportingLife method=GET url=https://www.sportinglife.com/racing/racecards/2026-01-23
+2026-01-23T00:04:52.9301313Z 2026-01-23 00:04:52 [info     ] Updating stale cache           cache_type=StaleDataCache key=2026-01-23
+2026-01-23T00:04:52.9303558Z [2026-01-23 00:04:52] ✅ Saved raw race data to raw_race_data.json
+2026-01-23T00:04:52.9304621Z [2026-01-23 00:04:52] ❌ No races returned from OddsEngine. This is a critical failure.
+2026-01-23T00:04:52.9305596Z [2026-01-23 00:04:52] ℹ️ Generating Markdown summary...
+2026-01-23T00:04:52.9306272Z [2026-01-23 00:04:52] ✅ Generated Markdown summary at github_summary.md
+2026-01-23T00:04:52.9308612Z [2026-01-23 00:04:52] ℹ️ Generated 1/4 outputs
+2026-01-23T00:04:53.0113369Z ##[error]Process completed with exit code 1.
+2026-01-23T00:04:53.0176883Z ##[group]Run actions/upload-artifact@v4
+2026-01-23T00:04:53.0177173Z with:
+2026-01-23T00:04:53.0177372Z   name: race-reports-33-1
+2026-01-23T00:04:53.0177755Z   path: race-report.html
+qualified_races.json
+raw_race_data.json
+reporter_output.log
+
+2026-01-23T00:04:53.0178380Z   retention-days: 14
+2026-01-23T00:04:53.0178581Z   if-no-files-found: warn
+2026-01-23T00:04:53.0178788Z   compression-level: 9
+2026-01-23T00:04:53.0178982Z   overwrite: false
+2026-01-23T00:04:53.0179170Z   include-hidden-files: false
+2026-01-23T00:04:53.0179380Z env:
+2026-01-23T00:04:53.0179540Z   PYTHON_VERSION: 3.11
+2026-01-23T00:04:53.0179732Z   REPORT_RETENTION_DAYS: 14
+2026-01-23T00:04:53.0179938Z   MAX_RETRIES: 3
+2026-01-23T00:04:53.0180111Z   REQUEST_TIMEOUT: 30
+2026-01-23T00:04:53.0180368Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:53.0180789Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-23T00:04:53.0181222Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:53.0181576Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:53.0181937Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:53.0182302Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-23T00:04:53.0182611Z ##[endgroup]
+2026-01-23T00:04:53.2375636Z Multiple search paths detected. Calculating the least common ancestor of all paths
+2026-01-23T00:04:53.2380650Z The least common ancestor is /home/runner/work/fortuna/fortuna. This will be the root directory of the artifact
+2026-01-23T00:04:53.2381636Z With the provided path, there will be 4 files uploaded
+2026-01-23T00:04:53.2388424Z Artifact name is valid!
+2026-01-23T00:04:53.2391008Z Root directory input is valid!
+2026-01-23T00:04:53.3329050Z Beginning upload of artifact content to blob storage
+2026-01-23T00:04:53.3988009Z Uploaded bytes 9002
+2026-01-23T00:04:53.4169328Z Finished uploading artifact content to blob storage!
+2026-01-23T00:04:53.4173429Z SHA256 digest of uploaded artifact zip is f24b551d9b3427d891d9088c435711b58cce17fa945c0c0880917e3a8731381a
+2026-01-23T00:04:53.4175089Z Finalizing artifact upload
+2026-01-23T00:04:53.4952621Z Artifact race-reports-33-1.zip successfully finalized. Artifact ID 5227434720
+2026-01-23T00:04:53.4954057Z Artifact race-reports-33-1 has been successfully uploaded! Final size is 9002 bytes. Artifact ID is 5227434720
+2026-01-23T00:04:53.4960728Z Artifact download URL: https://github.com/masonj0/fortuna/actions/runs/21269413576/artifacts/5227434720
+2026-01-23T00:04:53.5055395Z ##[group]Run {
+2026-01-23T00:04:53.5055640Z [36;1m{[0m
+2026-01-23T00:04:53.5055868Z [36;1m  echo "## 🐴 Fortuna Race Report Summary"[0m
+2026-01-23T00:04:53.5056152Z [36;1m  echo ""[0m
+2026-01-23T00:04:53.5056389Z [36;1m  echo "**Run:** #33 | **Status:** unknown"[0m
+2026-01-23T00:04:53.5056696Z [36;1m  echo "**Analyzer:** tiny_field_trifecta"[0m
+2026-01-23T00:04:53.5056959Z [36;1m  echo ""[0m
+2026-01-23T00:04:53.5057136Z [36;1m[0m
+2026-01-23T00:04:53.5057340Z [36;1m  if [ -f "github_summary.md" ]; then[0m
+2026-01-23T00:04:53.5057631Z [36;1m    cat github_summary.md[0m
+2026-01-23T00:04:53.5057866Z [36;1m  else[0m
+2026-01-23T00:04:53.5058098Z [36;1m    echo "### ⚠️ Detailed summary not available"[0m
+2026-01-23T00:04:53.5058398Z [36;1m    echo ""[0m
+2026-01-23T00:04:53.5058646Z [36;1m    echo "Check the artifacts for the full report."[0m
+2026-01-23T00:04:53.5058937Z [36;1m  fi[0m
+2026-01-23T00:04:53.5059105Z [36;1m[0m
+2026-01-23T00:04:53.5059297Z [36;1m  echo ""[0m
+2026-01-23T00:04:53.5059482Z [36;1m  echo "---"[0m
+2026-01-23T00:04:53.5059772Z [36;1m  echo "*Generated at $(date -u '+%Y-%m-%d %H:%M:%S UTC')*"[0m
+2026-01-23T00:04:53.5060108Z [36;1m} >> $GITHUB_STEP_SUMMARY[0m
+2026-01-23T00:04:53.5091514Z shell: /usr/bin/bash -e {0}
+2026-01-23T00:04:53.5091754Z env:
+2026-01-23T00:04:53.5091928Z   PYTHON_VERSION: 3.11
+2026-01-23T00:04:53.5092154Z   REPORT_RETENTION_DAYS: 14
+2026-01-23T00:04:53.5092379Z   MAX_RETRIES: 3
+2026-01-23T00:04:53.5092566Z   REQUEST_TIMEOUT: 30
+2026-01-23T00:04:53.5092838Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:53.5093476Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-23T00:04:53.5094087Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:53.5094468Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:53.5094837Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:53.5095220Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-23T00:04:53.5095528Z ##[endgroup]
+2026-01-23T00:04:53.5209486Z ##[group]Run echo "::warning::Report generation failed. Check logs for details."
+2026-01-23T00:04:53.5210035Z [36;1mecho "::warning::Report generation failed. Check logs for details."[0m
+2026-01-23T00:04:53.5210438Z [36;1m# Archive any partial data for debugging[0m
+2026-01-23T00:04:53.5210744Z [36;1mif ls *.json 1> /dev/null 2>&1; then[0m
+2026-01-23T00:04:53.5211101Z [36;1m  tar -czf debug-data.tar.gz *.json *.log 2>/dev/null || true[0m
+2026-01-23T00:04:53.5211427Z [36;1mfi[0m
+2026-01-23T00:04:53.5241370Z shell: /usr/bin/bash -e {0}
+2026-01-23T00:04:53.5241610Z env:
+2026-01-23T00:04:53.5241806Z   PYTHON_VERSION: 3.11
+2026-01-23T00:04:53.5242025Z   REPORT_RETENTION_DAYS: 14
+2026-01-23T00:04:53.5242246Z   MAX_RETRIES: 3
+2026-01-23T00:04:53.5242434Z   REQUEST_TIMEOUT: 30
+2026-01-23T00:04:53.5242711Z   pythonLocation: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:53.5243476Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib/pkgconfig
+2026-01-23T00:04:53.5243934Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:53.5244306Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:53.5244676Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.14/x64
+2026-01-23T00:04:53.5245047Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.14/x64/lib
+2026-01-23T00:04:53.5245354Z ##[endgroup]
+2026-01-23T00:04:53.5302821Z ##[warning]Report generation failed. Check logs for details.
+2026-01-23T00:04:53.5415858Z Post job cleanup.
+2026-01-23T00:04:53.6379908Z [command]/usr/bin/git version
+2026-01-23T00:04:53.6429969Z git version 2.52.0
+2026-01-23T00:04:53.6492645Z Temporarily overriding HOME='/home/runner/work/_temp/3bd7e775-5312-4d88-8777-3984c707272d' before making global git config changes
+2026-01-23T00:04:53.6494171Z Adding repository directory to the temporary git global config as a safe directory
+2026-01-23T00:04:53.6535779Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/fortuna/fortuna
+2026-01-23T00:04:53.6581133Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-01-23T00:04:53.6649863Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-01-23T00:04:53.6999328Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-01-23T00:04:53.7044860Z http.https://github.com/.extraheader
+2026-01-23T00:04:53.7059574Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2026-01-23T00:04:53.7104878Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-01-23T00:04:53.7452785Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-01-23T00:04:53.7493699Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-01-23T00:04:53.7894917Z Evaluate and set job outputs
+2026-01-23T00:04:53.7900974Z Cleaning up orphan processes

--- a/web_service/backend/adapters/at_the_races_adapter.py
+++ b/web_service/backend/adapters/at_the_races_adapter.py
@@ -32,7 +32,7 @@ class AtTheRacesAdapter(BaseAdapterV3):
     async def _fetch_data(self, date: str) -> Optional[dict]:
         """
         Fetches the raw HTML for all race pages for a given date.
-        Returns a dictionary containing the HTML content and the date.
+        Returns a dictionary containing a list of (URL, HTML content) tuples and the date.
         """
         index_url = f"/racecards/{date}"
         index_response = await self.make_request(
@@ -42,18 +42,22 @@ class AtTheRacesAdapter(BaseAdapterV3):
             self.logger.warning("Failed to fetch AtTheRaces index page", url=index_url)
             return None
 
+        # Save the raw HTML for debugging in CI
+        with open("atr_debug.html", "w", encoding="utf-8") as f:
+            f.write(index_response.text)
+
         index_soup = BeautifulSoup(index_response.text, "html.parser")
-        links = {a["href"] for a in index_soup.select("a[data-test-selector='RC-meetingItem__link_race'][href]")}
+        links = {a["href"] for a in index_soup.select("a.race-card-header__link")}
 
         async def fetch_single_html(url_path: str):
             response = await self.make_request(
                 self.http_client, "GET", url_path, headers=self._get_headers()
             )
-            return response.text if response else ""
+            return (url_path, response.text) if response else (url_path, "")
 
         tasks = [fetch_single_html(link) for link in links]
-        html_pages = await asyncio.gather(*tasks)
-        return {"pages": html_pages, "date": date}
+        html_pages_with_urls = await asyncio.gather(*tasks)
+        return {"pages": html_pages_with_urls, "date": date}
 
     def _get_headers(self) -> dict:
         return {
@@ -63,7 +67,7 @@ class AtTheRacesAdapter(BaseAdapterV3):
             "Connection": "keep-alive",
             "Host": "www.attheraces.com",
             "Pragma": "no-cache",
-            "sec-ch-ua": '"Google Chrome";v="125", "Chromium";v="125", "Not.A/Brand";v="24"',
+            "sec-ch-ua": '"Not/A)Brand";v="99", "Google Chrome";v="115", "Chromium";v="115"',
             "sec-ch-ua-mobile": "?0",
             "sec-ch-ua-platform": '"Windows"',
             "Sec-Fetch-Dest": "document",
@@ -71,15 +75,15 @@ class AtTheRacesAdapter(BaseAdapterV3):
             "Sec-Fetch-Site": "none",
             "Sec-Fetch-User": "?1",
             "Upgrade-Insecure-Requests": "1",
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36",
+            "Referer": "https://www.attheraces.com/racecards",
         }
 
     def _parse_races(self, raw_data: Any) -> List[Race]:
-        """Parses a list of raw HTML strings into Race objects."""
+        """Parses a list of (URL, raw HTML string) tuples into Race objects."""
         if not raw_data or not raw_data.get("pages"):
             return []
 
-        all_races = []
         try:
             race_date = datetime.strptime(raw_data["date"], "%Y-%m-%d").date()
         except ValueError:
@@ -89,28 +93,38 @@ class AtTheRacesAdapter(BaseAdapterV3):
             )
             return []
 
-        for html in raw_data["pages"]:
+        all_races = []
+        for url_path, html in raw_data["pages"]:
             if not html:
                 continue
             try:
                 soup = BeautifulSoup(html, "html.parser")
-                header_element = soup.select_one("h1.heading-racecard-title")
-                if not header_element:
+                details_container = soup.select_one("atr-racecard-race-header .container")
+                if not details_container:
                     continue
-                header = header_element.get_text()
-                track_name_raw, race_time = [p.strip() for p in header.split("|")[:2]]
+
+                track_name_node = details_container.select_one("h1 a")
+                track_name_raw = clean_text(track_name_node.get_text()) if track_name_node else ""
                 track_name = normalize_venue_name(track_name_raw)
-                active_link = soup.select_one("a.race-time-link.active")
+
+                race_time_node = details_container.select_one("h1 span")
+                race_time_str = (
+                    clean_text(race_time_node.get_text()).replace(" ATR", "") if race_time_node else ""
+                )
+
+                start_time = datetime.combine(
+                    race_date, datetime.strptime(race_time_str, "%H:%M").time()
+                )
+
                 race_number = 1
-                if active_link:
-                    parent_div = active_link.find_parent("div", "races")
-                    if parent_div:
-                        all_links = parent_div.select("a.race-time-link")
-                        race_number = all_links.index(active_link) + 1
+                try:
+                    parts = url_path.split("/")
+                    race_number = int([part for part in parts if part.isdigit()][-1])
+                except (ValueError, IndexError):
+                    self.logger.warning("Could not parse race number from URL", url=url_path)
 
-                start_time = datetime.combine(race_date, datetime.strptime(race_time, "%H:%M").time())
+                runners = [self._parse_runner(row) for row in soup.select("atr-horse-in-racecard")]
 
-                runners = [self._parse_runner(row) for row in soup.select("div.table-default__row--card-runner")]
                 race = Race(
                     id=f"atr_{track_name.replace(' ', '')}_{start_time.strftime('%Y%m%d')}_R{race_number}",
                     venue=track_name,
@@ -120,7 +134,7 @@ class AtTheRacesAdapter(BaseAdapterV3):
                     source=self.source_name,
                 )
                 all_races.append(race)
-            except (AttributeError, IndexError, ValueError):
+            except (AttributeError, ValueError):
                 self.logger.warning(
                     "Error parsing a race from AtTheRaces, skipping race.",
                     exc_info=True,
@@ -130,19 +144,19 @@ class AtTheRacesAdapter(BaseAdapterV3):
 
     def _parse_runner(self, row: Tag) -> Optional[Runner]:
         try:
-            name_element = row.select_one("span.runner-cloth-name__name")
-            if not name_element:
+            name_node = row.select_one("h3")
+            if not name_node:
                 return None
-            name = clean_text(name_element.get_text())
+            name = clean_text(name_node.get_text())
 
-            num_element = row.select_one("span.runner-number__no")
-            if not num_element:
+            num_node = row.select_one(".horse-in-racecard__saddle-cloth-number")
+            if not num_node:
                 return None
-            num_str = clean_text(num_element.get_text())
+            num_str = clean_text(num_node.get_text())
             number = int("".join(filter(str.isdigit, num_str)))
 
-            odds_element = row.select_one("button.bet-selector__odds")
-            odds_str = clean_text(odds_element.get_text()) if odds_element else ""
+            odds_node = row.select_one(".horse-in-racecard__odds")
+            odds_str = clean_text(odds_node.get_text()) if odds_node else ""
 
             win_odds = parse_odds_to_decimal(odds_str)
             odds_data = (

--- a/web_service/backend/adapters/base_adapter_v3.py
+++ b/web_service/backend/adapters/base_adapter_v3.py
@@ -288,24 +288,6 @@ class BaseAdapterV3(ABC):
         self.manual_override_manager: ManualOverrideManager | None = None
         self.supports_manual_override = True
 
-    async def __aenter__(self) -> "BaseAdapterV3":
-        """Async context manager entry."""
-        if self.http_client is None:
-            self.http_client = httpx.AsyncClient(timeout=self.timeout)
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
-        """Async context manager exit with cleanup."""
-        await self.close()
-
-    async def close(self) -> None:
-        """Clean up resources."""
-        if self.http_client:
-            await self.http_client.aclose()
-            self.http_client = None
-        if self.cache:
-            await self.cache.clear()
-        self.logger.debug("Adapter resources cleaned up")
         # Resilience components
         self.circuit_breaker = CircuitBreaker()
         self.rate_limiter = RateLimiter(requests_per_second=rate_limit)

--- a/web_service/backend/analyzer.py
+++ b/web_service/backend/analyzer.py
@@ -90,6 +90,8 @@ class TrifectaAnalyzer(BaseAnalyzer):
         """Scores all races and returns a dictionary with criteria and a sorted list."""
         qualified_races = []
         for race in races:
+            if not self.is_race_qualified(race):
+                continue
             score = self._evaluate_race(race)
             if score > 0:
                 race.qualification_score = score

--- a/web_service/backend/core/exceptions.py
+++ b/web_service/backend/core/exceptions.py
@@ -32,11 +32,22 @@ class AdapterRequestError(AdapterError):
 class AdapterHttpError(AdapterRequestError):
     """Raised for unsuccessful HTTP responses (e.g., 4xx or 5xx status codes)."""
 
-    def __init__(self, adapter_name: str, status_code: int, url: str):
+    def __init__(
+        self,
+        adapter_name: str,
+        status_code: int,
+        url: str,
+        message: str | None = None,
+        response_body: str | None = None,
+        request_method: str | None = None,
+    ):
         self.status_code = status_code
         self.url = url
-        message = f"Received HTTP {status_code} from {url}"
-        super().__init__(adapter_name, message)
+        self.response_body = response_body
+        self.request_method = request_method
+
+        final_message = message or f"Received HTTP {status_code} from {url}"
+        super().__init__(adapter_name, final_message)
 
 
 class AdapterAuthError(AdapterHttpError):


### PR DESCRIPTION
This commit adds debugging logic to the `AtTheRacesAdapter` and `SportingLifeAdapter` to diagnose persistent CI failures.

- Modified both adapters to save the raw HTML content of the main racecards page to `atr_debug.html` and `sl_debug.html`.
- Updated the `unified-race-report.yml` workflow to archive these HTML files as artifacts on job failure.

This will allow for direct inspection of the HTML received by the scrapers in the CI environment to determine if they are being blocked or served different content.