### PR TITLE
Fix: Correct fragile here-string in unified-race-report.yml

### DIFF
--- a/.github/workflows/unified-race-report.yml
+++ b/.github/workflows/unified-race-report.yml
@@ -97,9 +97,8 @@ jobs:
           set -o pipefail
           python scripts/fortuna_reporter.py 2>&1 | tee reporter_output.log
 
-          # Extract metrics from the log for outputs
-          if [ -f "qualified_races.json" ]; then
-            RACE_COUNT=$(python -c "
+          # Create a python script to extract race count
+          cat <<'EOF' > get_race_count.py
 import json
 import sys
 try:
@@ -108,7 +107,10 @@ try:
     print(len(data.get('races', [])))
 except (json.JSONDecodeError, IOError):
     print(0)
-")
+EOF
+          # Extract metrics from the log for outputs
+          if [ -f "qualified_races.json" ]; then
+            RACE_COUNT=$(python get_race_count.py)
             echo "race_count=${RACE_COUNT}" >> $GITHUB_OUTPUT
             echo "status=success" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Replaced the multi-line `python -c` command with a robust heredoc (`cat <<'EOF'`) to write a temporary script file. This avoids YAML parsing issues with inline scripts and aligns with GitHub Actions best practices.