### PR TITLE
fix(ci): Update system dependency for Ubuntu 24.04 runner

### DIFF
--- a/.github/workflows/unified-race-report.yml
+++ b/.github/workflows/unified-race-report.yml
@@ -290,7 +290,7 @@ jobs:
             libxkbcommon0 \
             libatspi2.0-0 \
             libgbm1 \
-            libasound2 \
+            libasound2t64
             fonts-liberation
 
       - name: '📦 Install Python Dependencies'


### PR DESCRIPTION
The unified-race-report workflow was failing during the "Install System Dependencies" step because the `libasound2` package is no longer available in the Ubuntu 24.04 runner image.

This change updates the package name to `libasound2t64`, which is the correct name for the package on this platform, resolving the installation failure.