### PR TITLE
fix(build): Correct PyInstaller spec for one-folder build

### DIFF
--- a/fortuna-desktop.spec
+++ b/fortuna-desktop.spec
@@ -38,7 +38,7 @@ hiddenimports = [
 hiddenimports += collect_submodules('web_service.backend')
 
 a = Analysis(
-    ['run_desktop_app.py'],
+    [str(project_root / 'run_desktop_app.py')],
     pathex=[str(project_root)],
     binaries=[],
     datas=datas,
@@ -72,4 +72,14 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='Fortuna-Desktop',
 )


### PR DESCRIPTION
-   Modified `fortuna-desktop.spec` to ensure a one-folder (`onedir`) build is created by adding a `COLLECT` statement.
-   This aligns the build output with the expectations of the GitHub Actions workflow, which was previously failing to find the executable in a subdirectory.
-   Restored `console=False` to maintain the correct GUI-only behavior for the desktop application.
-   Hardened the entry script path to be absolute, improving build robustness in the CI environment.
-   Removed a stray build log file from the commit.