### PR TITLE
fix(ci): Rename $pid variable in smoke test

### DIFF
--- a/.github/workflows/build-monolith-final.yml
+++ b/.github/workflows/build-monolith-final.yml
@@ -217,8 +217,8 @@ jobs:
           # 1. Launch App
           Write-Host "🚀 Launching $exe..."
           $process = Start-Process -FilePath $exe -PassThru
-          $pid = $process.Id
-          Write-Host "   PID: $pid"
+          $processId = $process.Id
+          Write-Host "   PID: $processId"
 
           # 2. Wait & Check Health
           $url = "http://127.0.0.1:8000/api/health"
@@ -245,7 +245,7 @@ jobs:
 
           # 3. Cleanup
           if (-not $process.HasExited) {
-            Stop-Process -Id $pid -Force
+            Stop-Process -Id $processId -Force
           }
 
           # 4. Diagnostics (If Failed)


### PR DESCRIPTION
Renames the problematic `$pid` variable to `$processId` in the smoke test portion of the `build-monolith-final.yml` workflow. This resolves a "Cannot overwrite variable" error in PowerShell, where `$pid` is a reserved, read-only automatic variable.