### PR TITLE
Fix: Repair Failing GitHub Actions Workflow

### DIFF
--- a/.github/workflows/unified-race-report.yml
+++ b/.github/workflows/unified-race-report.yml
@@ -99,16 +99,7 @@ jobs:
 
           # Extract metrics from the log for outputs
           if [ -f "qualified_races.json" ]; then
-            RACE_COUNT=$(python -c "
-import json
-import sys
-try:
-    with open('qualified_races.json') as f:
-        data = json.load(f)
-    print(len(data.get('races', [])))
-except (json.JSONDecodeError, IOError):
-    print(0)
-")
+            RACE_COUNT=$(python scripts/get_race_count.py)
             echo "race_count=${RACE_COUNT}" >> $GITHUB_OUTPUT
             echo "status=success" >> $GITHUB_OUTPUT
           else

--- a/scripts/get_race_count.py
+++ b/scripts/get_race_count.py
@@ -1,0 +1,17 @@
+import json
+import sys
+
+def get_race_count():
+    """
+    Reads 'qualified_races.json', counts the number of races, and prints the count.
+    Prints 0 if the file doesn't exist or is invalid.
+    """
+    try:
+        with open('qualified_races.json') as f:
+            data = json.load(f)
+        print(len(data.get('races', [])))
+    except (json.JSONDecodeError, IOError):
+        print(0)
+
+if __name__ == "__main__":
+    get_race_count()

--- a/web_service/backend/adapters/at_the_races_adapter.py
+++ b/web_service/backend/adapters/at_the_races_adapter.py
@@ -47,7 +47,12 @@ class AtTheRacesAdapter(BaseAdapterV3):
             f.write(index_response.text)
 
         index_soup = BeautifulSoup(index_response.text, "html.parser")
-        links = {a["href"] for a in index_soup.select("a.race-card-header__link")}
+        links = {
+            a["href"]
+            for a in index_soup.select(
+                'a[href*="/racecards/"][class*="button"]:not([href*="tomorrow"]):not([href*="SmartStats"])'
+            )
+        }
 
         async def fetch_single_html(url_path: str):
             response = await self.make_request(

--- a/web_service/backend/adapters/sporting_life_adapter.py
+++ b/web_service/backend/adapters/sporting_life_adapter.py
@@ -33,9 +33,13 @@ class SportingLifeAdapter(BaseAdapterV3):
         Fetches the raw HTML for all race pages for a given date.
         Returns a dictionary containing the HTML content and the date.
         """
-        index_url = f"/racing/racecards/{date}"
+        index_url = "/racing/racecards"  # The dated URL is causing a 307 redirect
         index_response = await self.make_request(
-            self.http_client, "GET", index_url, headers=self._get_headers()
+            self.http_client,
+            "GET",
+            index_url,
+            headers=self._get_headers(),
+            follow_redirects=True,
         )
         if not index_response:
             self.logger.warning("Failed to fetch SportingLife index page", url=index_url)


### PR DESCRIPTION
This commit resolves a multi-faceted failure in the `unified-race-report.yml` GitHub Actions workflow.

The initial problem was a YAML parsing error caused by an inline Python script. This was fixed by extracting the logic into a new, dedicated script: `scripts/get_race_count.py`.

After fixing the launch failure, the workflow still failed during the analysis phase. This was traced to data collection failures in the `SportingLifeAdapter` and `AtTheRacesAdapter`.

- The `SportingLifeAdapter` was failing due to a 307 redirect. This was fixed by updating the request URL to a non-dated endpoint and enabling `follow_redirects`.
- The `AtTheRacesAdapter` was failing because of a website redesign that made its CSS selectors obsolete. The selectors were updated to match the new site structure.

These changes restore the data pipeline, allowing the workflow to run successfully.