### PR TITLE
feat: Refine HTML parsing in CI workflow

### DIFF
--- a/.github/workflows/unified-race-report.yml
+++ b/.github/workflows/unified-race-report.yml
@@ -157,11 +157,11 @@ jobs:
         run: |
           mkdir -p debug-analysis
           [ -f "sl_debug.html" ] && python scripts/debug_html_parser.py sl_debug.html debug-analysis/sl_analysis.json || echo "sl_debug.html not found, skipping analysis."
-          [ -f "atr_debug.html" ] && python scripts/debug_html_parser.py atr_debug.html debug-analysis/atr_analysis.json || echo "atr_debug.html not found, skipping analysis."
+          [ -f "atr_debug.html" ] && python scripts/debug_html_parser.py atr_debug.html debug-analysis/atr_analysis.json "a[href^='/racecard/']" || echo "atr_debug.html not found, skipping analysis."
           [ -f "brisnet_debug.html" ] && python scripts/debug_html_parser.py brisnet_debug.html debug-analysis/brisnet_analysis.json || echo "brisnet_debug.html not found, skipping analysis."
           [ -f "equibase_debug.html" ] && python scripts/debug_html_parser.py equibase_debug.html debug-analysis/equibase_analysis.json || echo "equibase_debug.html not found, skipping analysis."
           [ -f "oddschecker_debug.html" ] && python scripts/debug_html_parser.py oddschecker_debug.html debug-analysis/oddschecker_analysis.json || echo "oddschecker_debug.html not found, skipping analysis."
-          [ -f "racingpost_debug.html" ] && python scripts/debug_html_parser.py racingpost_debug.html debug-analysis/racingpost_analysis.json || echo "racingpost_debug.html not found, skipping analysis."
+          [ -f "racingpost_debug.html" ] && python scripts/debug_html_parser.py racingpost_debug.html debug-analysis/racingpost_analysis.json "a[href*='/racecards/']" || echo "racingpost_debug.html not found, skipping analysis."
           [ -f "timeform_debug.html" ] && python scripts/debug_html_parser.py timeform_debug.html debug-analysis/timeform_analysis.json || echo "timeform_debug.html not found, skipping analysis."
 
       - name: 'Upload Debug Analysis Artifact'

--- a/atr_debug.html
+++ b/atr_debug.html
@@ -1,0 +1,1 @@
+<html><body><a href='/racecard/some-race'>race 1</a></body></html>

--- a/debug-analysis/atr_analysis.json
+++ b/debug-analysis/atr_analysis.json
@@ -1,0 +1,13 @@
+{
+  "links": [
+    {
+      "href": "/racecard/some-race",
+      "text": "race 1",
+      "parent_tag": "body",
+      "parent_classes": [],
+      "grandparent_tag": "html",
+      "grandparent_classes": []
+    }
+  ],
+  "error": null
+}

--- a/debug-analysis/racingpost_analysis.json
+++ b/debug-analysis/racingpost_analysis.json
@@ -1,0 +1,13 @@
+{
+  "links": [
+    {
+      "href": "/racecards/some-other-race",
+      "text": "race 2",
+      "parent_tag": "body",
+      "parent_classes": [],
+      "grandparent_tag": "html",
+      "grandparent_classes": []
+    }
+  ],
+  "error": null
+}

--- a/racingpost_debug.html
+++ b/racingpost_debug.html
@@ -1,0 +1,1 @@
+<html><body><a href='/racecards/some-other-race'>race 2</a></body></html>


### PR DESCRIPTION
Adds specific CSS selectors to the `debug_html_parser.py` script calls within the `unified-race-report.yml` GitHub Actions workflow.

This change filters the parsed links for `attheraces.com` and `racingpost.com`, ensuring that only relevant racecard links are extracted during the debug analysis. This improves the signal-to-noise ratio of the debug artifacts.